### PR TITLE
Skip canary tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,8 +44,6 @@ jobs:
       env: EMBER_TRY_SCENARIO=ember-release
     - stage: "Additional Tests - Ember Beta"
       env: EMBER_TRY_SCENARIO=ember-beta
-    - stage: "Additional Tests - Ember Canary"
-      env: EMBER_TRY_SCENARIO=ember-canary
     - stage: "Additional Tests - Ember Default with jQuery"
       env: EMBER_TRY_SCENARIO=ember-default-with-jquery
 


### PR DESCRIPTION
Ember Canary tests are slowing down our builds right now, they run
forever and don't pass.  Let's skip them for now.