### PR TITLE
Remove light table dependencies

### DIFF
--- a/addon/breakpoints.js
+++ b/addon/breakpoints.js
@@ -1,6 +1,0 @@
-export default {
-  smallScreen:  '(max-width: 320px)',
-  mediumScreen:  '(min-width: 321px) and (max-width: 640px)',
-  largeScreen:  '(min-width: 641px) and (max-width: 860px)',
-  giantScreen: '(min-width: 861px)'
-};

--- a/addon/components/removable-row.js
+++ b/addon/components/removable-row.js
@@ -1,5 +1,0 @@
-import Row from 'ember-light-table/components/lt-row';
-
-export default Row.extend({
-  classNameBindings: ['row.confirmDelete:confirm-removal'],
-});

--- a/app/components/removable-row.js
+++ b/app/components/removable-row.js
@@ -1,1 +1,0 @@
-export { default } from 'ilios-common/components/removable-row';

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "ember-one-way-select": "^4.0.0",
     "ember-pikaday": "^2.2.6",
     "ember-promise-helpers": "^1.0.6",
-    "ember-responsive": "^3.0.0-beta.3",
     "ember-rl-dropdown": "^0.10.2",
     "ember-simple-auth-token": "^4.0.4",
     "ember-simple-charts": "^0.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4685,13 +4685,6 @@ ember-resolver@^5.0.1:
     ember-cli-version-checker "^2.0.0"
     resolve "^1.3.3"
 
-ember-responsive@^3.0.0-beta.3:
-  version "3.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/ember-responsive/-/ember-responsive-3.0.0-beta.3.tgz#63f4f5cad179399e40cd6a591bb2677c4cc0a874"
-  integrity sha512-C7E0C/hKy5BT5tjHxzyLItc7Bq/Ci/IoUucQ1OQts81Uxq0SG4srjbfO0ZlDq6nbV7xxe9xdPMPD5tPHii8W2w==
-  dependencies:
-    ember-cli-babel "^6.6.0"
-
 ember-rfc176-data@^0.3.3, ember-rfc176-data@^0.3.5:
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.5.tgz#f630e550572c81a5e5c7220f864c0f06eee9e977"


### PR DESCRIPTION
We were only using this for light table and we're not using that
anymore.