### PR TITLE
Don't greenkeeper ember-qunit

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
       "ember-cli-htmlbars-inline-precompile",
       "ember-cli-htmlbars",
       "ember-cli-inject-live-reload",
-      "ember-cli-qunit",
+      "ember-qunit",
       "ember-cli-sri",
       "ember-cli-uglify",
       "ember-export-application-global",


### PR DESCRIPTION
When we updated ember-cli it changed the dependency from ember-cli-qunit
to ember-qunit, but this lock didn't get changed at the same time.

Refs #342