### PR TITLE
Refactor single-event to only use public data

### DIFF
--- a/addon/templates/components/single-event.hbs
+++ b/addon/templates/components/single-event.hbs
@@ -1,17 +1,17 @@
-{{#if (and event (is-fulfilled courseObjectives) (is-fulfilled courseLearningMaterials) (is-fulfilled sessionObjectives) (is-fulfilled sessionLearningMaterials))}}
+{{#if (and event (is-fulfilled courseObjectives) (is-fulfilled sessionObjectives))}}
   <div class='single-event-summary'>
     <h1>
       {{#if recentlyUpdated}}
         {{fa-icon 'exclamation-circle' class="recently-updated-icon-event" title=(t 'general.newUpdates')}}
       {{/if}}
-      {{get (await course) 'title'}} - <em>{{get (await session) 'title'}}</em>
+      {{event.courseTitle}} - <em>{{event.name}}</em>
     </h1>
     <div class='single-event-offered-at'>{{t 'general.offeredAt' date=(moment-format event.startDate 'dddd, MMMM Do YYYY, h:mm a')}}</div>
     <div class='single-event-location'>{{event.location}}</div>
     {{#if taughtBy}}
       <div class='single-event-instructors'>{{taughtBy}}</div>
     {{/if}}
-    <div class='single-event-session-is'>{{await sessionIs}}</div>
+    <div class='single-event-session-is'>{{sessionIs}}</div>
     {{#if event.equipmentRequired}}
       <div class='single-event-equipment-required'>
         {{{t 'general.specialEquipmentIs_Required_'}}} {{fa-icon 'flask' title=(t 'general.specialEquipment')}}
@@ -32,8 +32,8 @@
         <strong>{{t 'general.supplementalCurriculum'}}</strong> {{fa-icon 'calendar-minus-o' title=(t 'general.supplementalCurriculum')}}
       </div>
     {{/if}}
-    {{#if (and (is-fulfilled description) (gt (get (await description) 'length') 0))}}
-      {{{await description}}}<br>
+    {{#if (gt (get event.sessionDescription 'length') 0)}}
+      {{{event.sessionDescription}}}<br>
     {{/if}}
   </div>
 

--- a/tests/integration/components/single-event-test.js
+++ b/tests/integration/components/single-event-test.js
@@ -10,26 +10,17 @@ module('Integration | Component | ilios calendar single event', function(hooks) 
   setupRenderingTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
+    this.server.logging = true;
     const now = moment().hour(8).minute(0).second(0);
     const course = this.server.create('course', {
       id: 1,
       title: 'test course',
     });
-    const sessionType = this.server.create('session-type', {
-      id: 1,
-      title: 'test type',
-    });
-    const sessionDescription = this.server.create('session-description', {
-      id: 1,
-      description: 'test description',
-    });
-    const session = this.server.create('session', {
+    this.server.create('session', {
       id: 1,
       title: 'test session',
-      course,
-      sessionType,
-      sessionDescription,
+      course
     });
     this.sessionLearningMaterials = [
       this.server.create('session-learning-material', {
@@ -51,21 +42,18 @@ module('Integration | Component | ilios calendar single event', function(hooks) 
         endDate: new Date('2013-03-01T01:10:00')
       })
     ];
-    this.server.create('offering', {
-      id: 1,
-      session,
-    });
     this.ourEvent = EmberObject.create({
       user: 1,
       courseExternalId: 'ext1',
-      sessionTypeTitle: 'session type',
-      name: 'test event',
+      sessionTypeTitle: 'test type',
+      sessionDescription: 'test description',
+      name: 'test session',
       courseTitle: 'test course',
       startDate: now,
       endDate: now.clone().add(1, 'hour'),
       location: 'here',
       instructors: ['Great Teacher'],
-      offering: 1,
+      session: 1,
       learningMaterials: this.sessionLearningMaterials
     });
   });


### PR DESCRIPTION
Students don't have access to offering or ilmSession and we need to get
all event data from public endpoints.

- [x] Requires https://github.com/ilios/ilios/pull/2127