### PR TITLE
Fix role given to session instructors

### DIFF
--- a/addon/services/current-user.js
+++ b/addon/services/current-user.js
@@ -281,7 +281,7 @@ export default Service.extend({
       roles.pushObject('SESSION_ADMINISTRATOR');
     }
     if (await this.isTeachingSession(session)) {
-      roles.pushObject('COURSE_INSTRUCTOR');
+      roles.pushObject('SESSION_INSTRUCTOR');
     }
 
     return roles;


### PR DESCRIPTION
When someone is teaching in a session they get SESSION_INSTRUCTOR not
COURSE_INSTRUCTOR.  So it is written... so it must be done.

Fixes ilios/frontend#3780