### PR TITLE
Remove limits that were not real

### DIFF
--- a/addon/adapters/ilios.js
+++ b/addon/adapters/ilios.js
@@ -22,7 +22,6 @@ export default RESTAdapter.extend(DataAdapterMixin, {
     return this.ajax(url, 'GET', {
       data: {
         filters: { id: ids },
-        limit: 1000000
       }
     });
   },

--- a/addon/components/dashboard-calendar.js
+++ b/addon/components/dashboard-calendar.js
@@ -128,7 +128,6 @@ export default Component.extend({
               school: school.get('id'),
               year: year.get('title')
             },
-            limit: 1000
           }).then((courses) => {
             resolve(courses.sortBy('title'));
           });

--- a/addon/components/single-event.js
+++ b/addon/components/single-event.js
@@ -118,7 +118,6 @@ export default Component.extend(SortableByPosition, {
           filters: {
             course: course.get('id')
           },
-          limit: 1000
         }).then((courseLearningMaterials) => {
           let sortedMaterials = courseLearningMaterials.toArray().sort(this.positionSortingCallback);
           map(sortedMaterials, clm => {
@@ -198,7 +197,6 @@ export default Component.extend(SortableByPosition, {
           filters: {
             session: session.get('id')
           },
-          limit: 1000
         }).then((sessionLearningMaterials) => {
           let sortedMaterials = sessionLearningMaterials.toArray().sort(this.positionSortingCallback);
           map(sortedMaterials, slm => {

--- a/addon/models/school.js
+++ b/addon/models/school.js
@@ -29,7 +29,6 @@ export default Model.extend({
         filters: {
           schools: [this.get('id')]
         },
-        limit: 1000
       });
     }
   }).readOnly(),


### PR DESCRIPTION
These limits were being used to ensure that we got all data when the API
had a default limit of 20 items. They are no longer necessary since the
API now returns all data starting in v1.23.

Fixes #40