### PR TITLE
Unblock ember-concurrency update

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "ember-cli-htmlbars": "^2.0.3",
     "ember-cli-moment-shim": "^3.1.0",
     "ember-composable-helpers": "^2.0.1",
-    "ember-concurrency": "0.7.19",
+    "ember-concurrency": "0.8.12",
     "ember-i18n": "^5.0.1",
     "ember-moment": "^7.4.1",
     "ember-one-way-controls": "^3.0.0",
@@ -66,10 +66,5 @@
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"
-  },
-  "greenkeeper": {
-    "ignore": [
-      "ember-concurrency"
-    ]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -375,7 +375,7 @@ babel-core@^5.0.0:
     trim-right "^1.0.0"
     try-resolve "^1.0.0"
 
-babel-core@^6.14.0, babel-core@^6.26.0:
+babel-core@^6.14.0, babel-core@^6.24.1, babel-core@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.0.tgz#af32f78b31a6fcef119c87b0fd8d9753f03a0bb8"
   dependencies:
@@ -2560,13 +2560,14 @@ ember-composable-helpers@^2.0.1:
     broccoli-funnel "^1.0.1"
     ember-cli-babel "^6.1.0"
 
-ember-concurrency@0.7.19:
-  version "0.7.19"
-  resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-0.7.19.tgz#095f2ede1b56ab068958cac5b55e77b9de67e1c6"
+ember-concurrency@0.8.12:
+  version "0.8.12"
+  resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-0.8.12.tgz#fb91180e5efeb1024cfa2cfb99d2fe6721930c91"
   dependencies:
-    ember-cli-babel "^5.1.5"
-    ember-getowner-polyfill "^1.1.0"
-    ember-maybe-import-regenerator "^0.1.4"
+    babel-core "^6.24.1"
+    ember-cli-babel "^6.8.2"
+    ember-getowner-polyfill "^2.0.0"
+    ember-maybe-import-regenerator "^0.1.5"
 
 ember-cookies@^0.0.13:
   version "0.0.13"
@@ -2650,7 +2651,7 @@ ember-getowner-polyfill@^1.1.0, ember-getowner-polyfill@^1.2.2:
     ember-cli-version-checker "^1.2.0"
     ember-factory-for-polyfill "^1.1.0"
 
-ember-getowner-polyfill@^2.0.1:
+ember-getowner-polyfill@^2.0.0, ember-getowner-polyfill@^2.0.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz#38e7dccbcac69d5ec694000329ec0b2be651d2b2"
   dependencies:
@@ -2707,7 +2708,7 @@ ember-macro-helpers@^0.17.0:
     ember-cli-test-info "^1.0.0"
     ember-weakmap "^3.0.0"
 
-ember-maybe-import-regenerator@^0.1.4:
+ember-maybe-import-regenerator@^0.1.5:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/ember-maybe-import-regenerator/-/ember-maybe-import-regenerator-0.1.6.tgz#35d41828afa6d6a59bc0da3ce47f34c573d776ca"
   dependencies:


### PR DESCRIPTION
Frontend has been updated to handle this update so now we can unblock ember-concurrency and use the latest version.

WIP, needs:
https://github.com/ilios/frontend/pull/3437