### PR TITLE
display external course id in dashboard calendar filters.

### DIFF
--- a/addon/templates/components/dashboard-calendar.hbs
+++ b/addon/templates/components/dashboard-calendar.hbs
@@ -70,7 +70,12 @@
               {{#each (await courses) as |course|}}
                 <li class='clickable'>
                   <input {{action 'toggleCourse' course on='change'}} class='checkbox' type='checkbox' checked={{is-in selectedCourses course}}>
-                  <span {{action 'toggleCourse' course}} class="list-indentation">{{course.title}}</span>
+                  <span {{action 'toggleCourse' course}} class="list-indentation">
+                    {{course.title}}
+                    {{#if course.externalId}}
+                      ({{course.externalId}})
+                    {{/if}}
+                  </span>
                 </li>
               {{/each}}
             </ul>


### PR DESCRIPTION
refs ilios/frontend#3177

![selection_383](https://user-images.githubusercontent.com/1410427/29591183-3b516eba-8752-11e7-9fe2-b3713329bcab.png)
