### PR TITLE
async/await syntax in course model

### DIFF
--- a/addon/models/course.js
+++ b/addon/models/course.js
@@ -160,8 +160,8 @@ export default Model.extend(PublishableModel, CategorizableModel, SortableByPosi
    * @type {Ember.computed}
    */
   sortedObjectives: computed('objectives.@each.position', async function() {
-      const objectives = await this.get('objectives');
-      return objectives.toArray().sort(this.positionSortingCallback);
+    const objectives = await this.get('objectives');
+    return objectives.toArray().sort(this.positionSortingCallback);
   }),
 
   hasMultipleCohorts: computed('cohorts.[]', function(){

--- a/addon/models/course.js
+++ b/addon/models/course.js
@@ -5,7 +5,7 @@ import PublishableModel from 'ilios-common/mixins/publishable-model';
 import CategorizableModel from 'ilios-common/mixins/categorizable-model';
 import SortableByPosition from 'ilios-common/mixins/sortable-by-position';
 
-const { computed, RSVP } = Ember;
+const { computed, RSVP, isEmpty } = Ember;
 const { filterBy, mapBy, sum } = computed;
 const { all, map, Promise } = RSVP;
 const { attr, belongsTo, hasMany, Model } = DS;
@@ -52,20 +52,14 @@ export default Model.extend(PublishableModel, CategorizableModel, SortableByPosi
    * @type {Ember.computed}
    * @public
    */
-  competencies: computed('objectives.@each.treeCompetencies', function(){
-    return new Promise(resolve => {
-      this.get('objectives').then(function(objectives){
-        let promises = objectives.getEach('treeCompetencies');
-        all(promises).then(trees => {
-          let competencies = trees.reduce((array, set) => {
-            return array.pushObjects(set);
-          }, []);
-          competencies = competencies.uniq().filter(item => {
-            return item != null;
-          });
-          resolve(competencies);
-        });
-      });
+  competencies: computed('objectives.@each.treeCompetencies', async function(){
+    const objectives = await this.get('objectives');
+    const trees = await all(objectives.mapBy('treeCompetencies'));
+    const competencies = trees.reduce((array, set) => {
+      return array.pushObjects(set);
+    }, []);
+    return competencies.uniq().filter(item => {
+      return !isEmpty(item);
     });
   }),
 

--- a/addon/models/course.js
+++ b/addon/models/course.js
@@ -7,7 +7,7 @@ import SortableByPosition from 'ilios-common/mixins/sortable-by-position';
 
 const { computed, ObjectProxy, RSVP, isEmpty } = Ember;
 const { filterBy, mapBy, sum } = computed;
-const { all, map, Promise } = RSVP;
+const { all, map } = RSVP;
 const { attr, belongsTo, hasMany, Model } = DS;
 
 export default Model.extend(PublishableModel, CategorizableModel, SortableByPosition, {

--- a/addon/models/course.js
+++ b/addon/models/course.js
@@ -88,7 +88,7 @@ export default Model.extend(PublishableModel, CategorizableModel, SortableByPosi
               let subCompetencies = domainContainer[domain.get('id')].get('subCompetencies');
               if(!subCompetencies.includes(competency)){
                 subCompetencies.pushObject(competency);
-                subCompetencies.sortBy('title');
+                domainContainer[domain.get('id')].set('subCompetencies', subCompetencies.sortBy('title'));
               }
             }
           }));

--- a/addon/models/course.js
+++ b/addon/models/course.js
@@ -79,7 +79,7 @@ export default Model.extend(PublishableModel, CategorizableModel, SortableByPosi
 
       // filter out any competencies of this domain that are not linked to this course.
       subCompetencies = subCompetencies.filter(competency => {
-        return competencies.contains(competency);
+        return competencies.includes(competency);
       }).sortBy('title');
 
       return ObjectProxy.create({

--- a/addon/models/course.js
+++ b/addon/models/course.js
@@ -155,11 +155,11 @@ export default Model.extend(PublishableModel, CategorizableModel, SortableByPosi
   }),
 
   /**
-   * A list of course objectives, sorted by position and title.
+   * A list of course objectives, sorted by position (asc) and then id (desc).
    * @property sortedObjectives
    * @type {Ember.computed}
    */
-  sortedObjectives: computed('objectives.@each.position', 'objectives.@each.title', async function() {
+  sortedObjectives: computed('objectives.@each.position', async function() {
       const objectives = await this.get('objectives');
       return objectives.toArray().sort(this.positionSortingCallback);
   }),

--- a/addon/models/course.js
+++ b/addon/models/course.js
@@ -173,13 +173,11 @@ export default Model.extend(PublishableModel, CategorizableModel, SortableByPosi
    * @property sortedObjectives
    * @type {Ember.computed}
    */
-  sortedObjectives: computed('objectives.@each.position', 'objectives.@each.title', function() {
-    return new Promise(resolve => {
-      this.get('objectives').then(objectives => {
-        resolve(objectives.toArray().sort(this.positionSortingCallback));
-      });
-    });
+  sortedObjectives: computed('objectives.@each.position', 'objectives.@each.title', async function() {
+      const objectives = await this.get('objectives');
+      return objectives.toArray().sort(this.positionSortingCallback);
   }),
+
   hasMultipleCohorts: computed('cohorts.[]', function(){
     const meta = this.hasMany('cohorts');
     const ids = meta.ids();

--- a/tests/unit/models/course-test.js
+++ b/tests/unit/models/course-test.js
@@ -1,7 +1,4 @@
-import {
-  moduleForModel,
-  test
-} from 'ember-qunit';
+import { moduleForModel, test } from 'ember-qunit';
 import modelList from '../../helpers/model-list';
 import Ember from 'ember';
 
@@ -54,7 +51,7 @@ test('check competencies', async function(assert) {
   let course = this.subject();
   let store = this.store();
 
-  run( async () => {
+  await run( async () => {
     let competency1 = store.createRecord('competency');
     let competency2 = store.createRecord('competency');
     let competency3 = store.createRecord('competency');
@@ -99,5 +96,41 @@ test('check publishedSessionOfferingCounts count', function(assert) {
     session3.set('published', true);
 
     assert.equal(course.get('publishedOfferingCount'), 5);
+  });
+});
+
+test("domains", async function(assert) {
+  assert.expect(7);
+  let course = this.subject();
+  let store = this.store();
+  await run( async () => {
+    const domain1 = store.createRecord('competency', { id: 1 });
+    const domain2 = store.createRecord('competency', { id: 2 });
+    const domain3 = store.createRecord('competency', { id: 3 });
+    const competency1 = store.createRecord('competency', { id: 4, title: 'Zeppelin', parent: domain1 });
+    const competency2 = store.createRecord('competency', { id: 5, title: 'Aardvark', parent: domain1 });
+    const competency3 = store.createRecord('competency', { id: 6, title: 'Geflarknik', parent: domain2 });
+
+    let objective1 = store.createRecord('objective', { competency: competency1 });
+    let objective2 = store.createRecord('objective', { competency: competency2 });
+    let objective3 = store.createRecord('objective', { competency: competency3 });
+    let objective4 = store.createRecord('objective', { competency: domain3 });
+
+    course.get('objectives').pushObjects([ objective1, objective2, objective3, objective4 ]);
+
+    const domainProxies = await course.get('domains');
+    assert.equal(domainProxies.length, 3);
+
+    const domainProxy1 = domainProxies.findBy('content.id', domain1.get('id'));
+    assert.equal(domainProxy1.get('subCompetencies').length, 2);
+    assert.ok(domainProxy1.get('subCompetencies').includes(competency1));
+    assert.ok(domainProxy1.get('subCompetencies').includes(competency2));
+
+    const domainProxy2 = domainProxies.findBy('content.id', domain2.get('id'));
+    assert.equal(domainProxy2.get('subCompetencies').length, 1);
+    assert.ok(domainProxy2.get('subCompetencies').includes(competency3));
+
+    const domainProxy3 = domainProxies.findBy('content.id', domain3.get('id'));
+    assert.equal(domainProxy3.get('subCompetencies').length, 0);
   });
 });

--- a/tests/unit/models/course-test.js
+++ b/tests/unit/models/course-test.js
@@ -199,3 +199,47 @@ test('assignableVocabularies', async function(assert){
     assert.equal(vocabularies[3], vocabulary1);
   });
 });
+
+test('assignableVocabularies', async function(assert){
+  assert.expect(5);
+  let course = this.subject();
+  let store = this.store();
+  await run( async () => {
+    const school1 = store.createRecord('school', { title: 'Zeppelin' });
+    const school2 = store.createRecord('school', { title: 'Anton' });
+    const vocabulary1 = store.createRecord('vocabulary', { title: 'Sowjetunion',  school: school1 });
+    const vocabulary2 = store.createRecord('vocabulary', { title: 'DDR', school: school1 });
+    const vocabulary3 = store.createRecord('vocabulary', { title: 'Walter Ulbricht', school: school2 });
+    const vocabulary4 = store.createRecord('vocabulary', { title: 'Antifaschistischer Schutzwall', school: school2 });
+    const program = store.createRecord('program', { school: school1 });
+    const programYear = store.createRecord('programYear', { program });
+    const cohort = store.createRecord('cohort', { programYear });
+    course.get('cohorts').pushObject(cohort);
+    course.set('school', school2);
+
+    const vocabularies = await course.get('assignableVocabularies');
+    assert.equal(vocabularies.length, 4);
+    assert.equal(vocabularies[0], vocabulary4);
+    assert.equal(vocabularies[1], vocabulary3);
+    assert.equal(vocabularies[2], vocabulary2);
+    assert.equal(vocabularies[3], vocabulary1);
+  });
+});
+
+test('sortedObjectives', async function(assert) {
+  assert.expect(4);
+  let course = this.subject();
+  let store = this.store();
+  run( async () => {
+    const objective1 = store.createRecord('objective', { id: 1, position: 3, title: 'Aardvark'});
+    const objective2 = store.createRecord('objective', { id: 2, position: 2, title: 'Bar' });
+    const objective3 = store.createRecord('objective', { id: 3, position: 2, title: 'Foo' });
+    course.get('objectives').pushObjects([ objective1, objective2, objective3 ]);
+
+    const objectives = await course.get('sortedObjectives');
+    assert.equal(objectives.length, 3);
+    assert.equal(objectives[0], objective3);
+    assert.equal(objectives[1], objective2);
+    assert.equal(objectives[2], objective1);
+  });
+});

--- a/tests/unit/models/course-test.js
+++ b/tests/unit/models/course-test.js
@@ -110,6 +110,11 @@ test("domains", async function(assert) {
     const competency1 = store.createRecord('competency', { id: 4, title: 'Zeppelin', parent: domain1 });
     const competency2 = store.createRecord('competency', { id: 5, title: 'Aardvark', parent: domain1 });
     const competency3 = store.createRecord('competency', { id: 6, title: 'Geflarknik', parent: domain2 });
+    // competencies that are linked to these domains, but not to this course.
+    // they should not appear in the output.
+    store.createRecord('competency', { id: 7, parent: domain1 });
+    store.createRecord('competency', { id: 8, parent: domain2 });
+    store.createRecord('competency', { id: 9, parent: domain3 });
 
     let objective1 = store.createRecord('objective', { competency: competency1 });
     let objective2 = store.createRecord('objective', { competency: competency2 });

--- a/tests/unit/models/course-test.js
+++ b/tests/unit/models/course-test.js
@@ -100,13 +100,13 @@ test('check publishedSessionOfferingCounts count', function(assert) {
 });
 
 test("domains", async function(assert) {
-  assert.expect(7);
+  assert.expect(10);
   let course = this.subject();
   let store = this.store();
   await run( async () => {
-    const domain1 = store.createRecord('competency', { id: 1 });
-    const domain2 = store.createRecord('competency', { id: 2 });
-    const domain3 = store.createRecord('competency', { id: 3 });
+    const domain1 = store.createRecord('competency', { id: 1, title: 'Zylinder' });
+    const domain2 = store.createRecord('competency', { id: 2, title: 'Anton' });
+    const domain3 = store.createRecord('competency', { id: 3, title: 'Lexicon' });
     const competency1 = store.createRecord('competency', { id: 4, title: 'Zeppelin', parent: domain1 });
     const competency2 = store.createRecord('competency', { id: 5, title: 'Aardvark', parent: domain1 });
     const competency3 = store.createRecord('competency', { id: 6, title: 'Geflarknik', parent: domain2 });
@@ -121,16 +121,19 @@ test("domains", async function(assert) {
     const domainProxies = await course.get('domains');
     assert.equal(domainProxies.length, 3);
 
-    const domainProxy1 = domainProxies.findBy('content.id', domain1.get('id'));
-    assert.equal(domainProxy1.get('subCompetencies').length, 2);
-    assert.equal(domainProxy1.get('subCompetencies')[0], competency2);
-    assert.equal(domainProxy1.get('subCompetencies')[1], competency1);
+    const domainProxy1 = domainProxies[0];
+    assert.equal(domainProxy1.get('content'), domain2);
+    assert.equal(domainProxy1.get('subCompetencies').length, 1);
+    assert.ok(domainProxy1.get('subCompetencies').includes(competency3));
 
-    const domainProxy2 = domainProxies.findBy('content.id', domain2.get('id'));
-    assert.equal(domainProxy2.get('subCompetencies').length, 1);
-    assert.ok(domainProxy2.get('subCompetencies').includes(competency3));
+    const domainProxy2 = domainProxies[1];
+    assert.equal(domainProxy2.get('content'), domain3);
+    assert.equal(domainProxy2.get('subCompetencies').length, 0);
 
-    const domainProxy3 = domainProxies.findBy('content.id', domain3.get('id'));
-    assert.equal(domainProxy3.get('subCompetencies').length, 0);
+    const domainProxy3 = domainProxies[2];
+    assert.equal(domainProxy3.get('content'), domain1);
+    assert.equal(domainProxy3.get('subCompetencies').length, 2);
+    assert.equal(domainProxy3.get('subCompetencies')[0], competency2);
+    assert.equal(domainProxy3.get('subCompetencies')[1], competency1);
   });
 });

--- a/tests/unit/models/course-test.js
+++ b/tests/unit/models/course-test.js
@@ -173,3 +173,29 @@ test('schools', async function(assert) {
     assert.ok(schools.includes(school3));
   });
 });
+
+test('assignableVocabularies', async function(assert){
+  assert.expect(5);
+  let course = this.subject();
+  let store = this.store();
+  await run( async () => {
+    const school1 = store.createRecord('school', { title: 'Zylinder' });
+    const school2 = store.createRecord('school', { title: 'Anton' });
+    const vocabulary1 = store.createRecord('vocabulary', { title: 'Sowjetunion',  school: school1 });
+    const vocabulary2 = store.createRecord('vocabulary', { title: 'DDR', school: school1 });
+    const vocabulary3 = store.createRecord('vocabulary', { title: 'Walter Ulbricht', school: school2 });
+    const vocabulary4 = store.createRecord('vocabulary', { title: 'Antifaschistischer Schutzwall', school: school2 });
+    const program = store.createRecord('program', { school: school1 });
+    const programYear = store.createRecord('programYear', { program });
+    const cohort = store.createRecord('cohort', { programYear });
+    course.get('cohorts').pushObject(cohort);
+    course.set('school', school2);
+
+    const vocabularies = await course.get('assignableVocabularies');
+    assert.equal(vocabularies.length, 4);
+    assert.equal(vocabularies[0], vocabulary4);
+    assert.equal(vocabularies[1], vocabulary3);
+    assert.equal(vocabularies[2], vocabulary2);
+    assert.equal(vocabularies[3], vocabulary1);
+  });
+});

--- a/tests/unit/models/course-test.js
+++ b/tests/unit/models/course-test.js
@@ -123,8 +123,8 @@ test("domains", async function(assert) {
 
     const domainProxy1 = domainProxies.findBy('content.id', domain1.get('id'));
     assert.equal(domainProxy1.get('subCompetencies').length, 2);
-    assert.ok(domainProxy1.get('subCompetencies').includes(competency1));
-    assert.ok(domainProxy1.get('subCompetencies').includes(competency2));
+    assert.equal(domainProxy1.get('subCompetencies')[0], competency2);
+    assert.equal(domainProxy1.get('subCompetencies')[1], competency1);
 
     const domainProxy2 = domainProxies.findBy('content.id', domain2.get('id'));
     assert.equal(domainProxy2.get('subCompetencies').length, 1);

--- a/tests/unit/models/course-test.js
+++ b/tests/unit/models/course-test.js
@@ -142,3 +142,34 @@ test("domains", async function(assert) {
     assert.equal(domainProxy3.get('subCompetencies')[1], competency1);
   });
 });
+
+
+test('schools', async function(assert) {
+  assert.expect(4);
+  let course = this.subject();
+  let store = this.store();
+  await run( async () => {
+    const school1 = store.createRecord('school');
+    const school2 = store.createRecord('school');
+    const school3 = store.createRecord('school');
+    const program1 = store.createRecord('program', { school: school2 });
+    const program2 = store.createRecord('program', { school: school2 });
+    const program3 = store.createRecord('program', { school: school3 });
+    const programYear1 = store.createRecord('programYear', { program: program1 });
+    const programYear2 = store.createRecord('programYear', { program: program2 });
+    const programYear3 = store.createRecord('programYear', { program: program3 });
+    const cohort1 = store.createRecord('cohort', { programYear: programYear1 });
+    const cohort2 = store.createRecord('cohort', { programYear: programYear2 });
+    const cohort3 = store.createRecord('cohort', { programYear: programYear3 });
+
+    course.get('cohorts').pushObjects([ cohort1, cohort2, cohort3 ]);
+    course.set('school', school1);
+
+    const schools = await course.get('schools');
+
+    assert.equal(schools.length, 3);
+    assert.ok(schools.includes(school1));
+    assert.ok(schools.includes(school2));
+    assert.ok(schools.includes(school3));
+  });
+});


### PR DESCRIPTION
refs #79.

these changes may break tests upstream (e.g. in the frontend repo), but _not_ functionality:

- fixed sort order of sub-competencies returned by `domains` CP
- removed unnecessary dependency key from `sortedObjectives` CP

