### PR TITLE
Reload by default

### DIFF
--- a/addon/adapters/ilios.js
+++ b/addon/adapters/ilios.js
@@ -14,6 +14,8 @@ export default RESTAdapter.extend(DataAdapterMixin, {
 
   coalesceFindRequests: true,
 
+  shouldReloadAll() { return true; },
+
   findMany(store, type, ids, snapshots) {
     let url = this.urlForFindMany(ids, type.modelName, snapshots);
 


### PR DESCRIPTION
When we call store.findAll we don't want the cached results, we want all
the records. This ensures we will get them.