### PR TITLE
Avoid loading unnecessary data

### DIFF
--- a/addon/services/current-user.js
+++ b/addon/services/current-user.js
@@ -238,85 +238,85 @@ export default Service.extend({
 
     return ids.includes(report.get('id'));
   },
-  async getRolesInSchool(school) {
+  async getRolesInSchool(school, rolesToCheck = []) {
     let roles = [];
-    if (await this.isDirectingSchool(school)) {
+    if (rolesToCheck.includes('SCHOOL_DIRECTOR') && await this.isDirectingSchool(school)) {
       roles.pushObject('SCHOOL_DIRECTOR');
     }
-    if (await this.isAdministeringSchool(school)) {
+    if (rolesToCheck.includes('SCHOOL_ADMINISTRATOR') && await this.isAdministeringSchool(school)) {
       roles.pushObject('SCHOOL_ADMINISTRATOR');
     }
-    if (await this.isDirectingProgramInSchool(school)) {
+    if (rolesToCheck.includes('PROGRAM_DIRECTOR') && await this.isDirectingProgramInSchool(school)) {
       roles.pushObject('PROGRAM_DIRECTOR');
     }
-    if (await this.isDirectingCourseInSchool(school)) {
+    if (rolesToCheck.includes('COURSE_DIRECTOR') && await this.isDirectingCourseInSchool(school)) {
       roles.pushObject('COURSE_DIRECTOR');
     }
-    if (await this.isAdministeringCourseInSchool(school)) {
+    if (rolesToCheck.includes('COURSE_ADMINISTRATOR') && await this.isAdministeringCourseInSchool(school)) {
       roles.pushObject('COURSE_ADMINISTRATOR');
     }
-    if (await this.isAdministeringSessionInSchool(school)) {
+    if (rolesToCheck.includes('SESSION_ADMINISTRATOR') && await this.isAdministeringSessionInSchool(school)) {
       roles.pushObject('SESSION_ADMINISTRATOR');
     }
-    if (await this.isTeachingCourseInSchool(school)) {
+    if (rolesToCheck.includes('COURSE_INSTRUCTOR') && await this.isTeachingCourseInSchool(school)) {
       roles.pushObject('COURSE_INSTRUCTOR');
     }
-    if (await this.isAdministeringCurriculumInventoryReportInSchool(school)) {
+    if (rolesToCheck.includes('CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR') && await this.isAdministeringCurriculumInventoryReportInSchool(school)) {
       roles.pushObject('CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR');
     }
 
     return roles;
   },
-  async getRolesInCourse(course) {
+  async getRolesInCourse(course, rolesToCheck = []) {
     let roles = [];
-    if (await this.isDirectingCourse(course)) {
+    if (rolesToCheck.includes('COURSE_DIRECTOR') && await this.isDirectingCourse(course)) {
       roles.pushObject('COURSE_DIRECTOR');
     }
-    if (await this.isAdministeringCourse(course)) {
+    if (rolesToCheck.includes('COURSE_ADMINISTRATOR') && await this.isAdministeringCourse(course)) {
       roles.pushObject('COURSE_ADMINISTRATOR');
     }
-    if (await this.isAdministeringSessionInCourse(course)) {
+    if (rolesToCheck.includes('SESSION_ADMINISTRATOR') && await this.isAdministeringSessionInCourse(course)) {
       roles.pushObject('SESSION_ADMINISTRATOR');
     }
-    if (await this.isTeachingCourse(course)) {
+    if (rolesToCheck.includes('COURSE_INSTRUCTOR') && await this.isTeachingCourse(course)) {
       roles.pushObject('COURSE_INSTRUCTOR');
     }
 
     return roles;
   },
-  async getRolesInSession(session) {
+  async getRolesInSession(session, rolesToCheck = []) {
     let roles = [];
-    if (await this.isAdministeringSession(session)) {
+    if (rolesToCheck.includes('SESSION_ADMINISTRATOR') && await this.isAdministeringSession(session)) {
       roles.pushObject('SESSION_ADMINISTRATOR');
     }
-    if (await this.isTeachingSession(session)) {
+    if (rolesToCheck.includes('SESSION_INSTRUCTOR') && await this.isTeachingSession(session)) {
       roles.pushObject('SESSION_INSTRUCTOR');
     }
 
     return roles;
   },
-  async getRolesInProgram(program) {
+  async getRolesInProgram(program, rolesToCheck = []) {
     let roles = [];
-    if (await this.isDirectingProgram(program)) {
+    if (rolesToCheck.includes('PROGRAM_DIRECTOR') && await this.isDirectingProgram(program)) {
       roles.pushObject('PROGRAM_DIRECTOR');
     }
-    if (await this.isDirectingProgramYearInProgram(program)) {
+    if (rolesToCheck.includes('PROGRAM_YEAR_DIRECTOR') && await this.isDirectingProgramYearInProgram(program)) {
       roles.pushObject('PROGRAM_YEAR_DIRECTOR');
     }
 
     return roles;
   },
-  async getRolesInProgramYear(programYear) {
+  async getRolesInProgramYear(programYear, rolesToCheck = []) {
     let roles = [];
-    if (await this.isDirectingProgramYear(programYear)) {
+    if (rolesToCheck.includes('PROGRAM_YEAR_DIRECTOR') && await this.isDirectingProgramYear(programYear)) {
       roles.pushObject('PROGRAM_YEAR_DIRECTOR');
     }
 
     return roles;
   },
-  async getRolesInCurriculumInventoryReport(report) {
+  async getRolesInCurriculumInventoryReport(report, rolesToCheck = []) {
     let roles = [];
-    if (await this.isAdministeringCurriculumInventoryReport(report)) {
+    if (rolesToCheck.includes('CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR') && await this.isAdministeringCurriculumInventoryReport(report)) {
       roles.pushObject('CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR');
     }
 

--- a/addon/services/permission-checker.js
+++ b/addon/services/permission-checker.js
@@ -11,7 +11,8 @@ export default Service.extend({
       return true;
     }
     const permissionMatrix = this.get('permissionMatrix');
-    const rolesInSchool = await currentUser.getRolesInSchool(school);
+    const rolesToCheck = await permissionMatrix.getPermittedRoles(school, capability);
+    const rolesInSchool = await currentUser.getRolesInSchool(school, rolesToCheck);
 
     return permissionMatrix.hasPermission(school, capability, rolesInSchool);
   },
@@ -22,12 +23,13 @@ export default Service.extend({
       return false;
     }
     const school = await course.get('school');
-
-    if (await this.canDoInSchool(school, 'CAN_UPDATE_ALL_COURSES')) {
+    const capability = 'CAN_UPDATE_ALL_COURSES';
+    if (await this.canDoInSchool(school, capability)) {
       return true;
     }
 
-    const rolesInCourse = await currentUser.getRolesInCourse(course);
+    const rolesToCheck = await permissionMatrix.getPermittedRoles(school, capability);
+    const rolesInCourse = await currentUser.getRolesInCourse(course, rolesToCheck);
     return await permissionMatrix.hasPermission(school, 'CAN_UPDATE_THEIR_COURSES', rolesInCourse);
   },
   async canUpdateAllCoursesInSchool(school) {
@@ -45,8 +47,10 @@ export default Service.extend({
       return true;
     }
 
-    const rolesInCourse = await currentUser.getRolesInCourse(course);
-    return await permissionMatrix.hasPermission(school, 'CAN_DELETE_THEIR_COURSES', rolesInCourse);
+    const capability = 'CAN_DELETE_THEIR_COURSES';
+    const rolesToCheck = await permissionMatrix.getPermittedRoles(school, capability);
+    const rolesInCourse = await currentUser.getRolesInCourse(course, rolesToCheck);
+    return await permissionMatrix.hasPermission(school, capability, rolesInCourse);
   },
   async canCreateCourse(school) {
     return this.canDoInSchool(school, 'CAN_CREATE_COURSES');
@@ -60,8 +64,10 @@ export default Service.extend({
       return true;
     }
 
-    const rolesInCourse = await currentUser.getRolesInCourse(course);
-    return await permissionMatrix.hasPermission(school, 'CAN_UNLOCK_THEIR_COURSES', rolesInCourse);
+    const capability = 'CAN_UNLOCK_THEIR_COURSES';
+    const rolesToCheck = await permissionMatrix.getPermittedRoles(school, capability);
+    const rolesInCourse = await currentUser.getRolesInCourse(course, rolesToCheck);
+    return await permissionMatrix.hasPermission(school, capability, rolesInCourse);
   },
   async canUpdateSession(session) {
     const currentUser = await this.get('currentUser');
@@ -78,8 +84,10 @@ export default Service.extend({
       return true;
     }
 
-    const rolesInSession = await currentUser.getRolesInSession(session);
-    if (await permissionMatrix.hasPermission(school, 'CAN_UPDATE_THEIR_SESSIONS', rolesInSession)) {
+    const capability = 'CAN_UPDATE_THEIR_SESSIONS';
+    const rolesToCheck = await permissionMatrix.getPermittedRoles(school, capability);
+    const rolesInSession = await currentUser.getRolesInSession(session, rolesToCheck);
+    if (await permissionMatrix.hasPermission(school, capability, rolesInSession)) {
       return true;
     }
 
@@ -100,8 +108,10 @@ export default Service.extend({
       return true;
     }
 
-    const rolesInSession = await currentUser.getRolesInSession(session);
-    if (await permissionMatrix.hasPermission(school, 'CAN_DELETE_THEIR_SESSIONS', rolesInSession)) {
+    const capability = 'CAN_DELETE_THEIR_SESSIONS';
+    const rolesToCheck = await permissionMatrix.getPermittedRoles(school, capability);
+    const rolesInSession = await currentUser.getRolesInSession(session, rolesToCheck);
+    if (await permissionMatrix.hasPermission(school, capability, rolesInSession)) {
       return true;
     }
 
@@ -162,8 +172,10 @@ export default Service.extend({
       return true;
     }
 
-    const rolesInProgram = await currentUser.getRolesInProgram(program);
-    return await permissionMatrix.hasPermission(school, 'CAN_UPDATE_THEIR_PROGRAMS', rolesInProgram);
+    const capability = 'CAN_UPDATE_THEIR_PROGRAMS';
+    const rolesToCheck = await permissionMatrix.getPermittedRoles(school, capability);
+    const rolesInProgram = await currentUser.getRolesInProgram(program, rolesToCheck);
+    return await permissionMatrix.hasPermission(school, capability, rolesInProgram);
   },
   async canDeleteProgram(program) {
     const currentUser = await this.get('currentUser');
@@ -173,8 +185,10 @@ export default Service.extend({
       return true;
     }
 
-    const rolesInProgram = await currentUser.getRolesInProgram(program);
-    return await permissionMatrix.hasPermission(school, 'CAN_DELETE_THEIR_PROGRAMS', rolesInProgram);
+    const capability = 'CAN_DELETE_THEIR_PROGRAMS';
+    const rolesToCheck = await permissionMatrix.getPermittedRoles(school, capability);
+    const rolesInProgram = await currentUser.getRolesInProgram(program, rolesToCheck);
+    return await permissionMatrix.hasPermission(school, capability, rolesInProgram);
   },
   async canCreateProgram(school) {
     return this.canDoInSchool(school, 'CAN_CREATE_PROGRAMS');
@@ -192,8 +206,11 @@ export default Service.extend({
     if (await this.canDoInSchool(school, 'CAN_UPDATE_ALL_PROGRAM_YEARS')) {
       return true;
     }
-    const rolesInProgramYear = await currentUser.getRolesInProgramYear(programYear);
-    if (await permissionMatrix.hasPermission(school, 'CAN_UPDATE_THEIR_PROGRAM_YEARS', rolesInProgramYear)) {
+
+    const capability = 'CAN_UPDATE_THEIR_PROGRAM_YEARS';
+    const rolesToCheck = await permissionMatrix.getPermittedRoles(school, capability);
+    const rolesInProgramYear = await currentUser.getRolesInProgramYear(programYear, rolesToCheck);
+    if (await permissionMatrix.hasPermission(school, capability, rolesInProgramYear)) {
       return true;
     }
 
@@ -212,8 +229,11 @@ export default Service.extend({
     if (await this.canDoInSchool(school, 'CAN_DELETE_ALL_PROGRAM_YEARS')) {
       return true;
     }
-    const rolesInProgramYear = await currentUser.getRolesInProgramYear(programYear);
-    if (await permissionMatrix.hasPermission(school, 'CAN_DELETE_THEIR_PROGRAM_YEARS', rolesInProgramYear)) {
+
+    const capability = 'CAN_DELETE_THEIR_PROGRAM_YEARS';
+    const rolesToCheck = await permissionMatrix.getPermittedRoles(school, capability);
+    const rolesInProgramYear = await currentUser.getRolesInProgramYear(programYear, rolesToCheck);
+    if (await permissionMatrix.hasPermission(school, capability, rolesInProgramYear)) {
       return true;
     }
 
@@ -234,8 +254,10 @@ export default Service.extend({
     if (await this.canDoInSchool(school, 'CAN_UNLOCK_ALL_PROGRAM_YEARS')) {
       return true;
     }
-    const rolesInProgramYear = await currentUser.getRolesInProgramYear(programYear);
-    if (await permissionMatrix.hasPermission(school, 'CAN_UNLOCK_THEIR_PROGRAM_YEARS', rolesInProgramYear)) {
+    const capability = 'CAN_UNLOCK_THEIR_PROGRAM_YEARS';
+    const rolesToCheck = await permissionMatrix.getPermittedRoles(school, capability);
+    const rolesInProgramYear = await currentUser.getRolesInProgramYear(programYear, rolesToCheck);
+    if (await permissionMatrix.hasPermission(school, capability, rolesInProgramYear)) {
       return true;
     }
 
@@ -328,9 +350,12 @@ export default Service.extend({
     if (await this.canDoInSchool(school, 'CAN_UPDATE_ALL_CURRICULUM_INVENTORY_REPORTS')) {
       return true;
     }
-    const rolesInReport = await currentUser.getRolesInCurriculumInventoryReport(curriculumInventoryReport);
 
-    return permissionMatrix.hasPermission(school, 'CAN_UPDATE_THEIR_CURRICULUM_INVENTORY_REPORTS', rolesInReport);
+    const capability = 'CAN_UPDATE_THEIR_CURRICULUM_INVENTORY_REPORTS';
+    const rolesToCheck = await permissionMatrix.getPermittedRoles(school, capability);
+    const rolesInReport = await currentUser.getRolesInCurriculumInventoryReport(curriculumInventoryReport, rolesToCheck);
+
+    return permissionMatrix.hasPermission(school, capability, rolesInReport);
   },
   async canDeleteCurriculumInventoryReport(curriculumInventoryReport) {
     const currentUser = await this.get('currentUser');
@@ -346,8 +371,10 @@ export default Service.extend({
       return true;
     }
 
-    const rolesInReport = await currentUser.getRolesInCurriculumInventoryReport(curriculumInventoryReport);
-    return permissionMatrix.hasPermission(school, 'CAN_DELETE_THEIR_CURRICULUM_INVENTORY_REPORTS', rolesInReport);
+    const capability = 'CAN_DELETE_THEIR_CURRICULUM_INVENTORY_REPORTS';
+    const rolesToCheck = await permissionMatrix.getPermittedRoles(school, capability);
+    const rolesInReport = await currentUser.getRolesInCurriculumInventoryReport(curriculumInventoryReport, rolesToCheck);
+    return permissionMatrix.hasPermission(school, capability, rolesInReport);
   },
   async canCreateCurriculumInventoryReport(school) {
     return this.canDoInSchool(school, 'CAN_CREATE_CURRICULUM_INVENTORY_REPORTS');

--- a/addon/services/permission-matrix.js
+++ b/addon/services/permission-matrix.js
@@ -254,4 +254,17 @@ export default Service.extend({
 
     return matchedRoles.length > 0;
   },
+  async getPermittedRoles(school, capability) {
+    const matrix = await this.get('permissionMatrix');
+    const schoolId = school.get('id');
+    if (!matrix.hasOwnProperty(schoolId)) {
+      return [];
+    }
+    const schoolMatrix = matrix[schoolId];
+    if (!schoolMatrix.hasOwnProperty(capability)) {
+      return [];
+    }
+
+    return schoolMatrix[capability];
+  },
 });


### PR DESCRIPTION
By pre-selecting which roles we are actually searching for we can avoid
loading data that we don't need. This can speed up checking
significantly in some situations.