### PR TITLE
Fix dotenv usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,10 +39,10 @@
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
+    "dotenv": "^4.0.0",
     "ember-ajax": "^3.0.0",
     "ember-cli": "2.16.2",
     "ember-cli-dependency-checker": "^2.0.1",
-    "ember-cli-dotenv": "^1.2.0",
     "ember-cli-eslint": "^4.2.0",
     "ember-cli-htmlbars-inline-precompile": "^1.0.2",
     "ember-cli-inject-live-reload": "^1.7.0",

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -1,6 +1,14 @@
 /* eslint-env node */
 'use strict';
 
+const existsSync = require('exists-sync');
+const dotenv = require('dotenv');
+const path = require('path');
+const dotEnvPath = path.join(__dirname, '../../../.env');
+if (existsSync(dotEnvPath)) {
+  dotenv.config({ path: dotEnvPath });
+}
+
 module.exports = function(environment) {
   let ENV = {
     modulePrefix: 'dummy',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2190,9 +2190,9 @@ dot-prop@^4.1.0:
   dependencies:
     is-obj "^1.0.0"
 
-dotenv@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-1.2.0.tgz#7cd73e16e07f057c8072147a5bc3a8677f0ab5c6"
+dotenv@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-4.0.0.tgz#864ef1379aced55ce6f95debecdce179f7a0cd1d"
 
 ecc-jsbn@~0.1.1:
   version "0.1.1"
@@ -2279,13 +2279,6 @@ ember-cli-dependency-checker@^2.0.1:
     chalk "^1.1.3"
     is-git-url "^1.0.0"
     semver "^5.3.0"
-
-ember-cli-dotenv@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-dotenv/-/ember-cli-dotenv-1.2.0.tgz#11aab75ee3d98305799778dad58072fca97c57f1"
-  dependencies:
-    dotenv "^1.0.0"
-    exists-sync "0.0.3"
 
 ember-cli-eslint@^4.2.0:
   version "4.2.1"
@@ -2793,7 +2786,7 @@ ember-moment@^7.4.1:
     ember-getowner-polyfill "^2.0.1"
     ember-macro-helpers "^0.15.1"
 
-ember-one-way-controls@3.0.0:
+ember-one-way-controls@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ember-one-way-controls/-/ember-one-way-controls-3.0.0.tgz#03baadb75a2455b048fdef758cba561c5b3dcfa3"
   dependencies:


### PR DESCRIPTION
The latest ember-cli doesn't work with ember-cli-dotenv, but we can just
use this node component directly.