### PR TITLE
Remove jwt-decode shim

### DIFF
--- a/addon/services/current-user.js
+++ b/addon/services/current-user.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import moment from 'moment';
-import jwtDecode from 'jwt-decode';
+import jwtDecode from '../utils/jwt-decode';
 
 const { computed, RSVP, isEmpty, inject, get, Service } = Ember;
 const { service } = inject;

--- a/addon/utils/jwt-decode.js
+++ b/addon/utils/jwt-decode.js
@@ -1,0 +1,19 @@
+
+/**
+ * Stolen from https://github.com/auth0/jwt-decode/blob/master/lib/base64_url_decode.js
+ */
+let b64DecodeUnicode = function (str) {
+  return decodeURIComponent(atob(str).replace(/(.)/g, function (m, p) {
+    let code = p.charCodeAt(0).toString(16).toUpperCase();
+    if (code.length < 2) {
+      code = '0' + code;
+    }
+    return '%' + code;
+  }));
+};
+
+export default function jwtDecode(token) {
+  let parts = token.split('.');
+  let body = parts[1];
+  return JSON.parse(b64DecodeUnicode(body));
+}

--- a/app/utils/jwt-decode.js
+++ b/app/utils/jwt-decode.js
@@ -1,0 +1,1 @@
+export { default } from 'ilios-common/utils/jwt-decode';

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "ember-composable-helpers": "^2.0.1",
     "ember-concurrency": "0.7.19",
     "ember-i18n": "^5.0.1",
-    "ember-jwt-decode-shim": "^1.0.0",
     "ember-moment": "^7.4.1",
     "ember-one-way-controls": "^3.0.0",
     "ember-promise-helpers": "^1.0.3",

--- a/tests/unit/utils/jwt-decode-test.js
+++ b/tests/unit/utils/jwt-decode-test.js
@@ -1,0 +1,13 @@
+import jwtDecode from 'dummy/utils/jwt-decode';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | jwt decode');
+
+const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ';
+test('it decodes a token', function(assert) {
+  let obj = jwtDecode(token);
+  assert.equal(obj.sub, '1234567890');
+  assert.equal(obj.name, 'John Doe');
+  assert.equal(obj.admin, true);
+
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2692,15 +2692,6 @@ ember-invoke-action@^1.5.0:
   dependencies:
     ember-cli-babel "^6.6.0"
 
-ember-jwt-decode-shim@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/ember-jwt-decode-shim/-/ember-jwt-decode-shim-1.2.0.tgz#4c4fb7d4cb6631b0bbe093b50bd3db5b991ffa0e"
-  dependencies:
-    broccoli-funnel "^2.0.0"
-    broccoli-merge-trees "^2.0.0"
-    ember-cli-babel "^6.6.0"
-    jwt-decode "^2.2.0"
-
 ember-load-initializers@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-load-initializers/-/ember-load-initializers-1.0.0.tgz#4919eaf06f6dfeca7e134633d8c05a6c9921e6e7"
@@ -4441,10 +4432,6 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
-
-jwt-decode@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-2.2.0.tgz#7d86bd56679f58ce6a84704a657dd392bba81a79"
 
 kind-of@^3.0.2:
   version "3.2.2"


### PR DESCRIPTION
This shim probably isn't going to be maintained for ember 2.17+ as it doesn't
seem to work. We can replace it with a simple implementation of our own.

This unlocks #123