### PR TITLE
Correct the proportions of the pulse-loader SVG

### DIFF
--- a/addon/templates/components/pulse-loader.hbs
+++ b/addon/templates/components/pulse-loader.hbs
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="670" height="236" viewBox="0 0 670 236">
+<svg xmlns="http://www.w3.org/2000/svg" width="168" height="106" viewBox="0 0 168 106">
   <path class="path" stroke="#ca6728" stroke-width="4" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" stroke-dasharray="391 300" stroke-dashoffset="0" fill="none" d="M0,80.9h20.6c0.5,0,1.4-0.2,1.8-0.5L38,70.1
 	c0.5-0.3,1.2-0.3,1.6,0l12.7,9.4c0.4,0.3,1.3,0.6,1.8,0.6l13.3,0c0.6,0,1.2,0.4,1.5,0.9l6.2,11.3c0.3,0.5,0.5,0.4,0.5-0.1l4.4-90.8
 	c0-0.5,0.1-0.5,0.1,0l6.9,102.1c0,0.5,0.2,0.6,0.4,0l7-22.4c0.2-0.5,0.7-1,1.3-1l16.1,0c0.5,0,1.3-0.3,1.8-0.7L129,66.4

--- a/app/styles/ilios-common/components/pulse-loader.scss
+++ b/app/styles/ilios-common/components/pulse-loader.scss
@@ -1,27 +1,15 @@
 .pulse-loader {
-  margin-left: 150px;
-  margin-top: 50px;
+
+  text-align: center;
 
   @keyframes pulse {
     0% {
       stroke-dashoffset: 691;
-     }
+    }
 
     100% {
       stroke-dashoffset: 0;
     }
-  }
-
-  .text {
-    color: $ilios-orange;
-    font-weight: bold;
-    line-height: 1;
-  }
-
-  &.is-full-size {
-    align-items: center;
-    display: flex;
-    min-height: 100px;
   }
 
   .path {


### PR DESCRIPTION
There was a lot of unused space in the box for this SVG so it was
difficult to use it in smaller areas. I constrained the viewBox to the proportions needed by the animation.  I also removed some CSS we were no longer using and text-align centered the loader which looks nicer.