### PR TITLE
Allow ember-beta to fail tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
+    - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:


### PR DESCRIPTION
Until a new version of ember-tether is published this test is going to
continue failing so let's ignore that failure for now