### PR TITLE
Make z-index reasonable

### DIFF
--- a/app/styles/ilios-common/mixins/ilios-input.scss
+++ b/app/styles/ilios-common/mixins/ilios-input.scss
@@ -10,7 +10,7 @@ $form-input-text-types: 'input[type="text"], input[type="password"], input[type=
   font-style: italic;
   min-width: 220px;
   overflow: show;
-  z-index: 100;
+  z-index: 5;
 
   #{$form-input-text-types} {
     background-position: right 4px bottom .75em;


### PR DESCRIPTION
The 100 value makes inputs cut through modals. They are important, but
not that important. Set it to 5 instead.

Fixes ilios/frontend#4021