### PR TITLE
Fix the rebuilding of the addon-test-support directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,8 +59,10 @@ module.exports = {
     // so that can have our `import`'s be
     // import { ... } from 'ilios-common';
 
-    return this.preprocessJs(tree, '/', this.name, {
-      registry: this.registry,
-    });
+    if (tree) {
+      return this.preprocessJs(tree, '/', this.name, {
+        registry: this.registry,
+      });
+    }
   },
 };


### PR DESCRIPTION
When this was included in ilios/frontend this hook gets called with no
tree, since we wouldn't actually want to modify the tree in that case we
can just move on.