### PR TITLE
Parse offering and ILM times correctly

### DIFF
--- a/addon/models/session.js
+++ b/addon/models/session.js
@@ -136,7 +136,7 @@ export default Model.extend(PublishableModel, CategorizableModel, SortableByPosi
 
     const ilmHours = ilmSession.get('hours');
 
-    return parseInt(ilmHours, 10) + parseInt(maxSingleOfferingDuration, 10);
+    return parseFloat(ilmHours) + parseFloat(maxSingleOfferingDuration);
   }),
 
   requiredPublicationIssues: computed(

--- a/tests/unit/models/session-test.js
+++ b/tests/unit/models/session-test.js
@@ -376,14 +376,14 @@ module('Unit | Model | Session', function(hooks) {
     const store = this.owner.lookup('service:store');
 
     await run( async () => {
-      const allDayOffering = store.createRecord('offering', {startDate: moment('2017-01-01') , endDate: moment('2017-01-02') });
+      const allDayOffering = store.createRecord('offering', { startDate: moment('2017-01-01'), endDate: moment('2017-01-02').add(30, 'minutes') });
       const halfAnHourOffering = store.createRecord('offering', {startDate: moment('2017-01-01 09:30:00'), endDate: moment('2017-01-01 10:00:00') });
       subject.get('offerings').pushObjects([allDayOffering, halfAnHourOffering]);
-      let ilmSession = store.createRecord('ilmSession', { hours: 2});
+      let ilmSession = store.createRecord('ilmSession', { hours: 2.1});
       subject.set('ilmSession', ilmSession);
 
       const max = await subject.get('totalSumDuration');
-      assert.equal(max, 26.00);
+      assert.equal(max, 26.60);
     });
   });
 


### PR DESCRIPTION
These are not integers, they are fractional hours and need to be parsed
as floats when summing them.

Fixes ilios/frontend#3636