### PR TITLE
Copy ICS feed url instead of displaying it

### DIFF
--- a/addon/components/ics-feed.js
+++ b/addon/components/ics-feed.js
@@ -1,11 +1,18 @@
 import Component from '@ember/component';
 import layout from '../templates/components/ics-feed';
+import { task, timeout } from 'ember-concurrency';
 
 export default Component.extend({
   layout: layout,
   classNames: ['ilios-calendar-ics-feed'],
   url: null,
   instructions: null,
+  showCopySuccessMessage: false,
+  textCopied: task(function * (){
+    this.set('showCopySuccessMessage', true);
+    yield timeout(3000);
+    this.set('showCopySuccessMessage', false);
+  }).restartable(),
   actions: {
     refresh(){
       this.sendAction('refresh');

--- a/addon/locales/en/translations.js
+++ b/addon/locales/en/translations.js
@@ -10,6 +10,8 @@ export default {
     'calendar': 'Calendar',
     'citation': 'Citation',
     'clearFilters': 'Clear Filters',
+    'copiedSuccessfully': 'Copied Successfully',
+    'copyIcsFeedUrl': 'Copy My ICS Link',
     'course': 'Course',
     'courseLearningMaterials': 'Course Learning Materials',
     'courseLevels': 'Course Levels',

--- a/addon/locales/es/translations.js
+++ b/addon/locales/es/translations.js
@@ -10,6 +10,8 @@ export default {
     'calendar': 'Calendario',
     'citation': 'Citación',
     'clearFilters': 'Borrar Filtros',
+    'copiedSuccessfully': 'Copiado con Éxito',
+    'copyIcsFeedUrl': 'Copiar Mi Enlace ICS',
     'course': 'Curso',
     'courseLearningMaterials': 'Materiales de Aprendizaje del Curso',
     'courseLevels': 'Niveles de Curso',

--- a/addon/locales/fr/translations.js
+++ b/addon/locales/fr/translations.js
@@ -10,6 +10,8 @@ export default {
     'calendar': 'Calendrier',
     'citation': "Citation",
     'clearFilters': 'Effacerez les Filtres',
+    'copiedSuccessfully': 'Copié avec succès',
+    'copyIcsFeedUrl': 'Copier mon lien ICS',
     'course': "Cours",
     'courseLearningMaterials': "Matières d’Étude du Cours",
     'courseLevels':  "Niveaux de Cours",

--- a/addon/templates/components/ics-feed.hbs
+++ b/addon/templates/components/ics-feed.hbs
@@ -1,7 +1,11 @@
 <p>{{instructions}}</p>
 <p>
-  <input value={{url}}>
-  {{#copy-button clipboardText=url}}
-    {{fa-icon 'copy'}}
-  {{/copy-button}}
+  <span>
+    {{#copy-button clipboardText=url success=(perform textCopied)}}
+      {{fa-icon 'copy'}} {{t 'general.copyIcsFeedUrl'}}
+    {{/copy-button}}
+    {{#if showCopySuccessMessage}}
+      <span class='yes'>{{t 'general.copiedSuccessfully'}}</span>
+    {{/if}}
+  </span>
 </p>

--- a/app/styles/ilios-common/components/ilios-calendar.scss
+++ b/app/styles/ilios-common/components/ilios-calendar.scss
@@ -128,18 +128,21 @@
     margin: auto;
     margin-bottom: 1em;
     padding: 2em;
+    text-align: center;
     width: 90%;
 
-    input {
-      padding: .25em;
-      width: 80%;
+    span {
+      display: inline-block;
+      margin: 0;
+      padding: 0;
+
+      &.yes {
+        color: $ilios-green;
+      }
     }
 
     button {
-      background-color: $white;
-      color: $ilios-accent-color;
-      margin-left: .5em;
-      padding: 0;
+      @include ilios-button;
     }
 
   }

--- a/tests/integration/components/ics-feed-test.js
+++ b/tests/integration/components/ics-feed-test.js
@@ -7,34 +7,11 @@ moduleForComponent('ics-feed', 'Integration | Component | ics feed', {
 
 test('it show instructions', function(assert) {
   assert.expect(1);
-  let instructions = 'SOME TEST INS';
+  const instructions = 'SOME TEST INS';
+  const element = 'p:eq(0)';
   this.set('instructions', instructions);
 
   this.render(hbs`{{ics-feed instructions=instructions}}`);
 
-  assert.equal(this.$().text().trim(), instructions);
+  assert.equal(this.$(element).text().trim(), instructions);
 });
-
-test('it show url', function(assert) {
-  assert.expect(1);
-  let url = 'http://example.com/url';
-  this.set('url', url);
-
-  this.render(hbs`{{ics-feed url=url}}`);
-
-  assert.equal(this.$('input').val().trim(), url);
-});
-
-// test('refresh calls action', function(assert) {
-//   assert.expect(1);
-//   let url = 'http://example.com/url';
-//   this.set('url', url);
-//   // Set any properties with this.set('myProperty', 'value');
-//   // Handle any actions with this.on('myAction', function(val) { ... });
-//   this.on('refresh', function(){
-//     assert.ok(true);
-//   });
-//   this.render(hbs`{{ics-feed refresh='refresh'}}`);
-//
-//   this.$('button:eq(1)').click();
-// });


### PR DESCRIPTION
Displaying the link makes it too easy to partially copy, the button
takes away that chance.

Fixes ilios/frontend#3237

wip:
- [x] needs translations