### PR TITLE
Replace state for expanded weeks

### DIFF
--- a/addon/routes/weeklyevents.js
+++ b/addon/routes/weeklyevents.js
@@ -1,4 +1,9 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+  queryParams: {
+    expanded: {
+      replace: true
+    }
+  }
 });


### PR DESCRIPTION
This prevents creating history entries for every click. If we don't do
this then a user has to go 'back' through every single click to return
to the dashboard.