### PR TITLE
Import pluralize from ember-inflector directly

### DIFF
--- a/addon/adapters/ilios.js
+++ b/addon/adapters/ilios.js
@@ -1,12 +1,12 @@
 import Ember from 'ember';
 import DS from 'ember-data';
 import DataAdapterMixin from 'ember-simple-auth/mixins/data-adapter-mixin';
+import { pluralize } from 'ember-inflector';
 
-const { inject, computed, String:EmberString } = Ember;
+const { inject, computed } = Ember;
 const { service } = inject;
 const { reads } = computed;
 const { RESTAdapter } = DS;
-const { pluralize } = EmberString;
 
 export default RESTAdapter.extend(DataAdapterMixin, {
   iliosConfig: service(),


### PR DESCRIPTION
Pulling this from Ember.String is deprecated.