### PR TITLE
If no apiHost is configured use the current URL

### DIFF
--- a/addon/components/dashboard-calendar.js
+++ b/addon/components/dashboard-calendar.js
@@ -474,7 +474,9 @@ export default Component.extend({
     const model = await currentUser.get('model');
     const icsFeedKey = model.get('icsFeedKey');
     const apiHost = iliosConfig.get('apiHost');
-    return apiHost + '/ics/' + icsFeedKey;
+    const loc = window.location.protocol + '//' + window.location.hostname;
+    const server = apiHost ? apiHost : loc;
+    return server + '/ics/' + icsFeedKey;
   }),
 
   actions: {


### PR DESCRIPTION
When we're serving the frontend from an API server we don't actually
send and apiHost because it is just /. We need to handle this as a case
here otherwise the ICS feed URL won't be an absolute path.

Fixes ilios/frontend#3485