### PR TITLE
Add a noop import for mirage config

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const Funnel = require('broccoli-funnel');
 const MergeTrees = require('broccoli-merge-trees');
 const path = require('path');
+const WriteFile = require('broccoli-file-creator');
 
 module.exports = {
   name: require('./package').name,
@@ -49,6 +50,11 @@ module.exports = {
     if (this.app.env && ['test', 'development'].includes(this.app.env)) {
       const mirageDir = path.join(__dirname, 'addon-mirage-support');
       const mirageTree = new Funnel(mirageDir, { destDir: 'mirage' });
+      trees.push(mirageTree);
+    } else {
+      //add a noop export for production builds
+      const noopTree = WriteFile('setup.js', 'export default function(){};');
+      const mirageTree = new Funnel(noopTree, { destDir: 'mirage' });
       trees.push(mirageTree);
     }
     return MergeTrees(trees);

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@fortawesome/pro-light-svg-icons": "^5.1.0",
     "@fortawesome/pro-regular-svg-icons": "^5.1.0",
     "@fortawesome/pro-solid-svg-icons": "^5.1.0",
+    "broccoli-file-creator": "^2.1.1",
     "broccoli-funnel": "^2.0.1",
     "broccoli-merge-trees": "^3.0.1",
     "elemental-calendar": "^0.1.0",


### PR DESCRIPTION
Mirage removed the config.js file in the app in production environments,
but in 'preview' it isn't removed and the import fails because the
setup.js file doesn't exist. This created a minimal fake setup.js file
that can be imported, but does nothing.