### PR TITLE
Cohorts do not keep track of primary users

### DIFF
--- a/addon/models/user.js
+++ b/addon/models/user.js
@@ -82,7 +82,7 @@ export default Model.extend({
     async: true,
     inverse: 'users'
   }),
-  primaryCohort: belongsTo('cohort', {async: true}),
+  primaryCohort: belongsTo('cohort', {async: true, inverse: null}),
   pendingUserUpdates: hasMany('pending-user-update', {async: true}),
   permissions: hasMany('permission', {async: true}),
 


### PR DESCRIPTION
This is mainly a fix so that mirage will correctly understand that there
is no inverse property for this relationship on the cohort model.