### PR TITLE
Better definition for computed property

### DIFF
--- a/addon/models/offering.js
+++ b/addon/models/offering.js
@@ -70,7 +70,7 @@ export default Model.extend({
    * @property allInstructors
    * @type {Ember.computed}
    */
-  allInstructors: computed('instructors.[]', 'instructorGroups.[]', async function(){
+  allInstructors: computed('instructors.[]', 'instructorGroups.@each.users', async function(){
     const instructorGroups = await this.get('instructorGroups');
     const instructors = await this.get('instructors');
     const instructorsInInstructorGroups = await all(instructorGroups.mapBy('users'));


### PR DESCRIPTION
We need to specifically track this second level array, it works
correctly in ember data 3.2+ and the old definition did not.