### PR TITLE
Add needed count properties to learner-group

### DIFF
--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -250,6 +250,27 @@ export default Model.extend({
   }),
 
   /**
+   * Returns the number of users in this group
+   * @property usersCount
+   * @type {Ember.computed}
+   * @public
+   */
+  usersCount: computed('users.[]', function() {
+    const userIds = this.hasMany('users').ids();
+    return userIds.length;
+  }),
+  /**
+   * Returns the number of children in this group
+   * @property childrenCount
+   * @type {Ember.computed}
+   * @public
+   */
+  childrenCount: computed('children.[]', function() {
+    const childrenIds = this.hasMany('children').ids();
+    return childrenIds.length;
+  }),
+
+  /**
    * Takes a user out of  a group and then traverses child groups recursively
    * to remove the user from them as well.  Will only modify groups where the
    * user currently exists.

--- a/tests/unit/models/learner-group-test.js
+++ b/tests/unit/models/learner-group-test.js
@@ -525,3 +525,31 @@ test('school', async function(assert) {
     assert.equal(owningSchool, school);
   });
 });
+
+test('usersCount', async function(assert) {
+  assert.expect(2);
+  const learnerGroup = this.subject();
+  assert.equal(learnerGroup.get('usersCount'), 0);
+  const store = this.store();
+  await run( async () => {
+    const user1 = store.createRecord('user');
+    const user2 = store.createRecord('user');
+
+    learnerGroup.get('users').pushObjects([user1, user2 ]);
+    assert.equal(learnerGroup.get('usersCount'), 2);
+  });
+});
+
+test('childrenCount', async function(assert) {
+  assert.expect(2);
+  const learnerGroup = this.subject();
+  assert.equal(learnerGroup.get('childrenCount'), 0);
+  const store = this.store();
+  await run( async () => {
+    const group1 = store.createRecord('learner-group',);
+    const group2 = store.createRecord('learner-group');
+
+    learnerGroup.get('children').pushObjects([group1, group2 ]);
+    assert.equal(learnerGroup.get('childrenCount'), 2);
+  });
+});


### PR DESCRIPTION
These sync counts are needed to display group info without loading all
of the related records.