### PR TITLE
Convert promise result to array

### DIFF
--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -81,10 +81,10 @@ export default Model.extend({
     let users = await this.get('users');
     let subgroups = await this.get('children');
     let usersInSubgroups = await all(subgroups.mapBy('allDescendantUsers'));
-    let allUsers = (usersInSubgroups.reduce((array, set) => {
-      array.pushObjects(set);
+    let allUsers = usersInSubgroups.reduce((array, subGroupUsers) => {
+      array.pushObjects(subGroupUsers);
       return array;
-    }, []));
+    }, []);
     allUsers.pushObjects(users.toArray());
 
     return allUsers.uniq();
@@ -255,14 +255,13 @@ export default Model.extend({
    * @param {Object} user The user model.
    * @return {Array} The modified learner groups.
    */
-  async removeUserFromGroupAndAllDescendants(user){
+  async removeUserFromGroupAndAllDescendants(user) {
     const modifiedGroups = [];
     const userId = user.get('id');
     if (this.hasMany('users').ids().includes(userId)) {
       this.get('users').removeObject(user);
       modifiedGroups.pushObject(this);
     }
-
     const children = await this.get('children');
     const groups = await map(children.toArray(), async group => {
       return group.removeUserFromGroupAndAllDescendants(user);

--- a/tests/unit/models/learner-group-test.js
+++ b/tests/unit/models/learner-group-test.js
@@ -21,7 +21,7 @@ test('list courses', async function(assert) {
   assert.expect(3);
   const model = this.subject();
   const store = model.store;
-  run( async () => {
+  await run( async () => {
     const course1 = store.createRecord('course', {title:'course1'});
     const course2 = store.createRecord('course', {title:'course2'});
     const session1 = store.createRecord('session', {course: course1});
@@ -46,7 +46,7 @@ test('list courses', async function(assert) {
 test('check allDescendantUsers on empty group', async function(assert) {
   assert.expect(1);
   let learnerGroup = this.subject();
-  run( async () => {
+  await run( async () => {
     let allDescendantUsers = await learnerGroup.get('allDescendantUsers');
     assert.equal(allDescendantUsers.length, 0);
   });
@@ -57,7 +57,7 @@ test('check allDescendantUsers on populated group with sub-groups', async functi
   let learnerGroup = this.subject();
   let store = this.store();
 
-  run( async () => {
+  await run( async () => {
     let user1 = store.createRecord('user');
     let user2 = store.createRecord('user');
     let user3 = store.createRecord('user');
@@ -92,7 +92,7 @@ test('check allDescendants', async function(assert) {
   let learnerGroup = this.subject();
   let store = this.store();
 
-  run( async () => {
+  await run( async () => {
     let subGroup1 = store.createRecord('learner-group', {parent: learnerGroup});
     let subGroup2 = store.createRecord('learner-group', {parent: subGroup1});
     let subGroup3 = store.createRecord('learner-group', {parent: subGroup2});
@@ -111,7 +111,7 @@ test('check subgroupNumberingOffset on group with no sub-groups', async function
   assert.expect(1);
   const groupTitle = 'Lorem Ipsum';
   let learnerGroup = this.subject();
-  run( async () => {
+  await run( async () => {
     learnerGroup.set('title', groupTitle);
     let offset = await learnerGroup.get('subgroupNumberingOffset');
     assert.equal(offset, 1, 'no subgroups. offset is 1.');
@@ -123,7 +123,7 @@ test('check subgroupNumberingOffset on group with sub-groups', async function(as
   const groupTitle = 'Lorem Ipsum';
   let store = this.store();
   let learnerGroup = this.subject();
-  run( async () => {
+  await run( async () => {
     learnerGroup.set('title', groupTitle);
     store.createRecord('learner-group', {parent: learnerGroup, title: groupTitle + ' 1' });
     store.createRecord('learner-group', {parent: learnerGroup, title: groupTitle + ' 3' });
@@ -137,7 +137,7 @@ test('check subgroupNumberingOffset on group with sub-groups and mis-matched sub
   const groupTitle = 'Lorem Ipsum';
   let store = this.store();
   let learnerGroup = this.subject();
-  run( async () => {
+  await run( async () => {
     learnerGroup.set('title', groupTitle);
     store.createRecord('learner-group', {parent: learnerGroup, title: groupTitle + ' 1' });
     store.createRecord('learner-group', {parent: learnerGroup, title: groupTitle + ' 3' });
@@ -173,7 +173,7 @@ test('check allinstructors', async function(assert) {
     assert.ok(allInstructors.includes(user3));
   });
 
-  run( async () => {
+  await run( async () => {
     const user4 = store.createRecord('user');
     const user5 = store.createRecord('user');
     learnerGroup.get('instructors').pushObject(user4);
@@ -191,7 +191,7 @@ test('check allParents', async function(assert) {
   assert.expect(3);
   let store = this.store();
 
-  run(async ()=>{
+  await run(async ()=>{
     let subGroup1 = store.createRecord('learner-group');
     let subGroup2 = store.createRecord('learner-group', {parent: subGroup1});
     let subGroup3 = store.createRecord('learner-group', {parent: subGroup2});
@@ -207,7 +207,7 @@ test('check filterTitle on top group', async function(assert) {
   assert.expect(2);
   let store = this.store();
 
-  run( async () => {
+  await run( async () => {
     let learnerGroup = store.createRecord('learner-group', {title: 'top group'});
     let subGroup1 = store.createRecord('learner-group', {parent: learnerGroup, title: 'subGroup1'});
     let subGroup2 = store.createRecord('learner-group', {parent: subGroup1, title: 'subGroup2'});
@@ -223,7 +223,7 @@ test('check filterTitle on top group', async function(assert) {
 test('check filterTitle on sub group', async function(assert) {
   assert.expect(2);
   const store = this.store();
-  run( async () => {
+  await run( async () => {
     const learnerGroup = store.createRecord('learner-group', {title: 'top group'});
     const subGroup1 = store.createRecord('learner-group', {parent: learnerGroup, title: 'subGroup1'});
     const subGroup2 = store.createRecord('learner-group', {parent: subGroup1, title: 'subGroup2'});
@@ -246,7 +246,7 @@ test('check sortTitle on top group', async function(assert) {
     assert.equal(groups.length, 0);
   });
 
-  run( async () => {
+  await run( async () => {
     store.createRecord('learner-group', {parent: learnerGroup, title: 'subGroup1'});
     const sortTitle = await learnerGroup.get('sortTitle');
     assert.equal(sortTitle, 'topgroup');
@@ -265,7 +265,7 @@ test('check sortTitle on sub group', async function(assert) {
     assert.equal(groups.length, 0);
   });
 
-  run( async () => {
+  await run( async () => {
     const subGroup1 = store.createRecord('learner-group', {id: 2, parent: learnerGroup, title: 'subGroup1'});
     const subGroup2 = store.createRecord('learner-group', {id: 3, parent: subGroup1, title: 'subGroup2'});
     const subGroup3 = store.createRecord('learner-group', {id: 4, parent: subGroup2, title: 'subGroup3'});
@@ -292,13 +292,15 @@ test('check removeUserFromGroupAndAllDescendants', async function(assert) {
     const subGroup3 = store.createRecord('learner-group', {parent: subGroup2, users: [user1]});
     const subGroup4 = store.createRecord('learner-group', {parent: subGroup1});
 
-    const groupsToRemove = await subGroup1.removeUserFromGroupAndAllDescendants(user1);
-    assert.equal(groupsToRemove.length, 3);
-    assert.notOk(groupsToRemove.includes(learnerGroup));
-    assert.ok(groupsToRemove.includes(subGroup1));
-    assert.ok(groupsToRemove.includes(subGroup2));
-    assert.ok(groupsToRemove.includes(subGroup3));
-    assert.notOk(groupsToRemove.includes(subGroup4));
+    await run(async () => {
+      const groupsToRemove = await subGroup1.removeUserFromGroupAndAllDescendants(user1);
+      assert.equal(groupsToRemove.length, 3);
+      assert.notOk(groupsToRemove.includes(learnerGroup));
+      assert.ok(groupsToRemove.includes(subGroup1));
+      assert.ok(groupsToRemove.includes(subGroup2));
+      assert.ok(groupsToRemove.includes(subGroup3));
+      assert.notOk(groupsToRemove.includes(subGroup4));
+    });
   });
 });
 
@@ -312,7 +314,7 @@ test('check addUserToGroupAndAllParents', async function(assert) {
     assert.equal(groups.length, 0);
   });
 
-  run( async () => {
+  await run( async () => {
     const user1 = store.createRecord('user', {id: 1});
     const subGroup1 = store.createRecord('learner-group', {id: 1, parent: learnerGroup, users: [user1]});
     const subGroup2 = store.createRecord('learner-group', {id: 2, parent: subGroup1});
@@ -332,7 +334,7 @@ test('check addUserToGroupAndAllParents', async function(assert) {
 test('has no learners in group without learners and without subgroups', async function(assert) {
   assert.expect(1);
   const learnerGroup = this.subject();
-  run( async () => {
+  await run( async () => {
     const hasLearners = await learnerGroup.get('hasLearnersInGroupOrSubgroups');
     assert.notOk(hasLearners);
   });
@@ -342,7 +344,7 @@ test('has learners in group with learners and but without learners in subgroups'
   assert.expect(1);
   const learnerGroup = this.subject();
   const store = this.store();
-  run( async () => {
+  await run( async () => {
     let learner = store.createRecord('user');
     learnerGroup.get('users').pushObject(learner);
     const hasLearners = await learnerGroup.get('hasLearnersInGroupOrSubgroups');
@@ -355,7 +357,7 @@ test('has no learners with no learners in group nor in subgroups', async functio
   assert.expect(1);
   const learnerGroup = this.subject();
   const store = this.store();
-  run( async () => {
+  await run( async () => {
     const subgroup = store.createRecord('learner-group', { id: 2, parent: learnerGroup });
     learnerGroup.get('children').pushObject(subgroup);
     const hasLearners = await learnerGroup.get('hasLearnersInGroupOrSubgroups');
@@ -364,11 +366,11 @@ test('has no learners with no learners in group nor in subgroups', async functio
 });
 
 
-test('has learners with no learners in group but with learners in subgroups', function(assert) {
+test('has learners with no learners in group but with learners in subgroups', async function(assert) {
   assert.expect(1);
   let learnerGroup = this.subject();
   let store = this.store();
-  run(() => {
+  await run(() => {
     let learner = store.createRecord('user', { id: 1 });
     let subgroup = store.createRecord('learner-group', { id: 2, users: [ learner ], parent: learnerGroup });
     learnerGroup.get('children').then(subgroups => {
@@ -380,11 +382,11 @@ test('has learners with no learners in group but with learners in subgroups', fu
   });
 });
 
-test('has learners with learners in group and with learners in subgroups', function(assert) {
+test('has learners with learners in group and with learners in subgroups', async function(assert) {
   assert.expect(1);
   let learnerGroup = this.subject();
   let store = this.store();
-  run(() => {
+  await run(() => {
     let learner = store.createRecord('user', { id: 1 });
     let learner2 = store.createRecord('user', { id: 2 });
     let subgroup = store.createRecord('learner-group', { id: 2, users: [ learner ], parent: learnerGroup });
@@ -404,7 +406,7 @@ test('users only at this level', async function(assert) {
   assert.expect(2);
   const learnerGroup = this.subject();
   const store = this.store();
-  run( async () => {
+  await run( async () => {
     const user1 = store.createRecord('user', {id: 1});
     const user2 = store.createRecord('user', {id: 2});
     const user3 = store.createRecord('user', {id: 3});
@@ -431,7 +433,7 @@ test('allParentTitles', async function(assert) {
     const titles = await learnerGroup.get('allParentTitles');
     assert.equal(titles.length, 0);
   });
-  run( async () => {
+  await run( async () => {
     const subGroup = store.createRecord('learner-group', { id: 2, title: 'Bar', parent: learnerGroup });
     const subSubGroup = store.createRecord('learner-group', {id: 3, title: 'Baz', parent: subGroup });
     const titles = await subSubGroup.get('allParentTitles');
@@ -451,7 +453,7 @@ test('allParentsTitle', async function(assert) {
     const titles = await learnerGroup.get('allParentsTitle');
     assert.equal(titles, '');
   });
-  run( async () => {
+  await run( async () => {
     const subGroup = store.createRecord('learner-group', { id: 2, title: 'Bar', parent: learnerGroup });
     const subSubGroup = store.createRecord('learner-group', {id: 3, title: 'Baz', parent: subGroup });
     const titles = await subSubGroup.get('allParentsTitle');
@@ -469,7 +471,7 @@ test('sortTitle', async function(assert) {
     const title = await learnerGroup.get('sortTitle');
     assert.equal(title, 'Foo');
   });
-  run( async () => {
+  await run( async () => {
     const subGroup = store.createRecord('learner-group', { id: 2, title: 'Bar', parent: learnerGroup });
     const subSubGroup = store.createRecord('learner-group', {id: 3, title: 'Baz', parent: subGroup });
     const title = await subSubGroup.get('sortTitle');
@@ -485,7 +487,7 @@ test('topLevelGroup', async function(assert) {
     const topLevelGroup = await learnerGroup.get('topLevelGroup');
     assert.equal(topLevelGroup, learnerGroup);
   });
-  run( async () => {
+  await run( async () => {
     const subGroup = store.createRecord('learner-group', { parent: learnerGroup });
     const subSubGroup = store.createRecord('learner-group', { parent: subGroup });
     const topLevelGroup = await subSubGroup.get('topLevelGroup');
@@ -502,7 +504,7 @@ test('isTopLevelGroup', async function(assert) {
     const isTopLevelGroup = await learnerGroup.get('isTopLevelGroup');
     assert.ok(isTopLevelGroup);
   });
-  run( async () => {
+  await run( async () => {
     const subGroup = store.createRecord('learner-group', { parent: learnerGroup });
     const isTopLevelGroup = await subGroup.get('isTopLevelGroup');
     assert.notOk(isTopLevelGroup);
@@ -513,7 +515,7 @@ test('school', async function(assert) {
   assert.expect(1);
   const learnerGroup = this.subject();
   const store = this.store();
-  run( async () => {
+  await run( async () => {
     const school = store.createRecord('school');
     const program = store.createRecord('program', { school });
     const programYear = store.createRecord('program-year', { program });


### PR DESCRIPTION
Tacking .toArray() onto a promise in an await call doesn't call
`toArray` on the result of the promise. It calls it on the promise
itself and doesn't work.