### PR TITLE
Week starts on Sunday

### DIFF
--- a/addon/components/dashboard-week.js
+++ b/addon/components/dashboard-week.js
@@ -2,10 +2,16 @@ import Ember from 'ember';
 import layout from '../templates/components/dashboard-week';
 import moment from 'moment';
 
-const { Component } = Ember;
+const { Component, computed } = Ember;
 
 export default Component.extend({
   layout,
   classNames: ['dashboard-week'],
-  today: moment().day(1),
+  expanded: computed(function(){
+    const lastSunday = moment().day(1).subtract(1, 'week').format('W');
+    const thisSunday = moment().day(1).format('W');
+    const nextSunday = moment().day(1).add(1, 'week').format('W');
+
+    return `${lastSunday}-${thisSunday}-${nextSunday}`;
+  }),
 });

--- a/addon/components/week-glance.js
+++ b/addon/components/week-glance.js
@@ -11,8 +11,8 @@ export default Component.extend({
 
   userEvents: service(),
 
-  startOfWeek: 1,
-  endOfWeek: 7,
+  startOfWeek: 0,
+  endOfWeek: 6,
 
   year: null,
   week: null,

--- a/addon/templates/components/dashboard-week.hbs
+++ b/addon/templates/components/dashboard-week.hbs
@@ -1,4 +1,8 @@
-{{#link-to 'weeklyevents' (query-params expanded=(moment-format today 'W')) class='weeklylink'}}{{t 'general.allWeeks'}}{{/link-to}}
+{{#link-to
+  'weeklyevents'
+  (query-params expanded=expanded)
+  class='weeklylink'
+}}{{t 'general.allWeeks'}}{{/link-to}}
 {{week-glance
   collapsible=false
   collapsed=false

--- a/tests/integration/components/dashboard-week-test.js
+++ b/tests/integration/components/dashboard-week-test.js
@@ -105,8 +105,8 @@ moduleForComponent('dashboard-week', 'Integration | Component | dashboard week',
 });
 
 const getTitle = function(){
-  const startOfWeek = today.clone().day(1).hour(0).minute(0).second(0);
-  const endOfWeek = today.clone().day(7).hour(23).minute(59).second(59);
+  const startOfWeek = today.clone().day(0).hour(0).minute(0).second(0);
+  const endOfWeek = today.clone().day(6).hour(23).minute(59).second(59);
 
   let expectedTitle;
   if (startOfWeek.month() != endOfWeek.month()) {

--- a/tests/integration/components/week-glance-test.js
+++ b/tests/integration/components/week-glance-test.js
@@ -112,8 +112,8 @@ moduleForComponent('week-glance', 'Integration | Component | week glance', {
 });
 
 const getTitle = function(fullTitle){
-  const startOfWeek = today.clone().day(1).hour(0).minute(0).second(0);
-  const endOfWeek = today.clone().day(7).hour(23).minute(59).second(59);
+  const startOfWeek = today.clone().day(0).hour(0).minute(0).second(0);
+  const endOfWeek = today.clone().day(6).hour(23).minute(59).second(59);
 
   let expectedTitle;
   if (startOfWeek.month() != endOfWeek.month()) {
@@ -342,14 +342,14 @@ test('changing passed properties re-renders', async function(assert) {
       case 1:
         assert.ok(from.isSame(today, 'year'));
         assert.ok(to.isSame(today, 'year'));
-        assert.ok(from.isSame(today, 'isoWeek'));
-        assert.ok(to.isSame(today, 'isoWeek'));
+        assert.ok(from.isSame(today, 'week'));
+        assert.ok(to.isSame(today, 'week'));
         break;
       case 2:
         assert.ok(from.isSame(nextYear, 'year'));
         assert.ok(to.isSame(nextYear, 'year'));
-        assert.ok(from.isSame(nextYear, 'isoWeek'));
-        assert.ok(to.isSame(nextYear, 'isoWeek'));
+        assert.ok(from.isSame(nextYear, 'week'));
+        assert.ok(to.isSame(nextYear, 'week'));
         break;
       default:
         assert.notOk(true, 'Called too many times');


### PR DESCRIPTION
1 . Switches the week to start on Sunday in week at a glance
2. When a user follows the 'all weeks' link this opens not just the current week, but also the previous and next week.