### PR TITLE
Add remaining capabilities to permission-checker

### DIFF
--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -28,6 +28,24 @@ export default Model.extend({
   }),
 
   /**
+   * A list of all sessions associated with this learner group, via offerings or via ILMs.
+   * @property sessions
+   * @type {Ember.computed}
+   * @public
+   */
+  sessions: computed('ilmSessions.[]', 'offerings.[]', async function () {
+    const offerings = await this.get('offerings');
+    const ilms = await this.get('ilmSessions');
+    const arr = [].concat(offerings.toArray(), ilms.toArray());
+
+    let sessions = await all(arr.mapBy('session'));
+
+    return sessions.filter(session => {
+      return !isEmpty(session);
+    }).uniq();
+  }),
+
+  /**
    * A list of all courses associated with this learner group, via offerings/sessions or via ILMs.
    * @property courses
    * @type {Ember.computed}

--- a/addon/services/current-user.js
+++ b/addon/services/current-user.js
@@ -244,6 +244,46 @@ export default Service.extend({
 
     return matches.length > 0;
   },
+  async isAdministeringSession(sessionId) {
+    const user = await this.get('model');
+
+    const ids = user.hasMany('administeredSessions').ids();
+    const matches = ids.filterBy('id', sessionId);
+
+    return matches.length > 0;
+  },
+  async isTeachingSession(sessionId) {
+    const user = await this.get('model');
+
+    const sessions = await user.get('allInstructedSessions');
+    const matches = sessions.filterBy('id', sessionId);
+
+    return matches.length > 0;
+  },
+  async isDirectingProgram(programId) {
+    const user = await this.get('model');
+
+    const ids = user.hasMany('directedPrograms').ids();
+    const matches = ids.filterBy('id', programId);
+
+    return matches.length > 0;
+  },
+  async isDirectingProgramYearInProgram(programId) {
+    const user = await this.get('model');
+
+    const programYears = await user.get('programYears');
+    const matches = programYears.filter(programYear => programId === programYear.belongsTo('program').id());
+
+    return matches.length > 0;
+  },
+  async isAdministeringCurriculumInventoryReport(reportId) {
+    const user = await this.get('model');
+
+    const ids = user.hasMany('administeredCurriculumInventoryReports').ids();
+    const matches = ids.filterBy('id', reportId);
+
+    return matches.length > 0;
+  },
   async getRolesInSchool(schoolId) {
     let roles = [];
     if (await this.isDirectingSchool(schoolId)) {
@@ -283,6 +323,36 @@ export default Service.extend({
     }
     if (await this.isTeachingCourse(courseId)) {
       roles.pushObject('COURSE_INSTRUCTOR');
+    }
+
+    return roles;
+  },
+  async getRolesInSession(sessionId) {
+    let roles = [];
+    if (await this.isAdministeringSession(sessionId)) {
+      roles.pushObject('SESSION_ADMINISTRATOR');
+    }
+    if (await this.isTeachingSession(sessionId)) {
+      roles.pushObject('COURSE_INSTRUCTOR');
+    }
+
+    return roles;
+  },
+  async getRolesInProgram(programId) {
+    let roles = [];
+    if (await this.isDirectingProgram(programId)) {
+      roles.pushObject('PROGRAM_DIRECTOR');
+    }
+    if (await this.isDirectingProgramYearInProgram(programId)) {
+      roles.pushObject('PROGRAM_YEAR_DIRECTOR');
+    }
+
+    return roles;
+  },
+  async getRolesInCurriculumInventoryReport(reportId) {
+    let roles = [];
+    if (await this.isAdministeringCurriculumInventoryReport(reportId)) {
+      roles.pushObject('CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR');
     }
 
     return roles;

--- a/addon/services/permission-checker.js
+++ b/addon/services/permission-checker.js
@@ -4,7 +4,7 @@ import { inject as service } from '@ember/service';
 export default Service.extend({
   currentUser: service(),
   permissionMatrix: service(),
-  async canCreateCourse(schoolId) {
+  async canDoInSchool(schoolId, capability) {
     const currentUser = await this.get('currentUser');
     const isRoot = await currentUser.get('isRoot');
     if (isRoot) {
@@ -13,25 +13,285 @@ export default Service.extend({
     const permissionMatrix = this.get('permissionMatrix');
     const rolesInSchool = await currentUser.getRolesInSchool(schoolId);
 
-    return permissionMatrix.hasPermission(schoolId, 'CAN_CREATE_COURSES', rolesInSchool);
+    return permissionMatrix.hasPermission(schoolId, capability, rolesInSchool);
   },
-  async canUpdateCourse(course, schoolId) {
+  async canUpdateCourse(course) {
     const currentUser = await this.get('currentUser');
     const permissionMatrix = this.get('permissionMatrix');
     if (course.get('locked') || course.get('archived')) {
       return false;
     }
-    const isRoot = await currentUser.get('isRoot');
-    if (isRoot) {
-      return true;
-    }
+    const schoolId = course.belongsTo('school').id;
 
-    const rolesInSchool = await currentUser.getRolesInSchool(schoolId);
-    if (await permissionMatrix.hasPermission(schoolId, 'CAN_UPDATE_ALL_COURSES', rolesInSchool)) {
+    if (await this.canDoInSchool(schoolId, 'CAN_UPDATE_ALL_COURSES')) {
       return true;
     }
 
     const rolesInCourse = await currentUser.getRolesInCourse(course.get('id'));
     return await permissionMatrix.hasPermission(schoolId, 'CAN_UPDATE_THEIR_COURSES', rolesInCourse);
-  }
+  },
+  async canDeleteCourse(course) {
+    const currentUser = await this.get('currentUser');
+    const permissionMatrix = this.get('permissionMatrix');
+    if (course.get('locked') || course.get('archived')) {
+      return false;
+    }
+
+    const schoolId = course.belongsTo('school').id;
+    if (await this.canDoInSchool(schoolId, 'CAN_DELETE_ALL_COURSES')) {
+      return true;
+    }
+
+    const rolesInCourse = await currentUser.getRolesInCourse(course.get('id'));
+    return await permissionMatrix.hasPermission(schoolId, 'CAN_DELETE_THEIR_COURSES', rolesInCourse);
+  },
+  async canCreateCourse(schoolId) {
+    return this.canDoInSchool(schoolId, 'CAN_CREATE_COURSES');
+  },
+  async canUnlockCourse(course) {
+    const currentUser = await this.get('currentUser');
+    const permissionMatrix = this.get('permissionMatrix');
+
+    const schoolId = course.belongsTo('school').id;
+    if (await this.canDoInSchool(schoolId, 'CAN_UNLOCK_ALL_COURSES')) {
+      return true;
+    }
+
+    const rolesInCourse = await currentUser.getRolesInCourse(course.get('id'));
+    return await permissionMatrix.hasPermission(schoolId, 'CAN_UNLOCK_THEIR_COURSES', rolesInCourse);
+  },
+  async canUpdateSession(session) {
+    const currentUser = await this.get('currentUser');
+    const permissionMatrix = this.get('permissionMatrix');
+
+    const course = await session.get('course');
+    const schoolId = course.belongsTo('school').id;
+    if (await this.canDoInSchool(schoolId, 'CAN_UPDATE_ALL_SESSIONS')) {
+      return true;
+    }
+
+    const rolesInSession = await currentUser.getRolesInSession(session.get('id'));
+    if (await permissionMatrix.hasPermission(schoolId, 'CAN_UPDATE_THEIR_SESSIONS', rolesInSession)) {
+      return true;
+    }
+
+    return this.canUpdateCourse(course);
+  },
+  async canDeleteSession(session) {
+    const currentUser = await this.get('currentUser');
+    const permissionMatrix = this.get('permissionMatrix');
+
+    const course = await session.get('course');
+    const schoolId = course.belongsTo('school').id;
+    if (await this.canDoInSchool(schoolId, 'CAN_DELETE_ALL_SESSIONS')) {
+      return true;
+    }
+
+    const rolesInSession = await currentUser.getRolesInSession(session.get('id'));
+    if (await permissionMatrix.hasPermission(schoolId, 'CAN_DELETE_THEIR_SESSIONS', rolesInSession)) {
+      return true;
+    }
+
+    return this.canUpdateCourse(course);
+  },
+  async canCreateSession(session) {
+    const course = await session.get('course');
+    const schoolId = course.belongsTo('school').id;
+    if (await this.canDoInSchool(schoolId, 'CAN_CREATE_SESSIONS')) {
+      return true;
+    }
+
+    return this.canUpdateCourse(course);
+  },
+  async canUpdateSessionType(schoolId) {
+    return this.canDoInSchool(schoolId, 'CAN_UPDATE_SESSION_TYPES');
+  },
+  async canDeleteSessionType(schoolId) {
+    return this.canDoInSchool(schoolId, 'CAN_DELETE_SESSION_TYPES');
+  },
+  async canCreateSessionType(schoolId) {
+    return this.canDoInSchool(schoolId, 'CAN_CREATE_SESSION_TYPES');
+  },
+  async canUpdateDepartment(schoolId) {
+    return this.canDoInSchool(schoolId, 'CAN_UPDATE_DEPARTMENTS');
+  },
+  async canDeleteDepartment(schoolId) {
+    return this.canDoInSchool(schoolId, 'CAN_DELETE_DEPARTMENTS');
+  },
+  async canCreateDepartment(schoolId) {
+    return this.canDoInSchool(schoolId, 'CAN_CREATE_DEPARTMENTS');
+  },
+  async canUpdateProgram(program) {
+    const currentUser = await this.get('currentUser');
+    const permissionMatrix = this.get('permissionMatrix');
+
+    const schoolId = program.belongsTo('school').id;
+    if (await this.canDoInSchool(schoolId, 'CAN_UPDATE_ALL_PROGRAMS')) {
+      return true;
+    }
+
+    const rolesInProgram = await currentUser.getRolesInProgram(program.get('id'));
+    return await permissionMatrix.hasPermission(schoolId, 'CAN_UPDATE_THEIR_PROGRAMS', rolesInProgram);
+  },
+  async canDeleteProgram(program) {
+    const currentUser = await this.get('currentUser');
+    const permissionMatrix = this.get('permissionMatrix');
+    const schoolId = program.belongsTo('school').id;
+    if (await this.canDoInSchool(schoolId, 'CAN_DELETE_ALL_PROGRAMS')) {
+      return true;
+    }
+
+    const rolesInProgram = await currentUser.getRolesInProgram(program.get('id'));
+    return await permissionMatrix.hasPermission(schoolId, 'CAN_DELETE_THEIR_PROGRAMS', rolesInProgram);
+  },
+  async canCreateProgram(schoolId) {
+    return this.canDoInSchool(schoolId, 'CAN_CREATE_PROGRAMS');
+  },
+  async canUpdateProgramYear(programYear) {
+    const currentUser = await this.get('currentUser');
+    const permissionMatrix = this.get('permissionMatrix');
+
+    const program = await programYear.get('program');
+    const schoolId = program.belongsTo('school').id;
+    if (await this.canDoInSchool(schoolId, 'CAN_UPDATE_ALL_PROGRAM_YEARS')) {
+      return true;
+    }
+    const rolesInProgramYear = await currentUser.getRolesInProgramYear(programYear.get('id'));
+    if (await permissionMatrix.hasPermission(schoolId, 'CAN_UPDATE_THEIR_PROGRAM_YEARS', rolesInProgramYear)) {
+      return true;
+    }
+
+    return this.canUpdateProgram(program);
+  },
+  async canDeleteProgramYear(programYear) {
+    const currentUser = await this.get('currentUser');
+    const permissionMatrix = this.get('permissionMatrix');
+
+    const program = await programYear.get('program');
+    const schoolId = program.belongsTo('school').id;
+    if (await this.canDoInSchool(schoolId, 'CAN_DELETE_ALL_PROGRAM_YEARS')) {
+      return true;
+    }
+    const rolesInProgramYear = await currentUser.getRolesInProgramYear(programYear.get('id'));
+    if (await permissionMatrix.hasPermission(schoolId, 'CAN_DELETE_THEIR_PROGRAM_YEARS', rolesInProgramYear)) {
+      return true;
+    }
+
+    return this.canUpdateProgram(program);
+  },
+  async canCreateProgramYear(program) {
+    const schoolId = program.belongsTo('school').id;
+    if (await this.canDoInSchool(schoolId, 'CAN_CREATE_PROGRAM_YEARS')) {
+      return true;
+    }
+    return this.canUpdateProgram(program);
+  },
+  async canUnlockProgramYear(programYear) {
+    const currentUser = await this.get('currentUser');
+    const permissionMatrix = this.get('permissionMatrix');
+    const program = await programYear.get('program');
+    const schoolId = program.belongsTo('school').id;
+    if (await this.canDoInSchool(schoolId, 'CAN_UNLOCK_ALL_PROGRAM_YEARS')) {
+      return true;
+    }
+    const rolesInProgramYear = await currentUser.getRolesInProgramYear(programYear.get('id'));
+    if (await permissionMatrix.hasPermission(schoolId, 'CAN_UNLOCK_THEIR_PROGRAM_YEARS', rolesInProgramYear)) {
+      return true;
+    }
+
+    return this.canUpdateProgram(program);
+  },
+  async canUpdateSchoolConfig(schoolId) {
+    return this.canDoInSchool(schoolId, 'CAN_UPDATE_SCHOOL_CONFIGS');
+  },
+  async canDeleteSchoolConfig(schoolId) {
+    return this.canDoInSchool(schoolId, 'CAN_DELETE_SCHOOL_CONFIGS');
+  },
+  async canCreateSchoolConfig(schoolId) {
+    return this.canDoInSchool(schoolId, 'CAN_CREATE_SCHOOL_CONFIGS');
+  },
+  async canUpdateSchool(schoolId) {
+    return this.canDoInSchool(schoolId, 'CAN_UPDATE_SCHOOLS');
+  },
+  async canUpdateCompetency(schoolId) {
+    return this.canDoInSchool(schoolId, 'CAN_UPDATE_COMPETENCIES');
+  },
+  async canDeleteCompetency(schoolId) {
+    return this.canDoInSchool(schoolId, 'CAN_DELETE_COMPETENCIES');
+  },
+  async canCreateCompetency(schoolId) {
+    return this.canDoInSchool(schoolId, 'CAN_CREATE_COMPETENCIES');
+  },
+  async canUpdateVocabulary(schoolId) {
+    return this.canDoInSchool(schoolId, 'CAN_UPDATE_VOCABULARIES');
+  },
+  async canDeleteVocabulary(schoolId) {
+    return this.canDoInSchool(schoolId, 'CAN_DELETE_VOCABULARIES');
+  },
+  async canCreateVocabulary(schoolId) {
+    return this.canDoInSchool(schoolId, 'CAN_CREATE_VOCABULARIES');
+  },
+  async canUpdateTerm(schoolId) {
+    return this.canDoInSchool(schoolId, 'CAN_UPDATE_TERMS');
+  },
+  async canDeleteTerm(schoolId) {
+    return this.canDoInSchool(schoolId, 'CAN_DELETE_TERMS');
+  },
+  async canCreateTerm(schoolId) {
+    return this.canDoInSchool(schoolId, 'CAN_CREATE_TERMS');
+  },
+  async canUpdateInstructorGroup(schoolId) {
+    return this.canDoInSchool(schoolId, 'CAN_UPDATE_INSTRUCTOR_GROUPS');
+  },
+  async canDeleteInstructorGroup(schoolId) {
+    return this.canDoInSchool(schoolId, 'CAN_DELETE_INSTRUCTOR_GROUPS');
+  },
+  async canCreateInstructorGroup(schoolId) {
+    return this.canDoInSchool(schoolId, 'CAN_CREATE_INSTRUCTOR_GROUPS');
+  },
+  async canUpdateCurriculumInventoryReport(curriculumInventoryReport) {
+    const currentUser = await this.get('currentUser');
+    const permissionMatrix = this.get('permissionMatrix');
+    const program = await curriculumInventoryReport.get('program');
+    const schoolId = program.belongsTo('school').id();
+    if (await this.canDoInSchool(schoolId, 'CAN_UPDATE_ALL_CURRICULUM_INVENTORY_REPORTS')) {
+      return true;
+    }
+    const rolesInReport = await currentUser.getRolesInCurriculumInventoryReport(curriculumInventoryReport.get('id'));
+
+    return permissionMatrix.hasPermission(schoolId, 'CAN_UPDATE_THEIR_CURRICULUM_INVENTORY_REPORTS', rolesInReport);
+  },
+  async canDeleteCurriculumInventoryReport(curriculumInventoryReport) {
+    const currentUser = await this.get('currentUser');
+    const permissionMatrix = this.get('permissionMatrix');
+    const program = await curriculumInventoryReport.get('program');
+    const schoolId = program.belongsTo('school').id();
+    if (await this.canDoInSchool(schoolId, 'CAN_DELETE_ALL_CURRICULUM_INVENTORY_REPORTS')) {
+      return true;
+    }
+
+    const rolesInReport = await currentUser.getRolesInCurriculumInventoryReport(curriculumInventoryReport.get('id'));
+    return permissionMatrix.hasPermission(schoolId, 'CAN_DELETE_THEIR_CURRICULUM_INVENTORY_REPORTS', rolesInReport);
+  },
+  async canCreateCurriculumInventoryReport(schoolId) {
+    return this.canDoInSchool(schoolId, 'CAN_CREATE_CURRICULUM_INVENTORY_REPORTS');
+  },
+  async canUpdateLearnerGroup(schoolId) {
+    return this.canDoInSchool(schoolId, 'CAN_UPDATE_LEARNER_GROUPS');
+  },
+  async canDeleteLearnerGroup(schoolId) {
+    return this.canDoInSchool(schoolId, 'CAN_DELETE_LEARNER_GROUPS');
+  },
+  async canCreateLearnerGroup(schoolId) {
+    return this.canDoInSchool(schoolId, 'CAN_CREATE_LEARNER_GROUPS');
+  },
+  async canUpdateUser(schoolId) {
+    return this.canDoInSchool(schoolId, 'CAN_UPDATE_USERS');
+  },
+  async canDeleteUser(schoolId) {
+    return this.canDoInSchool(schoolId, 'CAN_DELETE_USERS');
+  },
+  async canCreateUser(schoolId) {
+    return this.canDoInSchool(schoolId, 'CAN_CREATE_USERS');
+  },
 });

--- a/addon/services/permission-matrix.js
+++ b/addon/services/permission-matrix.js
@@ -11,18 +11,240 @@ export default Service.extend({
     let matrix = {};
     schoolIds.forEach(id => {
       matrix[id] = {
+        'CAN_UPDATE_SCHOOLS': [
+          'SCHOOL_ADMINISTRATOR',
+          'SCHOOL_DIRECTOR',
+        ],
+        'CAN_CREATE_PROGRAMS': [
+          'SCHOOL_ADMINISTRATOR',
+          'SCHOOL_DIRECTOR',
+          'PROGRAM_DIRECTOR',
+        ],
+        'CAN_UPDATE_ALL_PROGRAMS': [
+          'SCHOOL_ADMINISTRATOR',
+          'SCHOOL_DIRECTOR',
+        ],
+        'CAN_UPDATE_THEIR_PROGRAMS': [
+          'PROGRAM_DIRECTOR',
+        ],
+        'CAN_DELETE_ALL_PROGRAMS': [
+          'SCHOOL_ADMINISTRATOR',
+          'SCHOOL_DIRECTOR',
+        ],
+        'CAN_DELETE_THEIR_PROGRAMS': [
+          'PROGRAM_DIRECTOR',
+        ],
+        'CAN_CREATE_PROGRAM_YEARS': [
+          'SCHOOL_ADMINISTRATOR',
+          'SCHOOL_DIRECTOR',
+          'PROGRAM_DIRECTOR',
+        ],
+        'CAN_UPDATE_ALL_PROGRAM_YEARS': [
+          'SCHOOL_ADMINISTRATOR',
+          'SCHOOL_DIRECTOR',
+          'PROGRAM_DIRECTOR',
+        ],
+        'CAN_UPDATE_THEIR_PROGRAM_YEARS': [
+          'PROGRAM_DIRECTOR',
+        ],
+        'CAN_DELETE_ALL_PROGRAM_YEARS': [
+          'SCHOOL_ADMINISTRATOR',
+          'SCHOOL_DIRECTOR',
+          'PROGRAM_DIRECTOR',
+        ],
+        'CAN_DELETE_THEIR_PROGRAM_YEARS': [
+          'PROGRAM_DIRECTOR',
+        ],
+        'CAN_UNLOCK_ALL_PROGRAM_YEARS': [
+          'SCHOOL_ADMINISTRATOR',
+          'SCHOOL_DIRECTOR',
+          'PROGRAM_DIRECTOR',
+        ],
+        'CAN_UNLOCK_THEIR_PROGRAM_YEARS': [
+          'PROGRAM_DIRECTOR',
+        ],
+        'CAN_UNARCHIVE_ALL_PROGRAM_YEARS': [
+          'SCHOOL_ADMINISTRATOR',
+          'SCHOOL_DIRECTOR',
+          'PROGRAM_DIRECTOR',
+        ],
+        'CAN_UNARCHIVE_THEIR_PROGRAM_YEARS': [
+          'PROGRAM_DIRECTOR',
+        ],
         'CAN_CREATE_COURSES': [
           'SCHOOL_ADMINISTRATOR',
-          'SCHOOL_DIRECTOR'
+          'SCHOOL_DIRECTOR',
         ],
         'CAN_UPDATE_ALL_COURSES': [
           'SCHOOL_ADMINISTRATOR',
           'SCHOOL_DIRECTOR',
-          'PROGRAM_DIRECTOR'
+          'PROGRAM_DIRECTOR',
         ],
         'CAN_UPDATE_THEIR_COURSES': [
           'COURSE_ADMINISTRATOR',
-          'COURSE_DIRECTOR'
+          'COURSE_DIRECTOR',
+        ],
+        'CAN_DELETE_ALL_COURSES': [
+          'SCHOOL_ADMINISTRATOR',
+        ],
+        'CAN_UNLOCK_ALL_COURSES': [
+          'SCHOOL_ADMINISTRATOR',
+        ],
+        'CAN_UNLOCK_THEIR_COURSES': [
+          'COURSE_ADMINISTRATOR',
+          'COURSE_DIRECTOR',
+        ],
+        'CAN_UNARCHIVE_ALL_COURSES': [
+          'SCHOOL_ADMINISTRATOR',
+        ],
+        'CAN_CREATE_SESSIONS': [
+          'SCHOOL_ADMINISTRATOR',
+          'SCHOOL_DIRECTOR',
+          'PROGRAM_DIRECTOR',
+          'COURSE_ADMINISTRATOR',
+          'COURSE_DIRECTOR',
+        ],
+        'CAN_UPDATE_ALL_SESSIONS': [
+          'SCHOOL_ADMINISTRATOR',
+          'SCHOOL_DIRECTOR',
+          'PROGRAM_DIRECTOR',
+          'COURSE_ADMINISTRATOR',
+          'COURSE_DIRECTOR',
+        ],
+        'CAN_UPDATE_THEIR_SESSIONS': [
+          'SESSION_ADMINISTRATOR',
+          'SESSION_INSTRUCTOR',
+        ],
+        'CAN_DELETE_ALL_SESSIONS': [
+          'SCHOOL_ADMINISTRATOR',
+          'SCHOOL_DIRECTOR',
+          'COURSE_ADMINISTRATOR',
+          'COURSE_DIRECTOR',
+        ],
+        'CAN_CREATE_COMPETENCIES': [
+          'SCHOOL_ADMINISTRATOR',
+        ],
+        'CAN_UPDATE_COMPETENCIES': [
+          'SCHOOL_ADMINISTRATOR',
+        ],
+        'CAN_DELETE_COMPETENCIES': [
+          'SCHOOL_ADMINISTRATOR',
+        ],
+        'CAN_CREATE_SESSION_TYPES': [
+          'SCHOOL_ADMINISTRATOR',
+        ],
+        'CAN_UPDATE_SESSION_TYPES': [
+          'SCHOOL_ADMINISTRATOR',
+        ],
+        'CAN_DELETE_SESSION_TYPES': [
+          'SCHOOL_ADMINISTRATOR',
+        ],
+        'CAN_CREATE_VOCABULARIES': [
+          'SCHOOL_ADMINISTRATOR',
+        ],
+        'CAN_UPDATE_VOCABULARIES': [
+          'SCHOOL_ADMINISTRATOR',
+        ],
+        'CAN_DELETE_VOCABULARIES': [
+          'SCHOOL_ADMINISTRATOR',
+        ],
+        'CAN_CREATE_TERMS': [
+          'SCHOOL_ADMINISTRATOR',
+          'SCHOOL_DIRECTOR',
+        ],
+        'CAN_UPDATE_TERMS': [
+          'SCHOOL_ADMINISTRATOR',
+          'SCHOOL_DIRECTOR',
+        ],
+        'CAN_DELETE_TERMS': [
+          'SCHOOL_ADMINISTRATOR',
+          'SCHOOL_DIRECTOR',
+        ],
+        'CAN_CREATE_INSTRUCTOR_GROUPS': [
+          'SCHOOL_ADMINISTRATOR',
+          'SCHOOL_DIRECTOR',
+          'PROGRAM_DIRECTOR',
+          'COURSE_ADMINISTRATOR',
+          'COURSE_DIRECTOR',
+        ],
+        'CAN_UPDATE_INSTRUCTOR_GROUPS': [
+          'SCHOOL_ADMINISTRATOR',
+          'COURSE_ADMINISTRATOR',
+          'COURSE_DIRECTOR',
+        ],
+        'CAN_DELETE_INSTRUCTOR_GROUPS': [
+          'SCHOOL_ADMINISTRATOR',
+        ],
+        'CAN_CREATE_LEARNER_GROUPS': [
+          'SCHOOL_ADMINISTRATOR',
+          'COURSE_ADMINISTRATOR',
+          'COURSE_DIRECTOR',
+          'SESSION_ADMINISTRATOR',
+        ],
+        'CAN_UPDATE_LEARNER_GROUPS': [
+          'SCHOOL_ADMINISTRATOR',
+          'COURSE_ADMINISTRATOR',
+          'COURSE_DIRECTOR',
+          'SESSION_ADMINISTRATOR',
+        ],
+        'CAN_DELETE_LEARNER_GROUPS': [
+          'SCHOOL_ADMINISTRATOR',
+        ],
+        'CAN_CREATE_CURRICULUM_INVENTORY_REPORTS': [
+          'SCHOOL_ADMINISTRATOR',
+          'SCHOOL_DIRECTOR',
+        ],
+        'CAN_UPDATE_ALL_CURRICULUM_INVENTORY_REPORTS': [
+          'SCHOOL_ADMINISTRATOR',
+          'SCHOOL_DIRECTOR',
+        ],
+        'CAN_UPDATE_THEIR_CURRICULUM_INVENTORY_REPORTS': [
+          'CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR',
+        ],
+        'CAN_DELETE_ALL_CURRICULUM_INVENTORY_REPORTS': [
+          'SCHOOL_ADMINISTRATOR',
+        ],
+        'CAN_CREATE_SCHOOL_CONFIGS': [
+          'SCHOOL_ADMINISTRATOR',
+          'SCHOOL_DIRECTOR',
+        ],
+        'CAN_UPDATE_SCHOOL_CONFIGS': [
+          'SCHOOL_ADMINISTRATOR',
+          'SCHOOL_DIRECTOR',
+        ],
+        'CAN_DELETE_SCHOOL_CONFIGS': [
+          'SCHOOL_ADMINISTRATOR',
+          'SCHOOL_DIRECTOR',
+        ],
+        'CAN_CREATE_CURRICULUM_INVENTORY_INSTITUTIONS': [
+          'SCHOOL_ADMINISTRATOR',
+        ],
+        'CAN_UPDATE_CURRICULUM_INVENTORY_INSTITUTIONS': [
+          'SCHOOL_ADMINISTRATOR',
+        ],
+        'CAN_DELETE_CURRICULUM_INVENTORY_INSTITUTIONS': [
+          'SCHOOL_ADMINISTRATOR',
+        ],
+        'CAN_CREATE_USERS': [
+          'SCHOOL_ADMINISTRATOR',
+        ],
+        'CAN_UPDATE_USERS': [
+          'SCHOOL_ADMINISTRATOR',
+        ],
+        'CAN_DELETE_USERS': [
+          'SCHOOL_ADMINISTRATOR',
+        ],
+        'CAN_CREATE_DEPARTMENTS': [
+          'SCHOOL_ADMINISTRATOR',
+          'SCHOOL_DIRECTOR',
+        ],
+        'CAN_UPDATE_DEPARTMENTS': [
+          'SCHOOL_ADMINISTRATOR',
+          'SCHOOL_DIRECTOR',
+        ],
+        'CAN_DELETE_DEPARTMENTS': [
+          'SCHOOL_ADMINISTRATOR',
+          'SCHOOL_DIRECTOR',
         ],
       };
     });

--- a/tests/unit/models/instructor-group-test.js
+++ b/tests/unit/models/instructor-group-test.js
@@ -40,4 +40,34 @@ module('Unit | Model | InstructorGroup', function(hooks) {
       assert.ok(courses.includes(course3));
     });
   });
+  test('list sessions', async function(assert) {
+    assert.expect(5);
+    run( async () => {
+      const model = run(() => this.owner.lookup('service:store').createRecord('instructor-group'));
+      const store = model.store;
+      const session1 = store.createRecord('session');
+      const session2 = store.createRecord('session');
+      const session3 = store.createRecord('session');
+      const session4 = store.createRecord('session');
+
+      model.get('offerings').pushObjects([
+        store.createRecord('offering', { session: session1 }),
+        store.createRecord('offering', { session: session1 }),
+        store.createRecord('offering', { session: session1 }),
+        store.createRecord('offering', { session: session2 }),
+        store.createRecord('offering', { session: session2 }),
+        store.createRecord('offering', { session: session3 })
+      ]);
+      model.get('ilmSessions').pushObjects([
+        store.createRecord('ilmSession', { session: session3 }),
+        store.createRecord('ilmSession', { session: session4 })
+      ]);
+      const sessions = await model.get('sessions');
+      assert.equal(sessions.length, 4);
+      assert.ok(sessions.includes(session1));
+      assert.ok(sessions.includes(session2));
+      assert.ok(sessions.includes(session3));
+      assert.ok(sessions.includes(session4));
+    });
+  });
 });

--- a/tests/unit/models/learner-group-test.js
+++ b/tests/unit/models/learner-group-test.js
@@ -40,6 +40,37 @@ module('Unit | Model | LearnerGroup', function(hooks) {
     });
   });
 
+  test('list sessions', async function(assert) {
+    assert.expect(5);
+    run( async () => {
+      const model = run(() => this.owner.lookup('service:store').createRecord('learner-group'));
+      const store = model.store;
+      const session1 = store.createRecord('session');
+      const session2 = store.createRecord('session');
+      const session3 = store.createRecord('session');
+      const session4 = store.createRecord('session');
+
+      model.get('offerings').pushObjects([
+        store.createRecord('offering', { session: session1 }),
+        store.createRecord('offering', { session: session1 }),
+        store.createRecord('offering', { session: session1 }),
+        store.createRecord('offering', { session: session2 }),
+        store.createRecord('offering', { session: session2 }),
+        store.createRecord('offering', { session: session3 })
+      ]);
+      model.get('ilmSessions').pushObjects([
+        store.createRecord('ilmSession', { session: session3 }),
+        store.createRecord('ilmSession', { session: session4 })
+      ]);
+      const sessions = await model.get('sessions');
+      assert.equal(sessions.length, 4);
+      assert.ok(sessions.includes(session1));
+      assert.ok(sessions.includes(session2));
+      assert.ok(sessions.includes(session3));
+      assert.ok(sessions.includes(session4));
+    });
+  });
+
   test('check allDescendantUsers on empty group', async function(assert) {
     assert.expect(1);
     let learnerGroup = run(() => this.owner.lookup('service:store').createRecord('learner-group'));

--- a/tests/unit/models/user-test.js
+++ b/tests/unit/models/user-test.js
@@ -546,4 +546,84 @@ module('Unit | Model | User', function(hooks) {
       assert.ok(schools.includes(school3));
     });
   });
+
+  test('allInstructedCourses gets ALL instructed courses', async function(assert) {
+    const model = run(() => this.owner.lookup('service:store').createRecord('user'));
+    const store = this.owner.lookup('service:store');
+    run(async () => {
+      const course1 = store.createRecord('course');
+      const session1 = store.createRecord('session', { course: course1 });
+      store.createRecord('offering', {
+        session: session1,
+        instructors: [model]
+      });
+      const course2 = store.createRecord('course');
+      const session2 = store.createRecord('session', { course: course2 });
+      const instructorGroup1 = store.createRecord('instructor-group', { users: [model]});
+      store.createRecord('offering', {
+        session: session2,
+        instructorGroups: [instructorGroup1]
+      });
+
+      const course3 = store.createRecord('course');
+      const session3 = store.createRecord('session', { course: course3 });
+      store.createRecord('ilmSession', {
+        session: session3,
+        instructors: [model]
+      });
+
+      const instructorGroup2 = store.createRecord('instructor-group', { users: [model] });
+      const course4 = store.createRecord('course');
+      const session4 = store.createRecord('session', { course: course4 });
+      store.createRecord('ilmSession', {
+        session: session4,
+        instructorGroups: [instructorGroup2]
+      });
+
+      const course = [course1, course2, course3, course4];
+      const allInstructedCourses = await model.get('allInstructedCourses');
+      assert.equal(allInstructedCourses.length, course.length);
+      course.forEach(session => {
+        assert.ok(allInstructedCourses.includes(session));
+      });
+    });
+  });
+
+  test('allInstructedSessions gets ALL instructed sessions', async function(assert) {
+    const model = run(() => this.owner.lookup('service:store').createRecord('user'));
+    const store = this.owner.lookup('service:store');
+    run(async () => {
+      const session1 = store.createRecord('session');
+      store.createRecord('offering', {
+        session: session1,
+        instructors: [model]
+      });
+      const session2 = store.createRecord('session');
+      const instructorGroup1 = store.createRecord('instructor-group', { users: [model]});
+      store.createRecord('offering', {
+        session: session2,
+        instructorGroups: [instructorGroup1]
+      });
+
+      const session3 = store.createRecord('session');
+      store.createRecord('ilmSession', {
+        session: session3,
+        instructors: [model]
+      });
+
+      const instructorGroup2 = store.createRecord('instructor-group', { users: [model] });
+      const session4 = store.createRecord('session');
+      store.createRecord('ilmSession', {
+        session: session4,
+        instructorGroups: [instructorGroup2]
+      });
+
+      const sessions = [session1, session2, session3, session4];
+      const allInstructedSessions = await model.get('allInstructedSessions');
+      assert.equal(allInstructedSessions.length, sessions.length);
+      sessions.forEach(session => {
+        assert.ok(allInstructedSessions.includes(session));
+      });
+    });
+  });
 });


### PR DESCRIPTION
This allows us to check everything that can be checked on the API. We
probably don't need all of this, but it is easier to do it all at once.