### PR TITLE
Async/await syntax in Learner-Group model

### DIFF
--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -154,25 +154,25 @@ export default Model.extend({
   }),
 
 
-  filterTitle: computed('allDescendants.@each.title', function(){
-    return new Promise(resolve => {
-      this.get('allDescendants').then(allDescendants => {
-        this.get('allParents').then(allParents => {
-          all([
-            map(allDescendants, learnerGroup => learnerGroup.get('title')),
-            map(allParents, learnerGroup => learnerGroup.get('title'))
-          ]).then(titles => {
-            let flat = titles.reduce((flattened, arr) => {
-              return flattened.pushObjects(arr);
-            }, []);
-            flat.pushObject(this.get('title'));
-
-            resolve(flat.join(''));
-          });
-        });
-
-      });
-    });
+  /**
+   * A text string comprised of all learner-group titles in this group's tree.
+   * This includes that titles of all of its ancestors, all its descendants and this group's title itself.
+   * @property filterTitle
+   * @type {Ember.computed}
+   * @public
+   */
+  filterTitle: computed('allDescendants.@each.title', async function(){
+    const allDescendants = await this.get('allDescendants');
+    const allParents = await this.get('allParents');
+    const titles = all([
+      map(allDescendants, learnerGroup => learnerGroup.get('title')),
+      map(allParents, learnerGroup => learnerGroup.get('title'))
+    ]);
+    const flat = titles.reduce((flattened, arr) => {
+      return flattened.pushObjects(arr);
+    }, []);
+    flat.pushObject(this.get('title'));
+    return flat.join('');
   }),
 
   allParents: computed('parent', 'parent.allParents.[]', async function(){

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -185,24 +185,12 @@ export default Model.extend({
     return [parent].concat(allParents);
   }),
 
-  topLevelGroup: computed('parent', 'parent.topLevelGroup', function(){
-    return new Ember.RSVP.Promise(
-      resolve => {
-        this.get('parent').then(
-          parent => {
-            if(!parent){
-              resolve(this);
-            } else {
-              parent.get('topLevelGroup').then(
-                topLevelGroup => {
-                  resolve(topLevelGroup);
-                }
-              );
-            }
-          }
-        );
-      }
-    );
+  topLevelGroup: computed('parent', 'parent.topLevelGroup', async function(){
+    const parent = await this.get('parent');
+    if (isEmpty(parent)) {
+      return this;
+    }
+    return await parent.get('topLevelGroup');
   }),
 
   isTopLevelGroup: computed('parent', function(){

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -247,14 +247,6 @@ export default Model.extend({
     }, false);
   }),
 
-  async destroyChildren() {
-    const children = await this.get('children');
-    return await all(children.toArray().forEach(async child => {
-      await child.destroyChildren();
-      child.destroyRecord();
-    }));
-  },
-
   /**
    * Takes a user out of  a group and then traverses child groups recursively
    * to remove the user from them as well.  Will only modify groups where the

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -214,7 +214,7 @@ export default Model.extend({
     listsOfGroupInstructors.forEach(groupInstructors => {
       allInstructors.pushObjects(groupInstructors.toArray());
     });
-    return users;
+    return allInstructors;
   }),
 
   school: computed('cohort.programYear.program.school', async function(){

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -56,39 +56,6 @@ export default Model.extend({
   }),
 
   /**
-   * A list of users in this group, its parent group and its sibling-groups.
-   * @property availableUsers
-   * @type {Ember.computed}
-   * @public
-   */
-  availableUsers: computed('users', 'parent.users.[]', 'parent.childUsers.[]', function(){
-    var group = this;
-    return new Ember.RSVP.Promise(function(resolve) {
-      group.get('parent').then(function(parent){
-        if(parent == null){
-          resolve(false);
-        } else {
-          parent.get('users').then(function(parentUsers){
-            var childUsers = parent.get('childUsers');
-            var selectedUsers = Ember.A();
-            Ember.RSVP.all(childUsers).then(function(){
-              childUsers.forEach(function(userSet){
-                userSet.forEach(function(c){
-                  selectedUsers.pushObject(c);
-                });
-              });
-              var availableUsers = parentUsers.filter(function(user){
-                return !selectedUsers.includes(user);
-              });
-              resolve(availableUsers);
-            });
-          });
-        }
-      });
-    });
-  }),
-
-  /**
    * Get the offset for numbering generated subgroups.
    *
    * This is best explained by an example:

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -4,7 +4,6 @@ import escapeRegExp from '../utils/escape-reg-exp';
 
 const { attr, belongsTo, hasMany, Model } = DS;
 const { computed, isEmpty, RSVP } = Ember;
-const { mapBy, sum } = computed;
 const { Promise, map, all } = RSVP;
 
 export default Model.extend({

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -203,7 +203,7 @@ export default Model.extend({
     return isEmpty(this.belongsTo('parent').id());
   }),
 
-  allInstructors: computed('instructors.[]', 'instructorGroups.[]', async function(){
+  allInstructors: computed('instructors.[]', 'instructorGroups.@each.users', async function(){
     const allInstructors = [];
     const instructors = await this.get('instructors');
     allInstructors.pushObjects(instructors.toArray());

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -220,18 +220,11 @@ export default Model.extend({
     });
   }),
 
-  school: computed('cohort.programYear.program.school', function(){
-    return new Promise(resolve => {
-      this.get('cohort').then(cohort => {
-        cohort.get('programYear').then(programYear => {
-          programYear.get('program').then(program => {
-            program.get('school').then(school => {
-              resolve(school);
-            });
-          });
-        });
-      });
-    });
+  school: computed('cohort.programYear.program.school', async function(){
+    const cohort = await this.get('cohort');
+    const programYear = await cohort.get('programYear');
+    const program = await programYear.get('program');
+    return await program.get('school');
   }),
 
   /**

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -129,8 +129,9 @@ export default Model.extend({
     return titles;
   }),
 
-  sortTitle: computed('title', 'allParentsTitle', function(){
-    var title = this.get('allParentsTitle') + this.get('title');
+  sortTitle: computed('title', 'allParentsTitle', async function(){
+    const allParentsTitle = await this.get('allParentsTitle');
+    const title = allParentsTitle + this.get('title');
     return title.replace(/([\s->]+)/ig,"");
   }),
 

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -245,19 +245,12 @@ export default Model.extend({
     }, false);
   }),
 
-  destroyChildren: function(){
-    var group = this;
-    return new Ember.RSVP.Promise(function(resolve) {
-      var promises = [];
-      group.get('children').then(function(children){
-        children.forEach(function(child){
-          promises.push(child.destroyChildren().then(function(){
-            child.destroyRecord();
-          }));
-        });
-        resolve(Ember.RSVP.all(promises));
-      });
-    });
+  async destroyChildren() {
+    const children = await this.get('children');
+    return await all(children.toArray().forEach(async child => {
+      await child.destroyChildren();
+      child.destroyRecord();
+    }));
   },
 
   /**

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -2,7 +2,6 @@ import DS from 'ember-data';
 import Ember from 'ember';
 import escapeRegExp from '../utils/escape-reg-exp';
 
-
 const { attr, belongsTo, hasMany, Model } = DS;
 const { computed, isEmpty, RSVP } = Ember;
 const { mapBy, sum } = computed;
@@ -11,20 +10,15 @@ const { Promise, map, all } = RSVP;
 export default Model.extend({
   title: attr('string'),
   location: attr('string'),
-  cohort: belongsTo('cohort', {async: true}),
-  parent: belongsTo('learner-group', {async: true, inverse: 'children'}),
-  children: hasMany('learner-group', {async: true, inverse: 'parent'}),
-  ilmSessions: hasMany('ilm-session', {async: true}),
-  offerings: hasMany('offering', {async: true}),
-  instructorGroups: hasMany('instructor-group', {async: true}),
-  users: hasMany('user', {
-    async: true,
-    inverse: 'learnerGroups'
-  }),
-  instructors: hasMany('user', {
-    async: true,
-    inverse: 'instructedLearnerGroups'
-  }),
+  cohort: belongsTo('cohort', { async: true }),
+  parent: belongsTo('learner-group', { async: true, inverse: 'children' }),
+  children: hasMany('learner-group', { async: true, inverse: 'parent' }),
+  ilmSessions: hasMany('ilm-session', { async: true }),
+  offerings: hasMany('offering', { async: true }),
+  instructorGroups: hasMany('instructor-group', { async: true }),
+  users: hasMany('user', { async: true, inverse: 'learnerGroups' }),
+  instructors: hasMany('user', { async: true, inverse: 'instructedLearnerGroups' }),
+
   /**
    * A list of all courses associated with this learner group, via offerings/sessions or via ILMs.
    * @property courses

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -161,7 +161,7 @@ export default Model.extend({
    * @type {Ember.computed}
    * @public
    */
-  filterTitle: computed('allDescendants.@each.title', async function(){
+  filterTitle: computed('allDescendants.@each.title', 'allParents.@each.title', 'title', async function(){
     const allDescendants = await this.get('allDescendants');
     const allParents = await this.get('allParents');
     const titles = all([

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -55,6 +55,12 @@ export default Model.extend({
     return this.get('users.length') + this.get('childUsersTotal') + this.get('childrenUsersTotal');
   }),
 
+  /**
+   * A list of users in this group, its parent group and its sibling-groups.
+   * @property availableUsers
+   * @type {Ember.computed}
+   * @public
+   */
   availableUsers: computed('users', 'parent.users.[]', 'parent.childUsers.[]', function(){
     var group = this;
     return new Ember.RSVP.Promise(function(resolve) {

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -107,12 +107,12 @@ export default Model.extend({
     return membersAtThisLevel.filter(user => !isNone(user));
   }),
 
-  allParentsTitle: computed('allParentTitles', function(){
+  allParentsTitle: computed('allParentTitles', async function(){
     let title = '';
-    this.get('allParentTitles').forEach(str => {
+    const allParentTitles = await this.get('allParentTitles');
+    allParentTitles.forEach(str => {
       title += str + ' > ';
     });
-
     return title;
   }),
 

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -185,7 +185,7 @@ export default Model.extend({
     return [parent].concat(allParents);
   }),
 
-  topLevelGroup: computed('parent', 'parent.topLevelGroup', async function(){
+  topLevelGroup: computed('parent.topLevelGroup', async function(){
     const parent = await this.get('parent');
     if (isEmpty(parent)) {
       return this;

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -241,7 +241,7 @@ export default Model.extend({
       return false;
     }
 
-    const hasLearnersInSubgroups = await all(children.map('hasLearnersInGroupOrSubgroups'));
+    const hasLearnersInSubgroups = await all(children.mapBy('hasLearnersInGroupOrSubgroups'));
     return hasLearnersInSubgroups.reduce((acc, val) => {
       return (acc || val);
     }, false);

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -116,15 +116,16 @@ export default Model.extend({
     return title;
   }),
 
-  allParentTitles: computed('isTopLevelGroup', 'parent.{title,allParentTitles}', function(){
-    let titles = [];
+  allParentTitles: computed('isTopLevelGroup', 'parent.{title,allParentTitles}', async function(){
+    const titles = [];
     if(!this.get('isTopLevelGroup')){
-      if(this.get('parent.allParentTitles')){
-        titles.pushObjects(this.get('parent.allParentTitles'));
+      const parent = await this.get('patent');
+      const allParentTitles = await parent.get('allParentTitles');
+      if(!isEmpty(allParentTitles)){
+        titles.pushObjects(allParentTitles);
       }
-      titles.pushObject(this.get('parent.title'));
+      titles.pushObject(parent.get('title'));
     }
-
     return titles;
   }),
 

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -185,6 +185,12 @@ export default Model.extend({
     return [parent].concat(allParents);
   }),
 
+  /**
+   * The top-level group in this group's parentage tree, or this group itself if it has no parent.
+   * @property topLevelGroup
+   * @type {Ember.computed}
+   * @public
+   */
   topLevelGroup: computed('parent.topLevelGroup', async function(){
     const parent = await this.get('parent');
     if (isEmpty(parent)) {

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -3,24 +3,25 @@ import Ember from 'ember';
 import escapeRegExp from '../utils/escape-reg-exp';
 
 
+const { attr, belongsTo, hasMany, Model } = DS;
 const { computed, isEmpty, RSVP } = Ember;
 const { mapBy, sum } = computed;
 const { Promise, map, all } = RSVP;
 
-export default DS.Model.extend({
-  title: DS.attr('string'),
-  location: DS.attr('string'),
-  cohort: DS.belongsTo('cohort', {async: true}),
-  parent: DS.belongsTo('learner-group', {async: true, inverse: 'children'}),
-  children: DS.hasMany('learner-group', {async: true, inverse: 'parent'}),
-  ilmSessions: DS.hasMany('ilm-session', {async: true}),
-  offerings: DS.hasMany('offering', {async: true}),
-  instructorGroups: DS.hasMany('instructor-group', {async: true}),
-  users: DS.hasMany('user', {
+export default Model.extend({
+  title: attr('string'),
+  location: attr('string'),
+  cohort: belongsTo('cohort', {async: true}),
+  parent: belongsTo('learner-group', {async: true, inverse: 'children'}),
+  children: hasMany('learner-group', {async: true, inverse: 'parent'}),
+  ilmSessions: hasMany('ilm-session', {async: true}),
+  offerings: hasMany('offering', {async: true}),
+  instructorGroups: hasMany('instructor-group', {async: true}),
+  users: hasMany('user', {
     async: true,
     inverse: 'learnerGroups'
   }),
-  instructors: DS.hasMany('user', {
+  instructors: hasMany('user', {
     async: true,
     inverse: 'instructedLearnerGroups'
   }),
@@ -354,7 +355,7 @@ export default DS.Model.extend({
   hasLearnersInGroupOrSubgroups: computed('users.[]', 'children.@each.hasLearnersInGroupOrSubgroup', function() {
     return new Promise(resolve => {
       const userIds = this.hasMany('users').ids();
-      if (userIds.length) {
+      if (userIlength) {
         resolve(true);
       }
       this.get('children').then(children => {

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -203,21 +203,16 @@ export default Model.extend({
     return isEmpty(this.belongsTo('parent').id());
   }),
 
-  allInstructors: computed('instructors.[]', 'instructorGroups.[]', function(){
-    return new Promise(resolve => {
-      let users = [];
-      this.get('instructors').then(instructors => {
-        users.pushObjects(instructors.toArray());
-        this.get('instructorGroups').then(instructorGroups => {
-          RSVP.all(instructorGroups.mapBy('users')).then(arr => {
-            arr.forEach(groupInstructors =>{
-              users.pushObjects(groupInstructors.toArray());
-            });
-            resolve(users.uniq());
-          });
-        });
-      });
+  allInstructors: computed('instructors.[]', 'instructorGroups.[]', async function(){
+    const allInstructors = [];
+    const instructors = await this.get('instructors');
+    allInstructors.pushObjects(instructors.toArray());
+    const instructorGroups = await this.get('instructorGroups');
+    const listsOfGroupInstructors = await all(instructorGroups.mapBy('users'));
+    listsOfGroupInstructors.forEach(groupInstructors => {
+      allInstructors.pushObjects(groupInstructors.toArray());
     });
+    return users;
   }),
 
   school: computed('cohort.programYear.program.school', async function(){

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -51,10 +51,6 @@ export default Model.extend({
     return courses.uniq();
   }),
 
-  usersCount: computed('users.length', 'childUsersTotal', 'childrenUsersTotal', function(){
-    return this.get('users.length') + this.get('childUsersTotal') + this.get('childrenUsersTotal');
-  }),
-
   /**
    * Get the offset for numbering generated subgroups.
    *

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -166,7 +166,7 @@ export default Model.extend({
   filterTitle: computed('allDescendants.@each.title', 'allParents.@each.title', 'title', async function(){
     const allDescendants = await this.get('allDescendants');
     const allParents = await this.get('allParents');
-    const titles = all([
+    const titles = await all([
       map(allDescendants, learnerGroup => learnerGroup.get('title')),
       map(allParents, learnerGroup => learnerGroup.get('title'))
     ]);

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -154,7 +154,7 @@ export default Model.extend({
   }),
 
 
-  filterTitle: computed('allDescendants.[].title', function(){
+  filterTitle: computed('allDescendants.@each.title', function(){
     return new Promise(resolve => {
       this.get('allDescendants').then(allDescendants => {
         this.get('allParents').then(allParents => {

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -254,7 +254,7 @@ export default Model.extend({
   hasLearnersInGroupOrSubgroups: computed('users.[]', 'children.@each.hasLearnersInGroupOrSubgroup', function() {
     return new Promise(resolve => {
       const userIds = this.hasMany('users').ids();
-      if (userIlength) {
+      if (userIds.length) {
         resolve(true);
       }
       this.get('children').then(children => {

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -4,7 +4,7 @@ import escapeRegExp from '../utils/escape-reg-exp';
 
 const { attr, belongsTo, hasMany, Model } = DS;
 const { computed, isEmpty, isNone, RSVP } = Ember;
-const { Promise, map, all } = RSVP;
+const { map, all } = RSVP;
 
 export default Model.extend({
   title: attr('string'),

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -119,7 +119,7 @@ export default Model.extend({
   allParentTitles: computed('isTopLevelGroup', 'parent.{title,allParentTitles}', async function(){
     const titles = [];
     if(!this.get('isTopLevelGroup')){
-      const parent = await this.get('patent');
+      const parent = await this.get('parent');
       const allParentTitles = await parent.get('allParentTitles');
       if(!isEmpty(allParentTitles)){
         titles.pushObjects(allParentTitles);

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -58,7 +58,7 @@ export default Model.extend({
    */
   subgroupNumberingOffset: computed('children.[]', async function () {
     const regex = new RegExp('^' + escapeRegExp(this.get('title')) + ' ([0-9]+)$');
-    const groups = this.get('children');
+    const groups = await this.get('children');
     let offset = groups.reduce((previousValue, item) => {
       let rhett = previousValue;
       let matches = regex.exec(item.get('title'));

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -19,13 +19,6 @@ export default Model.extend({
   users: hasMany('user', { async: true, inverse: 'learnerGroups' }),
   instructors: hasMany('user', { async: true, inverse: 'instructedLearnerGroups' }),
 
-  childUsers: mapBy('children', 'users'),
-  childUserLengths: mapBy('childUsers', 'length'),
-  childrenUsersCounts: mapBy('children', 'childUsersTotal'),
-
-  childUsersTotal: sum('childUserLengths'),
-  childrenUsersTotal: sum('childrenUsersCounts'),
-
   /**
    * A list of all courses associated with this learner group, via offerings/sessions or via ILMs.
    * @property courses

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -98,7 +98,7 @@ export default Model.extend({
   usersOnlyAtThisLevel: computed('users.[]', 'allDescendants.[]', async function(){
     const users = await this.get('users');
     const descendants = await this.get('allDescendants');
-    const membersAtThisLevel = await map(users, async user => {
+    const membersAtThisLevel = await map(users.toArray(), async user => {
       const userGroups = await user.get('learnerGroups');
       const subGroups = userGroups.toArray().filter(group => descendants.includes(group));
       return isEmpty(subGroups) ? user : null;

--- a/tests/unit/models/learner-group-test.js
+++ b/tests/unit/models/learner-group-test.js
@@ -399,3 +399,23 @@ test('has learners with learners in group and with learners in subgroups', funct
     });
   });
 });
+
+test('users only at this level', async function(assert) {
+  assert.expect(2);
+  const learnerGroup = this.subject();
+  const store = this.store();
+  run( async () => {
+    const user1 = store.createRecord('user', {id: 1});
+    const user2 = store.createRecord('user', {id: 2});
+    const user3 = store.createRecord('user', {id: 3});
+    const user4 = store.createRecord('user', {id: 4});
+
+    const subgroup = store.createRecord('learner-group', { id: 2, parent: learnerGroup, 'users': [ user1, user3 ] });
+    store.createRecord('learner-group', {id: 3, parent: subgroup, 'users': [ user4 ]});
+    learnerGroup.get('users').pushObjects([user1, user2, user3, user4 ]);
+    learnerGroup.get('children').pushObject(subgroup);
+    const users = await learnerGroup.get('usersOnlyAtThisLevel');
+    assert.equal(users.length, 1);
+    assert.ok(users.includes(user2));
+  });
+});

--- a/tests/unit/models/learner-group-test.js
+++ b/tests/unit/models/learner-group-test.js
@@ -419,3 +419,24 @@ test('users only at this level', async function(assert) {
     assert.ok(users.includes(user2));
   });
 });
+
+
+test('allParentTitles', async function(assert) {
+  assert.expect(4);
+  const learnerGroup = this.subject();
+  const store = this.store();
+  await run( async () => {
+    learnerGroup.set('title', 'Foo');
+    learnerGroup.set('id', 1);
+    const titles = await learnerGroup.get('allParentTitles');
+    assert.equal(titles.length, 0);
+  });
+  run( async () => {
+    const subGroup = store.createRecord('learner-group', { id: 2, title: 'Bar', parent: learnerGroup });
+    const subSubGroup = store.createRecord('learner-group', {id: 3, title: 'Baz', parent: subGroup });
+    const titles = await subSubGroup.get('allParentTitles');
+    assert.equal(titles.length, 2);
+    assert.equal(titles[0], 'Foo');
+    assert.equal(titles[1], 'Bar');
+  });
+});

--- a/tests/unit/models/learner-group-test.js
+++ b/tests/unit/models/learner-group-test.js
@@ -458,3 +458,21 @@ test('allParentsTitle', async function(assert) {
     assert.equal(titles, 'Foo > Bar > ');
   });
 });
+
+test('sortTitle', async function(assert) {
+  assert.expect(2);
+  const learnerGroup = this.subject();
+  const store = this.store();
+  await run( async () => {
+    learnerGroup.set('title', 'Foo');
+    learnerGroup.set('id', 1);
+    const title = await learnerGroup.get('sortTitle');
+    assert.equal(title, 'Foo');
+  });
+  run( async () => {
+    const subGroup = store.createRecord('learner-group', { id: 2, title: 'Bar', parent: learnerGroup });
+    const subSubGroup = store.createRecord('learner-group', {id: 3, title: 'Baz', parent: subGroup });
+    const title = await subSubGroup.get('sortTitle');
+    assert.equal(title, 'FooBarBaz');
+  });
+});

--- a/tests/unit/models/learner-group-test.js
+++ b/tests/unit/models/learner-group-test.js
@@ -222,16 +222,12 @@ test('check filterTitle on top group', async function(assert) {
 
 test('check filterTitle on sub group', async function(assert) {
   assert.expect(2);
-  let store = this.store();
-
+  const store = this.store();
   run( async () => {
-
-
-    let learnerGroup = store.createRecord('learner-group', {title: 'top group'});
-    let subGroup1 = store.createRecord('learner-group', {parent: learnerGroup, title: 'subGroup1'});
-    let subGroup2 = store.createRecord('learner-group', {parent: subGroup1, title: 'subGroup2'});
-    let subGroup3 = store.createRecord('learner-group', {parent: subGroup2, title: 'subGroup3'});
-
+    const learnerGroup = store.createRecord('learner-group', {title: 'top group'});
+    const subGroup1 = store.createRecord('learner-group', {parent: learnerGroup, title: 'subGroup1'});
+    const subGroup2 = store.createRecord('learner-group', {parent: subGroup1, title: 'subGroup2'});
+    const subGroup3 = store.createRecord('learner-group', {parent: subGroup2, title: 'subGroup3'});
     const groups = await learnerGroup.get('allDescendants');
     assert.equal(groups.length, 3);
     const filterTitle = await subGroup3.get('filterTitle');
@@ -333,44 +329,37 @@ test('check addUserToGroupAndAllParents', async function(assert) {
 });
 
 
-test('has no learners in group without learners and without subgroups', function(assert) {
+test('has no learners in group without learners and without subgroups', async function(assert) {
   assert.expect(1);
-  let learnerGroup = this.subject();
-  run(() => {
-    learnerGroup.get('hasLearnersInGroupOrSubgroups').then(hasLearners => {
-      assert.notOk(hasLearners);
-    });
+  const learnerGroup = this.subject();
+  run( async () => {
+    const hasLearners = await learnerGroup.get('hasLearnersInGroupOrSubgroups');
+    assert.notOk(hasLearners);
   });
 });
 
-test('has learners in group with learners and but without learners in subgroups', function(assert) {
+test('has learners in group with learners and but without learners in subgroups', async function(assert) {
   assert.expect(1);
-  let learnerGroup = this.subject();
-  let store = this.store();
-  run(() => {
+  const learnerGroup = this.subject();
+  const store = this.store();
+  run( async () => {
     let learner = store.createRecord('user');
-    learnerGroup.get('users').then(users => {
-      users.pushObject(learner);
-      learnerGroup.get('hasLearnersInGroupOrSubgroups').then(hasLearners => {
-        assert.ok(hasLearners);
-      });
-    });
+    learnerGroup.get('users').pushObject(learner);
+    const hasLearners = await learnerGroup.get('hasLearnersInGroupOrSubgroups');
+    assert.ok(hasLearners);
   });
 });
 
 
-test('has no learners with no learners in group nor in subgroups', function(assert) {
+test('has no learners with no learners in group nor in subgroups', async function(assert) {
   assert.expect(1);
-  let learnerGroup = this.subject();
-  let store = this.store();
-  run(() => {
-    let subgroup = store.createRecord('learner-group', { id: 2, parent: learnerGroup });
-    learnerGroup.get('children').then(subgroups => {
-      subgroups.pushObject(subgroup);
-      learnerGroup.get('hasLearnersInGroupOrSubgroups').then(hasLearners => {
-        assert.notOk(hasLearners);
-      });
-    });
+  const learnerGroup = this.subject();
+  const store = this.store();
+  run( async () => {
+    const subgroup = store.createRecord('learner-group', { id: 2, parent: learnerGroup });
+    learnerGroup.get('children').pushObject(subgroup);
+    const hasLearners = await learnerGroup.get('hasLearnersInGroupOrSubgroups');
+    assert.notOk(hasLearners);
   });
 });
 

--- a/tests/unit/models/learner-group-test.js
+++ b/tests/unit/models/learner-group-test.js
@@ -17,33 +17,29 @@ test('it exists', function(assert) {
   assert.ok(!!model);
 });
 
-test('list courses', function(assert) {
+test('list courses', async function(assert) {
   assert.expect(3);
-  let model = this.subject();
-  var store = model.store;
-  run(function(){
+  const model = this.subject();
+  const store = model.store;
+  run( async () => {
+    const course1 = store.createRecord('course', {title:'course1'});
+    const course2 = store.createRecord('course', {title:'course2'});
+    const session1 = store.createRecord('session', {course: course1});
+    const session2 = store.createRecord('session', {course: course1});
+    const session3 = store.createRecord('session', {course: course2});
+    model.get('offerings').pushObjects([
+      store.createRecord('offering', {session: session1}),
+      store.createRecord('offering', {session: session1}),
+      store.createRecord('offering', {session: session1}),
+      store.createRecord('offering', {session: session2}),
+      store.createRecord('offering', {session: session2}),
+      store.createRecord('offering', {session: session3}),
+    ]);
 
-    var course1 = store.createRecord('course', {title:'course1'});
-    var course2 = store.createRecord('course', {title:'course2'});
-    var session1 = store.createRecord('session', {course: course1});
-    var session2 = store.createRecord('session', {course: course1});
-    var session3 = store.createRecord('session', {course: course2});
-    model.get('offerings').then(function(offerings){
-      offerings.pushObject(store.createRecord('offering', {session: session1}));
-      offerings.pushObject(store.createRecord('offering', {session: session1}));
-      offerings.pushObject(store.createRecord('offering', {session: session1}));
-      offerings.pushObject(store.createRecord('offering', {session: session2}));
-      offerings.pushObject(store.createRecord('offering', {session: session2}));
-      offerings.pushObject(store.createRecord('offering', {session: session3}));
-    });
-  });
-
-  run(function(){
-    model.get('courses').then(function(courses){
-      assert.equal(courses.length, 2);
-      assert.equal(courses.objectAt(0).get('title'), 'course1');
-      assert.equal(courses.objectAt(1).get('title'), 'course2');
-    });
+    const courses = await model.get('courses');
+    assert.equal(courses.length, 2);
+    assert.equal(courses.objectAt(0).get('title'), 'course1');
+    assert.equal(courses.objectAt(1).get('title'), 'course2');
   });
 });
 
@@ -151,43 +147,43 @@ test('check subgroupNumberingOffset on group with sub-groups and mis-matched sub
   });
 });
 
-test('check allinstructors', function(assert) {
-  assert.expect(11);
-  let learnerGroup = this.subject();
-  let store = this.store();
+test('check allinstructors', async function(assert) {
+  assert.expect(8);
+  const learnerGroup = this.subject();
+  const store = this.store();
 
-  return learnerGroup.get('allInstructors').then(users => {
-    assert.equal(users.length, 0);
+  await run( async () => {
+    const allInstructors = await learnerGroup.get('allInstructors');
+    assert.equal(allInstructors.length, 0);
+  });
 
-    let user1 = store.createRecord('user');
-    let user2 = store.createRecord('user');
-    let user3 = store.createRecord('user');
+  await run( async () => {
+    const user1 = store.createRecord('user');
+    const user2 = store.createRecord('user');
+    const user3 = store.createRecord('user');
     learnerGroup.get('instructors').pushObject(user1);
-    let instructorGroup1 = store.createRecord('instructor-group', {users: [user2]});
-    let instructorGroup2 = store.createRecord('instructor-group', {users: [user3]});
+    const instructorGroup1 = store.createRecord('instructor-group', {users: [user2]});
+    const instructorGroup2 = store.createRecord('instructor-group', {users: [user3]});
     learnerGroup.get('instructorGroups').pushObjects([instructorGroup1, instructorGroup2]);
 
-    return learnerGroup.get('allInstructors').then(allInstructors => {
-      assert.equal(allInstructors.length, 3);
-      assert.ok(allInstructors.includes(user1));
-      assert.ok(allInstructors.includes(user2));
-      assert.ok(allInstructors.includes(user3));
-      let user4 = store.createRecord('user');
-      let user5 = store.createRecord('user');
-      learnerGroup.get('instructors').pushObject(user4);
-      let instructorGroup3 = store.createRecord('instructor-group', {users: [user5]});
-      learnerGroup.get('instructorGroups').pushObject(instructorGroup3);
+    const allInstructors = await learnerGroup.get('allInstructors');
+    assert.equal(allInstructors.length, 3);
+    assert.ok(allInstructors.includes(user1));
+    assert.ok(allInstructors.includes(user2));
+    assert.ok(allInstructors.includes(user3));
+  });
 
-      return learnerGroup.get('allInstructors').then(allInstructors2 => {
-        assert.equal(allInstructors2.length, 5);
-        assert.ok(allInstructors2.includes(user1));
-        assert.ok(allInstructors2.includes(user2));
-        assert.ok(allInstructors2.includes(user3));
-        assert.ok(allInstructors2.includes(user4));
-        assert.ok(allInstructors2.includes(user5));
-      });
+  run( async () => {
+    const user4 = store.createRecord('user');
+    const user5 = store.createRecord('user');
+    learnerGroup.get('instructors').pushObject(user4);
+    let instructorGroup3 = store.createRecord('instructor-group', {users: [user5]});
+    learnerGroup.get('instructorGroups').pushObject(instructorGroup3);
 
-    });
+    let allInstructors = await learnerGroup.get('allInstructors');
+    assert.equal(allInstructors.length, 5);
+    assert.ok(allInstructors.includes(user4));
+    assert.ok(allInstructors.includes(user5));
   });
 });
 

--- a/tests/unit/models/learner-group-test.js
+++ b/tests/unit/models/learner-group-test.js
@@ -440,3 +440,21 @@ test('allParentTitles', async function(assert) {
     assert.equal(titles[1], 'Bar');
   });
 });
+
+test('allParentsTitle', async function(assert) {
+  assert.expect(2);
+  const learnerGroup = this.subject();
+  const store = this.store();
+  await run( async () => {
+    learnerGroup.set('title', 'Foo');
+    learnerGroup.set('id', 1);
+    const titles = await learnerGroup.get('allParentsTitle');
+    assert.equal(titles, '');
+  });
+  run( async () => {
+    const subGroup = store.createRecord('learner-group', { id: 2, title: 'Bar', parent: learnerGroup });
+    const subSubGroup = store.createRecord('learner-group', {id: 3, title: 'Baz', parent: subGroup });
+    const titles = await subSubGroup.get('allParentsTitle');
+    assert.equal(titles, 'Foo > Bar > ');
+  });
+});

--- a/tests/unit/models/learner-group-test.js
+++ b/tests/unit/models/learner-group-test.js
@@ -492,3 +492,19 @@ test('topLevelGroup', async function(assert) {
     assert.equal(topLevelGroup, learnerGroup);
   });
 });
+
+test('isTopLevelGroup', async function(assert) {
+  assert.expect(2);
+  const learnerGroup = this.subject();
+  const store = this.store();
+  learnerGroup.set('id', 1);
+  await run( async () => {
+    const isTopLevelGroup = await learnerGroup.get('isTopLevelGroup');
+    assert.ok(isTopLevelGroup);
+  });
+  run( async () => {
+    const subGroup = store.createRecord('learner-group', { parent: learnerGroup });
+    const isTopLevelGroup = await subGroup.get('isTopLevelGroup');
+    assert.notOk(isTopLevelGroup);
+  });
+});

--- a/tests/unit/models/learner-group-test.js
+++ b/tests/unit/models/learner-group-test.js
@@ -476,3 +476,19 @@ test('sortTitle', async function(assert) {
     assert.equal(title, 'FooBarBaz');
   });
 });
+
+test('topLevelGroup', async function(assert) {
+  assert.expect(2);
+  const learnerGroup = this.subject();
+  const store = this.store();
+  await run( async () => {
+    const topLevelGroup = await learnerGroup.get('topLevelGroup');
+    assert.equal(topLevelGroup, learnerGroup);
+  });
+  run( async () => {
+    const subGroup = store.createRecord('learner-group', { parent: learnerGroup });
+    const subSubGroup = store.createRecord('learner-group', { parent: subGroup });
+    const topLevelGroup = await subSubGroup.get('topLevelGroup');
+    assert.equal(topLevelGroup, learnerGroup);
+  });
+});

--- a/tests/unit/models/learner-group-test.js
+++ b/tests/unit/models/learner-group-test.js
@@ -47,67 +47,6 @@ test('list courses', function(assert) {
   });
 });
 
-test('list available users', function(assert) {
-  assert.expect(4);
-  let model = this.subject();
-  var store = model.store;
-  var newUsers = [];
-
-  run(function(){
-    var parent = store.createRecord('learner-group', {title:'parent'});
-    model.set('parent', parent);
-    for(var i = 0; i < 5; i++){
-      newUsers[i] = store.createRecord('user', {firstName: i});
-    }
-    for(i = 10; i < 25; i++){
-      store.createRecord('user', {firstName: i});
-    }
-
-    var sibling = store.createRecord('learner-group', {title:'sibling'});
-    sibling.get('users').then(function(users){
-      users.pushObject(newUsers[0]);
-      users.pushObject(newUsers[1]);
-    });
-    parent.get('children').then(function(children){
-      children.pushObject(sibling);
-    });
-    parent.get('users').then(function(users){
-      for(var i = 0; i < 5; i++){
-        users.pushObject(newUsers[i]);
-      }
-    });
-  });
-
-  run(function(){
-    model.get('availableUsers').then(function(users){
-      var names = users.mapBy('firstName');
-      assert.equal(users.get('length'), 3);
-      assert.ok(names.includes(2));
-      assert.ok(names.includes(3));
-      assert.ok(names.includes(4));
-    });
-  });
-});
-
-test('top level groups return false for the list of available users', function(assert) {
-  assert.expect(1);
-  let model = this.subject();
-  var store = model.store;
-  var newUsers = [];
-
-  run(function(){
-    for(var i = 0; i < 10; i++){
-      newUsers[i] = store.createRecord('user', {firstName: i});
-    }
-  });
-
-  run(function(){
-    model.get('availableUsers').then(function(users){
-      assert.ok(!users);
-    });
-  });
-});
-
 test('check allDescendantUsers on empty group', async function(assert) {
   assert.expect(1);
   let learnerGroup = this.subject();

--- a/tests/unit/models/learner-group-test.js
+++ b/tests/unit/models/learner-group-test.js
@@ -508,3 +508,18 @@ test('isTopLevelGroup', async function(assert) {
     assert.notOk(isTopLevelGroup);
   });
 });
+
+test('school', async function(assert) {
+  assert.expect(1);
+  const learnerGroup = this.subject();
+  const store = this.store();
+  run( async () => {
+    const school = store.createRecord('school');
+    const program = store.createRecord('program', { school });
+    const programYear = store.createRecord('program-year', { program });
+    const cohort = store.createRecord('cohort', { programYear });
+    learnerGroup.set('cohort', cohort);
+    const owningSchool = await learnerGroup.get('school');
+    assert.equal(owningSchool, school);
+  });
+});

--- a/tests/unit/models/learner-group-test.js
+++ b/tests/unit/models/learner-group-test.js
@@ -208,8 +208,6 @@ test('check filterTitle on top group', async function(assert) {
   let store = this.store();
 
   run( async () => {
-
-
     let learnerGroup = store.createRecord('learner-group', {title: 'top group'});
     let subGroup1 = store.createRecord('learner-group', {parent: learnerGroup, title: 'subGroup1'});
     let subGroup2 = store.createRecord('learner-group', {parent: subGroup1, title: 'subGroup2'});
@@ -241,96 +239,96 @@ test('check filterTitle on sub group', async function(assert) {
   });
 });
 
-test('check sortTitle on top group', function(assert) {
+test('check sortTitle on top group', async function(assert) {
   assert.expect(2);
-  let learnerGroup = this.subject();
-  let store = this.store();
+  const learnerGroup = this.subject();
+  const store = this.store();
 
-  run(() => {
+  await run( async () => {
     learnerGroup.set('title', 'top group');
-    return learnerGroup.get('allDescendants').then(groups => {
-      assert.equal(groups.length, 0);
-
-      store.createRecord('learner-group', {parent: learnerGroup, title: 'subGroup1'});
-
-      let sortTitle = learnerGroup.get('sortTitle');
-      assert.equal(sortTitle, 'topgroup');
-    });
+    const groups = await learnerGroup.get('allDescendants');
+    assert.equal(groups.length, 0);
   });
 
+  run( async () => {
+    store.createRecord('learner-group', {parent: learnerGroup, title: 'subGroup1'});
+    const sortTitle = await learnerGroup.get('sortTitle');
+    assert.equal(sortTitle, 'topgroup');
+  });
 });
 
-test('check sortTitle on sub group', function(assert) {
+test('check sortTitle on sub group', async function(assert) {
   assert.expect(2);
-  let learnerGroup = this.subject();
-  let store = this.store();
+  const learnerGroup = this.subject();
+  const store = this.store();
 
-  run(() => {
+  await run( async () => {
     learnerGroup.set('title', 'top group');
     learnerGroup.set('id', 1);
-    return learnerGroup.get('allDescendants').then(groups => {
-      assert.equal(groups.length, 0);
-
-      let subGroup1 = store.createRecord('learner-group', {id: 2, parent: learnerGroup, title: 'subGroup1'});
-      let subGroup2 = store.createRecord('learner-group', {id: 3, parent: subGroup1, title: 'subGroup2'});
-      let subGroup3 = store.createRecord('learner-group', {id: 4, parent: subGroup2, title: 'subGroup3'});
-
-      let sortTitle = subGroup3.get('sortTitle');
-      assert.equal(sortTitle, 'topgroupsubGroup1subGroup2subGroup3');
-    });
+    const groups = await learnerGroup.get('allDescendants');
+    assert.equal(groups.length, 0);
   });
 
-});
+  run( async () => {
+    const subGroup1 = store.createRecord('learner-group', {id: 2, parent: learnerGroup, title: 'subGroup1'});
+    const subGroup2 = store.createRecord('learner-group', {id: 3, parent: subGroup1, title: 'subGroup2'});
+    const subGroup3 = store.createRecord('learner-group', {id: 4, parent: subGroup2, title: 'subGroup3'});
 
-test('check removeUserFromGroupAndAllDescendants', function(assert) {
-  assert.expect(7);
-  let learnerGroup = this.subject();
-  let store = this.store();
-
-  return learnerGroup.get('allParents').then(groups => {
-    assert.equal(groups.length, 0);
-
-    let user1 = store.createRecord('user');
-
-    let subGroup1 = store.createRecord('learner-group', {parent: learnerGroup, users: [user1]});
-    let subGroup2 = store.createRecord('learner-group', {parent: subGroup1, users: [user1]});
-    let subGroup3 = store.createRecord('learner-group', {parent: subGroup2, users: [user1]});
-    let subGroup4 = store.createRecord('learner-group', {parent: subGroup1});
-
-    return subGroup1.removeUserFromGroupAndAllDescendants(user1).then(groupsToRemove => {
-      assert.equal(groupsToRemove.length, 3);
-      assert.notOk(groupsToRemove.includes(learnerGroup));
-      assert.ok(groupsToRemove.includes(subGroup1));
-      assert.ok(groupsToRemove.includes(subGroup2));
-      assert.ok(groupsToRemove.includes(subGroup3));
-      assert.notOk(groupsToRemove.includes(subGroup4));
-    });
+    const sortTitle = await subGroup3.get('sortTitle');
+    assert.equal(sortTitle, 'topgroupsubGroup1subGroup2subGroup3');
   });
 });
 
-test('check addUserToGroupAndAllParents', function(assert) {
+test('check removeUserFromGroupAndAllDescendants', async function(assert) {
   assert.expect(7);
-  let learnerGroup = this.subject();
-  let store = this.store();
+  const learnerGroup = this.subject();
+  const store = this.store();
 
-  return learnerGroup.get('allParents').then(groups => {
+  await run( async () => {
+    const groups = await learnerGroup.get('allParents');
     assert.equal(groups.length, 0);
+  });
 
-    let user1 = store.createRecord('user', {id: 1});
+  run( async () => {
+    const user1 = store.createRecord('user');
+    const subGroup1 = store.createRecord('learner-group', {parent: learnerGroup, users: [user1]});
+    const subGroup2 = store.createRecord('learner-group', {parent: subGroup1, users: [user1]});
+    const subGroup3 = store.createRecord('learner-group', {parent: subGroup2, users: [user1]});
+    const subGroup4 = store.createRecord('learner-group', {parent: subGroup1});
 
-    let subGroup1 = store.createRecord('learner-group', {id: 1, parent: learnerGroup, users: [user1]});
-    let subGroup2 = store.createRecord('learner-group', {id: 2, parent: subGroup1});
-    let subGroup3 = store.createRecord('learner-group', {id: 3, parent: subGroup2});
-    let subGroup4 = store.createRecord('learner-group', {id: 4, parent: subGroup1});
+    const groupsToRemove = await subGroup1.removeUserFromGroupAndAllDescendants(user1);
+    assert.equal(groupsToRemove.length, 3);
+    assert.notOk(groupsToRemove.includes(learnerGroup));
+    assert.ok(groupsToRemove.includes(subGroup1));
+    assert.ok(groupsToRemove.includes(subGroup2));
+    assert.ok(groupsToRemove.includes(subGroup3));
+    assert.notOk(groupsToRemove.includes(subGroup4));
+  });
+});
 
-    return subGroup3.addUserToGroupAndAllParents(user1).then(groupsToAdd => {
-      assert.equal(groupsToAdd.length, 3);
-      assert.ok(groupsToAdd.includes(learnerGroup));
-      assert.notOk(groupsToAdd.includes(subGroup1));
-      assert.ok(groupsToAdd.includes(subGroup2));
-      assert.ok(groupsToAdd.includes(subGroup3));
-      assert.notOk(groupsToAdd.includes(subGroup4));
-    });
+test('check addUserToGroupAndAllParents', async function(assert) {
+  assert.expect(7);
+  const learnerGroup = this.subject();
+  const store = this.store();
+
+  await run( async () => {
+    const groups = await learnerGroup.get('allParents');
+    assert.equal(groups.length, 0);
+  });
+
+  run( async () => {
+    const user1 = store.createRecord('user', {id: 1});
+    const subGroup1 = store.createRecord('learner-group', {id: 1, parent: learnerGroup, users: [user1]});
+    const subGroup2 = store.createRecord('learner-group', {id: 2, parent: subGroup1});
+    const subGroup3 = store.createRecord('learner-group', {id: 3, parent: subGroup2});
+    const subGroup4 = store.createRecord('learner-group', {id: 4, parent: subGroup1});
+    const groupsToAdd = await subGroup3.addUserToGroupAndAllParents(user1);
+    assert.equal(groupsToAdd.length, 3);
+    assert.ok(groupsToAdd.includes(learnerGroup));
+    assert.notOk(groupsToAdd.includes(subGroup1));
+    assert.ok(groupsToAdd.includes(subGroup2));
+    assert.ok(groupsToAdd.includes(subGroup3));
+    assert.notOk(groupsToAdd.includes(subGroup4));
   });
 });
 


### PR DESCRIPTION
## Non-breaking changes
### Removed obsolete/unused CPs and methods

- `availableUsers`
- `childrenUserCounts`
- `childrenUsersTotal`
- `childUserLengths`
- `childUsers`
- `childUsersTotal`
- `usersCount`
- `destroyChilden()`

## Potentially breaking changes:
### Computed properties with changes to dependent keys
- `filterTitle`
- `topLevelGroup`
- `allInstructors`

## _Definitely_ breaking changes
### Conversion from synchronous to asynchronous CPs
- `allParentTitles`
- `allParentsTitle`
- `sortTitle`


