### PR TITLE
Specify which files to publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,5 +75,14 @@
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"
-  }
+  },
+  "files": [
+    "index.js",
+    "ember-cli-build.js",
+    "addon/",
+    "app/",
+    "blueprints/",
+    "config/",
+    "vendor/"
+  ]
 }


### PR DESCRIPTION
Prevents publishing things we don't really want to expose to the world
or things that just bloat the package.