### PR TITLE
Remove searchString CP from session

### DIFF
--- a/addon/models/session.js
+++ b/addon/models/session.js
@@ -130,10 +130,6 @@ export default Model.extend(PublishableModel, CategorizableModel, SortableByPosi
       });
     });
   }),
-
-  searchString: computed('title', 'sessionType.title', 'status', function(){
-    return this.get('title') + this.get('sessionType.title') + this.get('status');
-  }),
   optionalPublicationLengthFields: ['terms', 'objectives', 'meshDescriptors'],
   requiredPublicationIssues: computed(
     'title',


### PR DESCRIPTION
This isn't useful anymore since status is no longer provided by
PublisableModel. We need to construct the search string in the calling
component instead where we will have access to i18n.