### PR TITLE
Pass selectable status down to multiday events

### DIFF
--- a/addon/components/ilios-calendar-multiday-event.js
+++ b/addon/components/ilios-calendar-multiday-event.js
@@ -10,6 +10,7 @@ export default Ember.Component.extend({
   isIlm: notEmpty('event.ilmSession'),
   isOffering: notEmpty('event.offering'),
   clickable: or('isIlm', 'isOffering'),
+  isEventSelectable: true,
   actions: {
     selectEvent(){
       if (this.get('clickable')) {

--- a/addon/components/ilios-calendar-multiday-events.js
+++ b/addon/components/ilios-calendar-multiday-events.js
@@ -5,4 +5,5 @@ export default Ember.Component.extend({
   layout,
   events: null,
   multidayEvents: null,
+  areEventsSelectable: true,
 });

--- a/addon/templates/components/ilios-calendar-multiday-event.hbs
+++ b/addon/templates/components/ilios-calendar-multiday-event.hbs
@@ -1,5 +1,5 @@
 {{moment-format event.startDate 'M/D/YY h:mma'}} - {{moment-format event.endDate 'M/D/YY h:mma'}}
-<span {{action selectEvent event}} class='{{if clickable "clickable"}}'>
+<span {{action selectEvent event}} class='{{if (and clickable isEventSelectable) "clickable"}}'>
   {{event.name}}
 </span>
 {{event.location}}

--- a/addon/templates/components/ilios-calendar-multiday-events.hbs
+++ b/addon/templates/components/ilios-calendar-multiday-events.hbs
@@ -3,7 +3,7 @@
     <h4>{{t 'general.multidayEvents'}}</h4>
     <ul>
       {{#each events as |event|}}
-        {{ilios-calendar-multiday-event selectEvent=selectEvent event=event}}
+        {{ilios-calendar-multiday-event isEventSelectable=areEventsSelectable selectEvent=selectEvent event=event}}
       {{/each}}
     </ul>
   </div>

--- a/addon/templates/components/ilios-calendar-week.hbs
+++ b/addon/templates/components/ilios-calendar-week.hbs
@@ -42,4 +42,4 @@
   </div>
 {{/el-weekly-calendar}}
 
-{{ilios-calendar-multiday-events events=multiDayEventsList selectEvent=selectEvent}}
+{{ilios-calendar-multiday-events events=multiDayEventsList selectEvent=(action 'selectEvent') areEventsSelectable=areDaysSelectable}}

--- a/tests/integration/components/ilios-calendar-multiday-event-test.js
+++ b/tests/integration/components/ilios-calendar-multiday-event-test.js
@@ -59,3 +59,20 @@ test('action does not fire for scheduled events', function(assert) {
 
   this.$('.clickable').click();
 });
+
+test('action does not fire for unslecatbleEvents events', function(assert) {
+  let event = getEvent();
+  event.offering = 1;
+
+  this.set('event', event);
+  assert.expect(1);
+  this.on('handleAction', () => {
+    //this should never get called
+    assert.ok(false);
+  });
+  this.render(hbs`{{ilios-calendar-multiday-event event=event isEventSelectable=false selectEvent=(action 'handleAction')}}`);
+  assert.ok(this.$().text().search(/Cheramie is born/) > 0);
+
+
+  this.$('.clickable').click();
+});


### PR DESCRIPTION
This status is used to determine if click actions are available and
should be the same for a single event on a day and a multi day event.