### PR TITLE
Fix hasMoreThanOneSchool property in calendar

### DIFF
--- a/addon/components/dashboard-calendar.js
+++ b/addon/components/dashboard-calendar.js
@@ -215,7 +215,7 @@ export default Component.extend({
   }),
 
   hasMoreThanOneSchool: computed('allSchools.[]', async function() {
-    const schools = await this.get('schools');
+    const schools = await this.get('allSchools');
     return (schools.length > 1);
   }),
 


### PR DESCRIPTION
This determines if we should show a dropdown school selector and needs
to look at the updated allSchools property.

Refs ilios/ilios#1511