### PR TITLE
Add pre/post requisite to session model

### DIFF
--- a/addon/models/session.js
+++ b/addon/models/session.js
@@ -32,6 +32,14 @@ export default Model.extend(PublishableModel, CategorizableModel, SortableByPosi
     async: true,
     inverse: 'administeredSessions'
   }),
+  postrequisite: belongsTo('session', {
+    inverse: 'prerequisites',
+    async: true
+  }),
+  prerequisites: hasMany('session', {
+    inverse: 'postrequisite',
+    async: true
+  }),
   offeringLearnerGroups: mapBy('offerings', 'learnerGroups'),
   offeringLearnerGroupsLength: mapBy('offeringLearnerGroups', 'length'),
   learnerGroupCount: sum('offeringLearnerGroupsLength'),


### PR DESCRIPTION
This is available in the API at version 1.34 .