### PR TITLE
Converted Session model to async/await syntax

### DIFF
--- a/addon/models/session.js
+++ b/addon/models/session.js
@@ -229,12 +229,9 @@ export default Model.extend(PublishableModel, CategorizableModel, SortableByPosi
    * @property sortedObjectives
    * @type {Ember.computed}
    */
-  sortedObjectives: computed('objectives.@each.position', 'objectives.@each.title', function() {
-    return new Promise(resolve => {
-      this.get('objectives').then(objectives => {
-        resolve(objectives.toArray().sort(this.positionSortingCallback));
-      });
-    });
+  sortedObjectives: computed('objectives.@each.position', 'objectives.@each.title', async function() {
+    const objectives = await this.get('objectives');
+    return objectives.toArray().sort(this.positionSortingCallback);
   })
 
 });

--- a/addon/models/session.js
+++ b/addon/models/session.js
@@ -114,11 +114,9 @@ export default Model.extend(PublishableModel, CategorizableModel, SortableByPosi
       return 0;
     }
 
-    const total = offerings.reduce((sum, offering) => {
-      return sum + moment(offering.get('endDate')).diff(moment(offering.get('startDate')), 'hours', true);
-    }, 0);
-
-    return total.toFixed(2);
+    return offerings.reduce((total, offering) => {
+      return total + moment(offering.get('endDate')).diff(moment(offering.get('startDate')), 'hours', true);
+    }, 0).toFixed(2);
   }),
 
   optionalPublicationLengthFields: ['terms', 'objectives', 'meshDescriptors'],

--- a/addon/models/session.js
+++ b/addon/models/session.js
@@ -9,7 +9,7 @@ import SortableByPosition from 'ilios-common/mixins/sortable-by-position';
 const { computed, isEmpty, isPresent, RSVP } = Ember;
 const { alias, mapBy, sum } = computed;
 const { attr, belongsTo, hasMany, Model } = DS;
-const { all, Promise } = RSVP;
+const { all } = RSVP;
 
 export default Model.extend(PublishableModel, CategorizableModel, SortableByPosition, {
   title: attr('string'),
@@ -39,24 +39,20 @@ export default Model.extend(PublishableModel, CategorizableModel, SortableByPosi
   }),
 
   /**
-   * All offerings for this session, sorted by offering startdate in ascending order.
+   * All offerings for this session, sorted by offering start date in ascending order.
    * @property sortedOfferingsByDate
    * @type {Ember.computed}
    */
-  sortedOfferingsByDate: computed('offerings.@each.startDate', function() {
-    return new Promise(resolve => {
-      this.get('offerings').then(offerings => {
-        let filteredOfferings = offerings.filter(offering => isPresent(offering.get('startDate')));
-        let sortedOfferings = filteredOfferings.sort((a, b) => {
-          let aDate = moment(a.get('startDate'));
-          let bDate = moment(b.get('startDate'));
-          if(aDate === bDate){
-            return 0;
-          }
-          return aDate > bDate ? 1 : -1;
-        });
-        resolve(sortedOfferings);
-      });
+  sortedOfferingsByDate: computed('offerings.@each.startDate', async function() {
+    const offerings = await this.get('offerings');
+    const filteredOfferings = offerings.filter(offering => isPresent(offering.get('startDate')));
+    return filteredOfferings.sort((a, b) => {
+      let aDate = moment(a.get('startDate'));
+      let bDate = moment(b.get('startDate'));
+      if(aDate === bDate){
+        return 0;
+      }
+      return aDate > bDate ? 1 : -1;
     });
   }),
 

--- a/addon/models/session.js
+++ b/addon/models/session.js
@@ -225,11 +225,11 @@ export default Model.extend(PublishableModel, CategorizableModel, SortableByPosi
   assignableVocabularies: alias('course.assignableVocabularies'),
 
   /**
-   * A list of session objectives, sorted by position and title.
+   * A list of session objectives, sorted by position (asc) and then id (desc).
    * @property sortedObjectives
    * @type {Ember.computed}
    */
-  sortedObjectives: computed('objectives.@each.position', 'objectives.@each.title', async function() {
+  sortedObjectives: computed('objectives.@each.position', async function() {
     const objectives = await this.get('objectives');
     return objectives.toArray().sort(this.positionSortingCallback);
   })

--- a/addon/models/session.js
+++ b/addon/models/session.js
@@ -66,22 +66,18 @@ export default Model.extend(PublishableModel, CategorizableModel, SortableByPosi
    * @property firstOfferingDate
    * @type {Ember.computed}
    */
-  firstOfferingDate: computed('sortedOfferingsByDate.@each.startDate', 'ilmSession.dueDate', function(){
-    return new Promise(resolve => {
-      this.get('ilmSession').then(ilmSession => {
-        if(ilmSession){
-          resolve(ilmSession.get('dueDate'));
-        } else {
-          this.get('sortedOfferingsByDate').then(offerings => {
-            if(isEmpty(offerings)){
-              resolve(null);
-            } else {
-              resolve(offerings.get('firstObject.startDate'));
-            }
-          });
-        }
-      });
-    });
+  firstOfferingDate: computed('sortedOfferingsByDate.@each.startDate', 'ilmSession.dueDate', async function(){
+    const ilmSession = await this.get('ilmSession');
+    if(ilmSession){
+      return ilmSession.get('dueDate');
+    }
+
+    const offerings = await this.get('sortedOfferingsByDate');
+    if(isEmpty(offerings)){
+      return null;
+    }
+
+    return offerings.get('firstObject.startDate');
   }),
 
   /**

--- a/addon/models/session.js
+++ b/addon/models/session.js
@@ -89,28 +89,26 @@ export default Model.extend(PublishableModel, CategorizableModel, SortableByPosi
    * @property sortedTerms
    * @type {Ember.computed}
    */
-  maxSingleOfferingDuration: computed('offerings.@each.startDate', 'offerings.@each.endDate', function(){
-    return new Promise(resolve => {
-      this.get('offerings').then(offerings => {
-        if (! offerings.length) {
-          resolve(0);
-        } else {
-          const sortedOfferings = offerings.toArray().sort(function (a, b) {
-            const diffA = moment(a.get('endDate')).diff(moment(a.get('startDate')), 'minutes');
-            const diffB = moment(b.get('endDate')).diff(moment(b.get('startDate')), 'minutes');
-            if (diffA > diffB) {
-              return -1;
-            } else if (diffA < diffB) {
-              return 1;
-            }
-            return 0;
-          });
-          const offering = sortedOfferings[0];
-          const duration = moment(offering.get('endDate')).diff(moment(offering.get('startDate')), 'hours', true);
-          resolve(duration.toFixed(2));
-        }
-      });
+  maxSingleOfferingDuration: computed('offerings.@each.startDate', 'offerings.@each.endDate', async function(){
+    const offerings = await this.get('offerings');
+    if (isEmpty(offerings)) {
+      return 0;
+    }
+    const sortedOfferings = offerings.toArray().sort(function (a, b) {
+      const diffA = moment(a.get('endDate')).diff(moment(a.get('startDate')), 'minutes');
+      const diffB = moment(b.get('endDate')).diff(moment(b.get('startDate')), 'minutes');
+      if (diffA > diffB) {
+        return -1;
+      } else if (diffA < diffB) {
+        return 1;
+      }
+      return 0;
     });
+
+    const offering = sortedOfferings[0];
+    const duration = moment(offering.get('endDate')).diff(moment(offering.get('startDate')), 'hours', true);
+
+    return duration.toFixed(2);
   }),
 
   /**

--- a/addon/models/session.js
+++ b/addon/models/session.js
@@ -208,18 +208,11 @@ export default Model.extend(PublishableModel, CategorizableModel, SortableByPosi
    * @property associatedLearnerGroups
    * @type {Ember.computed}
    */
-  associatedLearnerGroups: computed('associatedIlmLearnerGroups.[]', 'associatedOfferingLearnerGroups.[]', function(){
-    return new Promise(resolve => {
-      this.get('associatedIlmLearnerGroups').then(ilmLearnerGroups => {
-        this.get('associatedOfferingLearnerGroups').then(offeringLearnerGroups => {
-          let allGroups = [].pushObjects(offeringLearnerGroups).pushObjects(ilmLearnerGroups);
-          if (! isEmpty(allGroups)) {
-            allGroups = allGroups.uniq().sortBy('title');
-          }
-          resolve(allGroups);
-        });
-      });
-    });
+  associatedLearnerGroups: computed('associatedIlmLearnerGroups.[]', 'associatedOfferingLearnerGroups.[]', async function(){
+    const ilmLearnerGroups = await this.get('associatedIlmLearnerGroups');
+    const offeringLearnerGroups = await this.get('associatedOfferingLearnerGroups');
+    const allGroups = [].pushObjects(offeringLearnerGroups).pushObjects(ilmLearnerGroups);
+    return allGroups.uniq().sortBy('title');
   }),
 
   assignableVocabularies: alias('course.assignableVocabularies'),

--- a/addon/models/session.js
+++ b/addon/models/session.js
@@ -114,8 +114,8 @@ export default Model.extend(PublishableModel, CategorizableModel, SortableByPosi
       return 0;
     }
 
-    const total = offerings.reduce((total, offering) => {
-      return total + moment(offering.get('endDate')).diff(moment(offering.get('startDate')), 'hours', true);
+    const total = offerings.reduce((sum, offering) => {
+      return sum + moment(offering.get('endDate')).diff(moment(offering.get('startDate')), 'hours', true);
     }, 0);
 
     return total.toFixed(2);

--- a/addon/models/session.js
+++ b/addon/models/session.js
@@ -99,9 +99,9 @@ export default Model.extend(PublishableModel, CategorizableModel, SortableByPosi
             const diffA = moment(a.get('endDate')).diff(moment(a.get('startDate')), 'minutes');
             const diffB = moment(b.get('endDate')).diff(moment(b.get('startDate')), 'minutes');
             if (diffA > diffB) {
-              return 1;
-            } else if (diffA < diffB) {
               return -1;
+            } else if (diffA < diffB) {
+              return 1;
             }
             return 0;
           });

--- a/addon/models/session.js
+++ b/addon/models/session.js
@@ -118,21 +118,19 @@ export default Model.extend(PublishableModel, CategorizableModel, SortableByPosi
    * @property sortedTerms
    * @type {Ember.computed}
    */
-  totalSumOfferingsDuration: computed('offerings.@each.startDate', 'offerings.@each.endDate', function() {
-    return new Promise(resolve => {
-      this.get('offerings').then(offerings => {
-        if (!offerings.length) {
-          resolve(0);
-        } else {
-          let total = 0;
-          offerings.forEach(offering => {
-            total = total + moment(offering.get('endDate')).diff(moment(offering.get('startDate')), 'hours', true);
-          });
-          resolve(total.toFixed(2));
-        }
-      });
-    });
+  totalSumOfferingsDuration: computed('offerings.@each.startDate', 'offerings.@each.endDate', async function() {
+    const offerings = await this.get('offerings');
+    if (isEmpty(offerings)) {
+      return 0;
+    }
+
+    const total = offerings.reduce((total, offering) => {
+      return total + moment(offering.get('endDate')).diff(moment(offering.get('startDate')), 'hours', true);
+    }, 0);
+
+    return total.toFixed(2);
   }),
+
   optionalPublicationLengthFields: ['terms', 'objectives', 'meshDescriptors'],
   requiredPublicationIssues: computed(
     'title',

--- a/addon/models/session.js
+++ b/addon/models/session.js
@@ -165,21 +165,13 @@ export default Model.extend(PublishableModel, CategorizableModel, SortableByPosi
    * @property associatedOfferingLearnerGroups
    * @type {Ember.computed}
    */
-  associatedOfferingLearnerGroups: computed('offerings.@each.learnerGroups', function(){
-    return new Promise(resolve => {
-      this.get('offerings').then(offerings => {
-        all(offerings.mapBy('learnerGroups')).then(offeringLearnerGroups => {
-          let allGroups = [];
-          offeringLearnerGroups.forEach(learnerGroups => {
-            learnerGroups.forEach(group => {
-              allGroups.pushObject(group);
-            });
-          });
-          let groups = allGroups ? allGroups.uniq().sortBy('title') : [];
-          resolve(groups);
-        });
-      });
-    });
+  associatedOfferingLearnerGroups: computed('offerings.@each.learnerGroups', async function(){
+    const offerings = await this.get('offerings');
+    const offeringLearnerGroups = await all(offerings.mapBy('learnerGroups'));
+    return offeringLearnerGroups.reduce((array, set) => {
+      array.pushObjects(set.toArray());
+      return array;
+    }, []).uniq().sortBy('title');
   }),
 
   /**

--- a/addon/models/session.js
+++ b/addon/models/session.js
@@ -187,20 +187,14 @@ export default Model.extend(PublishableModel, CategorizableModel, SortableByPosi
    * @property associatedIlmLearnerGroups
    * @type {Ember.computed}
    */
-  associatedIlmLearnerGroups: computed('ilmSession.learnerGroups', function(){
-    return new Promise(resolve => {
-      this.get('ilmSession').then(ilmSession => {
-        if (! isPresent(ilmSession)) {
-          resolve([]);
-          return;
-        }
+  associatedIlmLearnerGroups: computed('ilmSession.learnerGroups', async function(){
+    const ilmSession = await this.get('ilmSession');
+    if (! isPresent(ilmSession)) {
+      return [];
+    }
 
-        ilmSession.get('learnerGroups').then(learnerGroups => {
-          let sortedGroups = learnerGroups.sortBy('title');
-          resolve(sortedGroups);
-        });
-      });
-    });
+    const learnerGroups = await ilmSession.get('learnerGroups');
+    return learnerGroups.sortBy('title');
   }),
 
   /**

--- a/tests/unit/models/session-test.js
+++ b/tests/unit/models/session-test.js
@@ -302,6 +302,7 @@ test('totalSumOfferingsDuration', async function(assert){
 });
 
 test('maxSingleOfferingDuration', async function(assert){
+  assert.expect(2);
   const subject = this.subject();
   const store = this.store();
   await run( async () => {
@@ -320,8 +321,8 @@ test('maxSingleOfferingDuration', async function(assert){
 
 
 test('firstOfferingDate - no offerings, and no ILM', async function(assert) {
+  assert.expect(1);
   const subject = this.subject();
-  const store = this.store();
   await run(async () => {
     const firstDate = await subject.get('firstOfferingDate');
     assert.equal(firstDate, null);
@@ -329,6 +330,7 @@ test('firstOfferingDate - no offerings, and no ILM', async function(assert) {
 });
 
 test('firstOfferingDate - ILM', async function(assert) {
+  assert.expect(1);
   const subject = this.subject();
   const store = this.store();
   await run(async () => {
@@ -340,6 +342,7 @@ test('firstOfferingDate - ILM', async function(assert) {
 });
 
 test('firstOfferingDate - offerings', async function(assert) {
+  assert.expect(1);
   const subject = this.subject();
   const store = this.store();
   await run(async () => {
@@ -348,5 +351,23 @@ test('firstOfferingDate - offerings', async function(assert) {
     subject.get('offerings').pushObjects([ offering1, offering2 ]);
     const firstDate = await subject.get('firstOfferingDate');
     assert.equal(offering2.get('startDate'), firstDate);
+  });
+});
+
+test('sortedOfferingsByDate', async function(assert) {
+  assert.expect(4);
+  const subject = this.subject();
+  const store = this.store();
+  await run(async () => {
+    const offering1 = store.createRecord('offering', { startDate: moment('2017-01-01') });
+    const offering2 = store.createRecord('offering', { startDate: moment('2016-01-01') });
+    const offering3 = store.createRecord('offering', { startDate: moment('2015-01-01') });
+    const offeringWithNoStartDate = store.createRecord('offering');
+    subject.get('offerings').pushObjects([ offering1, offering2, offering3, offeringWithNoStartDate ]);
+    const sortedDates = await subject.get('sortedOfferingsByDate');
+    assert.equal(sortedDates.length, 3);
+    assert.equal(sortedDates[0], offering3);
+    assert.equal(sortedDates[1], offering2);
+    assert.equal(sortedDates[2], offering1);
   });
 });

--- a/tests/unit/models/session-test.js
+++ b/tests/unit/models/session-test.js
@@ -1,7 +1,4 @@
-import {
-  moduleForModel,
-  test
-} from 'ember-qunit';
+import { moduleForModel, test } from 'ember-qunit';
 import Ember from 'ember';
 import modelList from '../../helpers/model-list';
 import { initialize } from '../../../initializers/replace-promise';
@@ -11,12 +8,6 @@ const { run } = Ember;
 initialize();
 moduleForModel('session', 'Unit | Model | Session', {
   needs: modelList
-});
-
-test('it exists', function(assert) {
-  let model = this.subject();
-  // let store = this.store();
-  assert.ok(!!model);
 });
 
 test('check required publication items', function(assert) {
@@ -66,7 +57,7 @@ test('check first level associatedOfferingLearnerGroups', async function(assert)
   let session = this.subject();
   let store = this.store();
 
-  run( async ()=>{
+  await run( async ()=>{
     let learnerGroup1 = store.createRecord('learner-group');
     let learnerGroup2 = store.createRecord('learner-group');
     let learnerGroup3 = store.createRecord('learner-group');
@@ -90,7 +81,7 @@ test('check multi level associatedOfferingLearnerGroups', async function(assert)
   let session = this.subject();
   let store = this.store();
 
-  run( async () => {
+  await run( async () => {
     let learnerGroup1 = store.createRecord('learner-group');
     let learnerGroup2 = store.createRecord('learner-group');
     let learnerGroup3 = store.createRecord('learner-group');
@@ -116,7 +107,7 @@ test('check empty associatedIlmLearnerGroups', async function(assert) {
   assert.expect(1);
   let session = this.subject();
 
-  run( async () => {
+  await run( async () => {
     let groups = await session.get('associatedIlmLearnerGroups');
     assert.equal(groups.length, 0);
   });
@@ -127,7 +118,7 @@ test('check associatedIlmLearnerGroups', async function(assert) {
   let session = this.subject();
   let store = this.store();
 
-  run( async () => {
+  await run( async () => {
     let learnerGroup1 = store.createRecord('learner-group');
     let learnerGroup2 = store.createRecord('learner-group');
     let learnerGroup3 = store.createRecord('learner-group');
@@ -155,7 +146,7 @@ test('check associatedLearnerGroups', async function(assert) {
   let session = this.subject();
   let store = this.store();
 
-  run( async () => {
+  await run( async () => {
     let learnerGroup1 = store.createRecord('learner-group');
     let learnerGroup2 = store.createRecord('learner-group');
     let learnerGroup3 = store.createRecord('learner-group');
@@ -222,7 +213,7 @@ test('associatedVocabularies', async function(assert) {
   assert.expect(3);
   const subject = this.subject();
   const store = this.store();
-  run( async () => {
+  await run( async () => {
     const vocab1 = store.createRecord('vocabulary', { title: 'Zeppelin' });
     const vocab2 = store.createRecord('vocabulary', { title: 'Aardvark' });
     const term1 = store.createRecord('term', { vocabulary: vocab1 });
@@ -240,7 +231,7 @@ test('termsWithAllParents', async function(assert) {
   assert.expect(7);
   const subject = this.subject();
   const store = this.store();
-  run( async () => {
+  await run( async () => {
     const term1 = store.createRecord('term');
     const term2 = store.createRecord('term', { parent: term1 });
     const term3 = store.createRecord('term', { parent: term1 });

--- a/tests/unit/models/session-test.js
+++ b/tests/unit/models/session-test.js
@@ -2,6 +2,7 @@ import { moduleForModel, test } from 'ember-qunit';
 import Ember from 'ember';
 import modelList from '../../helpers/model-list';
 import { initialize } from '../../../initializers/replace-promise';
+import moment from 'moment';
 
 const { run } = Ember;
 
@@ -279,5 +280,23 @@ test('sortedObjectives', async function(assert){
     assert.equal(sortedObjectives[1], objective3);
     assert.equal(sortedObjectives[2], objective2);
     assert.equal(sortedObjectives[3], objective1);
+  });
+});
+
+test('totalSumOfferingsDuration', async function(assert){
+  assert.expect(2);
+  const subject = this.subject();
+  const store = this.store();
+  await run( async () => {
+    const total = await subject.get('totalSumOfferingsDuration');
+    assert.equal(total, 0);
+  });
+
+  await run( async () => {
+    const offering1 = store.createRecord('offering', {startDate: moment('2017-01-01') , endDate: moment('2017-01-02') });
+    const offering2 = store.createRecord('offering', {startDate: moment('2017-01-01 09:30:00'), endDate: moment('2017-01-01 10:00:00') });
+    subject.get('offerings').pushObjects([ offering1, offering2 ]);
+    const total = await subject.get('totalSumOfferingsDuration');
+    assert.equal(total, 24.50);
   });
 });

--- a/tests/unit/models/session-test.js
+++ b/tests/unit/models/session-test.js
@@ -293,10 +293,27 @@ test('totalSumOfferingsDuration', async function(assert){
   });
 
   await run( async () => {
-    const offering1 = store.createRecord('offering', {startDate: moment('2017-01-01') , endDate: moment('2017-01-02') });
-    const offering2 = store.createRecord('offering', {startDate: moment('2017-01-01 09:30:00'), endDate: moment('2017-01-01 10:00:00') });
-    subject.get('offerings').pushObjects([ offering1, offering2 ]);
+    const allDayOffering = store.createRecord('offering', {startDate: moment('2017-01-01') , endDate: moment('2017-01-02') });
+    const halfAnHourOffering = store.createRecord('offering', {startDate: moment('2017-01-01 09:30:00'), endDate: moment('2017-01-01 10:00:00') });
+    subject.get('offerings').pushObjects([ allDayOffering, halfAnHourOffering ]);
     const total = await subject.get('totalSumOfferingsDuration');
     assert.equal(total, 24.50);
+  });
+});
+
+test('maxSingleOfferingDuration', async function(assert){
+  const subject = this.subject();
+  const store = this.store();
+  await run( async () => {
+    const max = await subject.get('maxSingleOfferingDuration');
+    assert.equal(max, 0);
+  });
+
+  await run( async () => {
+    const allDayOffering = store.createRecord('offering', {startDate: moment('2017-01-01') , endDate: moment('2017-01-02') });
+    const halfAnHourOffering = store.createRecord('offering', {startDate: moment('2017-01-01 09:30:00'), endDate: moment('2017-01-01 10:00:00') });
+    subject.get('offerings').pushObjects([ allDayOffering, halfAnHourOffering ]);
+    const max = await subject.get('maxSingleOfferingDuration');
+    assert.equal(max, 24.00);
   });
 });

--- a/tests/unit/models/session-test.js
+++ b/tests/unit/models/session-test.js
@@ -262,3 +262,22 @@ test('termCount', function(assert) {
     assert.equal(subject.get('termCount'), 2);
   });
 });
+
+test('sortedObjectives', async function(assert){
+  assert.expect(5);
+  const subject = this.subject();
+  const store = this.store();
+  await run( async () => {
+    const objective1 = store.createRecord('objective', { id: 1, position: 10});
+    const objective2 = store.createRecord('objective', { id: 2, position: 5 });
+    const objective3 = store.createRecord('objective', { id: 3, position: 5 });
+    const objective4 = store.createRecord('objective', { id: 4, position: 0 });
+    subject.get('objectives').pushObjects([ objective1, objective2, objective3, objective4 ]);
+    const sortedObjectives = await subject.get('sortedObjectives');
+    assert.equal(sortedObjectives.length, 4);
+    assert.equal(sortedObjectives[0], objective4);
+    assert.equal(sortedObjectives[1], objective3);
+    assert.equal(sortedObjectives[2], objective2);
+    assert.equal(sortedObjectives[3], objective1);
+  });
+});

--- a/tests/unit/models/session-test.js
+++ b/tests/unit/models/session-test.js
@@ -317,3 +317,36 @@ test('maxSingleOfferingDuration', async function(assert){
     assert.equal(max, 24.00);
   });
 });
+
+
+test('firstOfferingDate - no offerings, and no ILM', async function(assert) {
+  const subject = this.subject();
+  const store = this.store();
+  await run(async () => {
+    const firstDate = await subject.get('firstOfferingDate');
+    assert.equal(firstDate, null);
+  });
+});
+
+test('firstOfferingDate - ILM', async function(assert) {
+  const subject = this.subject();
+  const store = this.store();
+  await run(async () => {
+    const ilm = store.createRecord('ilmSession', { dueDate: moment('2015-01-01') });
+    subject.set('ilmSession', ilm);
+    const firstDate = await subject.get('firstOfferingDate');
+    assert.equal(firstDate, ilm.get('dueDate'));
+  });
+});
+
+test('firstOfferingDate - offerings', async function(assert) {
+  const subject = this.subject();
+  const store = this.store();
+  await run(async () => {
+    const offering1 = store.createRecord('offering', { startDate: moment('2017-01-01') });
+    const offering2 = store.createRecord('offering', { startDate: moment('2016-01-01') });
+    subject.get('offerings').pushObjects([ offering1, offering2 ]);
+    const firstDate = await subject.get('firstOfferingDate');
+    assert.equal(offering2.get('startDate'), firstDate);
+  });
+});


### PR DESCRIPTION
refs #79.

this also contains a bugfix to the `tmaxSingleOfferingDuration` CP, which is used in the frontend in various places (I can file individual tickets there for reference if need be).