### PR TITLE
Extract error capture configuration into config

### DIFF
--- a/addon/services/ilios-config.js
+++ b/addon/services/ilios-config.js
@@ -72,4 +72,14 @@ export default Service.extend({
     }
     return '';
   }),
+
+  errorCaptureEnabled: computed('serverVariables.errorCaptureEnabled', function(){
+    const serverVariables = this.get('serverVariables');
+    const errorCaptureEnabled = serverVariables.get('errorCaptureEnabled');
+    if (typeof errorCaptureEnabled === 'boolean') {
+      return errorCaptureEnabled;
+    }
+
+    return errorCaptureEnabled === 'true';
+  }),
 });


### PR DESCRIPTION
This is provided in the index.html file by server variables, but is
accessed through the IliosConfig like all other configuration.