### PR TITLE
Display Prerequisite Events

### DIFF
--- a/addon-mirage-support/factories/schoolevent.js
+++ b/addon-mirage-support/factories/schoolevent.js
@@ -5,6 +5,8 @@ export default Factory.extend({
   name:  (i) => `event ${i}`,
   isPublished: false,
   isScheduled: false,
+  sessionObjectives: [],
+  courseObjectives: [],
   prerequisites: [],
   postrequisites: [],
 });

--- a/addon-mirage-support/factories/schoolevent.js
+++ b/addon-mirage-support/factories/schoolevent.js
@@ -1,7 +1,10 @@
+/* eslint ember/avoid-leaking-state-in-ember-objects: 0 */
 import { Factory } from 'ember-cli-mirage';
 
 export default Factory.extend({
   name:  (i) => `event ${i}`,
   isPublished: false,
   isScheduled: false,
+  prerequisites: [],
+  postrequisites: [],
 });

--- a/addon-mirage-support/factories/userevent.js
+++ b/addon-mirage-support/factories/userevent.js
@@ -5,6 +5,8 @@ export default Factory.extend({
   name:  (i) => `event ${i}`,
   isPublished: false,
   isScheduled: false,
+  sessionObjectives: [],
+  courseObjectives: [],
   prerequisites: [],
   postrequisites: [],
 });

--- a/addon-mirage-support/factories/userevent.js
+++ b/addon-mirage-support/factories/userevent.js
@@ -1,7 +1,10 @@
+/* eslint ember/avoid-leaking-state-in-ember-objects: 0 */
 import { Factory } from 'ember-cli-mirage';
 
 export default Factory.extend({
   name:  (i) => `event ${i}`,
   isPublished: false,
-  isScheduled: false
+  isScheduled: false,
+  prerequisites: [],
+  postrequisites: [],
 });

--- a/addon-test-support/ilios-common/page-objects/components/dashboard-week.js
+++ b/addon-test-support/ilios-common/page-objects/components/dashboard-week.js
@@ -1,0 +1,14 @@
+import {
+  create,
+  text
+} from 'ember-cli-page-object';
+import weekGlance from './week-glance';
+
+const definition = {
+  scope: '[data-test-dashboard-week]',
+  weeklyLink: text('[data-test-weekly-link] a'),
+  weekGlance,
+};
+
+export default definition;
+export const component = create(definition);

--- a/addon-test-support/ilios-common/page-objects/components/ilios-calendar-pre-work-event.js
+++ b/addon-test-support/ilios-common/page-objects/components/ilios-calendar-pre-work-event.js
@@ -1,0 +1,16 @@
+import {
+  attribute,
+  create,
+  text
+} from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-ilios-calendar-pre-work-event]',
+  title: text('[data-test-event-title]'),
+  titleUrl: attribute('href', '[data-test-event-title] a'),
+  date: text('[data-test-date]'),
+  url: attribute('href', '[data-test-date] a'),
+};
+
+export default definition;
+export const component = create(definition);

--- a/addon-test-support/ilios-common/page-objects/components/single-event.js
+++ b/addon-test-support/ilios-common/page-objects/components/single-event.js
@@ -1,4 +1,5 @@
 import {
+  attribute,
   create,
   collection,
   isPresent,
@@ -9,6 +10,7 @@ const definition = {
   scope: '[data-test-single-event]',
   title: text('[data-test-title]'),
   offeredAt: text('[data-test-offered-at]'),
+  offeredAtLink: attribute('href', '[data-test-offered-at] a'),
   preWork: collection('[data-test-pre-work] li', {
     title: text(),
     hasLink: isPresent('a'),

--- a/addon-test-support/ilios-common/page-objects/components/single-event.js
+++ b/addon-test-support/ilios-common/page-objects/components/single-event.js
@@ -1,0 +1,13 @@
+import {
+  create,
+  text
+} from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-single-event]',
+  title: text('[data-test-title]'),
+  offeredAt: text('[data-test-offered-at]'),
+};
+
+export default definition;
+export const component = create(definition);

--- a/addon-test-support/ilios-common/page-objects/components/single-event.js
+++ b/addon-test-support/ilios-common/page-objects/components/single-event.js
@@ -1,5 +1,7 @@
 import {
   create,
+  collection,
+  isPresent,
   text
 } from 'ember-cli-page-object';
 
@@ -7,6 +9,10 @@ const definition = {
   scope: '[data-test-single-event]',
   title: text('[data-test-title]'),
   offeredAt: text('[data-test-offered-at]'),
+  preWork: collection('[data-test-pre-work] li', {
+    title: text(),
+    hasLink: isPresent('a'),
+  }),
 };
 
 export default definition;

--- a/addon-test-support/ilios-common/page-objects/components/week-glance-event.js
+++ b/addon-test-support/ilios-common/page-objects/components/week-glance-event.js
@@ -34,6 +34,10 @@ const definition = {
     url: attribute('href', '[data-test-material-title]'),
     timedReleaseInfo: text('[data-test-time-release-info]'),
   }),
+  preWork: collection('[data-test-pre-work] li', {
+    title: text(),
+    hasLink: isPresent('a'),
+  }),
 };
 
 export default definition;

--- a/addon-test-support/ilios-common/page-objects/components/week-glance-event.js
+++ b/addon-test-support/ilios-common/page-objects/components/week-glance-event.js
@@ -1,0 +1,40 @@
+import {
+  attribute,
+  collection,
+  create,
+  hasClass,
+  isPresent,
+  text
+} from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-week-glance-event]',
+  title: text('[data-test-event-title]'),
+  date: text('[data-test-date]'),
+  sessionType: text('[data-test-session-type]'),
+  location: text('[data-test-location]'),
+  hasDescription: isPresent('[data-test-description]'),
+  description: text('[data-test-description]'),
+  sessionAttributes: collection('[data-test-session-attributes] svg', {
+    attire: hasClass('fa-black-tie'),
+    equipment: hasClass('fa-flask'),
+    attendance: hasClass('fa-calendar-check'),
+    supplemental: hasClass('fa-calendar-minus'),
+  }),
+  hasInstructors: isPresent('[data-test-instructors]'),
+  instructors: text('[data-test-instructors]'),
+  learningMaterials: collection('[data-test-learning-materials] [data-test-learning-material]', {
+    title: text('[data-test-material-title]'),
+    hasTypeIcon: isPresent('[data-test-lm-type-icon] svg'),
+    typeIconTitle: text('[data-test-lm-type-icon]'),
+    hasPublicNotes: isPresent('[data-test-public-notes]'),
+    publicNotes: text('[data-test-public-notes]'),
+    hasCitation: isPresent('[data-test-citation]'),
+    citation: text('[data-test-citation]'),
+    url: attribute('href', '[data-test-material-title]'),
+    timedReleaseInfo: text('[data-test-time-release-info]'),
+  }),
+};
+
+export default definition;
+export const component = create(definition);

--- a/addon-test-support/ilios-common/page-objects/components/week-glance-pre-work.js
+++ b/addon-test-support/ilios-common/page-objects/components/week-glance-pre-work.js
@@ -1,0 +1,13 @@
+import {
+  create,
+  text
+} from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-week-glance-pre-work]',
+  title: text('[data-test-event-title]'),
+  date: text('[data-test-date]'),
+};
+
+export default definition;
+export const component = create(definition);

--- a/addon-test-support/ilios-common/page-objects/components/week-glance-pre-work.js
+++ b/addon-test-support/ilios-common/page-objects/components/week-glance-pre-work.js
@@ -1,4 +1,5 @@
 import {
+  attribute,
   create,
   text
 } from 'ember-cli-page-object';
@@ -7,6 +8,7 @@ const definition = {
   scope: '[data-test-week-glance-pre-work]',
   title: text('[data-test-event-title]'),
   date: text('[data-test-date]'),
+  url: attribute('href', '[data-test-date] a'),
 };
 
 export default definition;

--- a/addon-test-support/ilios-common/page-objects/components/week-glance.js
+++ b/addon-test-support/ilios-common/page-objects/components/week-glance.js
@@ -8,7 +8,7 @@ import weekGlanceEvent from './week-glance-event';
 const definition = {
   scope: '[data-test-week-glance]',
   title: text('[data-test-week-title]'),
-  offeringEvents: collection('[data-test-offering-events] [data-test-week-glance-event]', weekGlanceEvent),
+  offeringEvents: collection('[data-test-week-glance-event]', weekGlanceEvent),
   ilmEvents: collection('[data-test-ilm-events] [data-test-week-glance-event]', weekGlanceEvent),
 };
 

--- a/addon-test-support/ilios-common/page-objects/components/week-glance.js
+++ b/addon-test-support/ilios-common/page-objects/components/week-glance.js
@@ -1,0 +1,16 @@
+import {
+  collection,
+  create,
+  text
+} from 'ember-cli-page-object';
+import weekGlanceEvent from './week-glance-event';
+
+const definition = {
+  scope: '[data-test-week-glance]',
+  title: text('[data-test-week-title]'),
+  offeringEvents: collection('[data-test-offering-events] [data-test-week-glance-event]', weekGlanceEvent),
+  ilmEvents: collection('[data-test-ilm-events] [data-test-week-glance-event]', weekGlanceEvent),
+};
+
+export default definition;
+export const component = create(definition);

--- a/addon/components/dashboard-week.js
+++ b/addon/components/dashboard-week.js
@@ -6,6 +6,7 @@ import moment from 'moment';
 export default Component.extend({
   layout,
   classNames: ['dashboard-week'],
+  'data-test-dashboard-week': true,
   expanded: computed(function(){
     const lastSunday = moment().day(1).subtract(1, 'week').format('W');
     const thisSunday = moment().day(1).format('W');

--- a/addon/components/ilios-calendar-day.js
+++ b/addon/components/ilios-calendar-day.js
@@ -15,8 +15,23 @@ export default Component.extend({
       this.$(".el-calendar .week").scrollTop(500);
     });
   },
-  singleDayEvents: computed('calendarEvents.[]', function(){
-    const events = this.get('calendarEvents');
+  ilmPreWorkEvents: computed('calendarEvents.[]', function () {
+    const calendarEvents = this.calendarEvents || [];
+    const preWork =  calendarEvents.reduce((arr, eventObject) => {
+      return arr.pushObjects(eventObject.prerequisites);
+    }, []);
+
+    return preWork.filter(ev => ev.ilmSession);
+  }),
+
+  nonIlmPreWorkEvents: computed('calendarEvents.[]', function () {
+    const calendarEvents = this.calendarEvents || [];
+    return calendarEvents.filter(ev => {
+      return ev.postrequisites.length === 0 && !ev.ilmSession;
+    });
+  }),
+  singleDayEvents: computed('nonIlmPreWorkEvents.[]', function(){
+    const events = this.get('nonIlmPreWorkEvents');
     if(isEmpty(events)){
       return [];
     }
@@ -24,8 +39,8 @@ export default Component.extend({
       event => moment(event.startDate).isSame(moment(event.endDate), 'day')
     );
   }),
-  multiDayEventsList: computed('calendarEvents.[]', function(){
-    const events = this.get('calendarEvents');
+  multiDayEvents: computed('nonIlmPreWorkEvents.[]', function(){
+    const events = this.get('nonIlmPreWorkEvents');
     if(isEmpty(events)){
       return [];
     }

--- a/addon/components/ilios-calendar-month.js
+++ b/addon/components/ilios-calendar-month.js
@@ -1,4 +1,5 @@
 import Component from '@ember/component';
+import { computed } from '@ember/object';
 import layout from '../templates/components/ilios-calendar-month';
 
 export default Component.extend({
@@ -7,6 +8,21 @@ export default Component.extend({
   date: null,
   calendarEvents: null,
   showMore: null,
+  ilmPreWorkEvents: computed('calendarEvents.[]', function () {
+    const calendarEvents = this.calendarEvents || [];
+    const preWork =  calendarEvents.reduce((arr, eventObject) => {
+      return arr.pushObjects(eventObject.prerequisites);
+    }, []);
+
+    return preWork.filter(ev => ev.ilmSession);
+  }),
+
+  nonIlmPreWorkEvents: computed('calendarEvents.[]', function () {
+    const calendarEvents = this.calendarEvents || [];
+    return calendarEvents.filter(ev => {
+      return ev.postrequisites.length === 0 && !ev.ilmSession;
+    });
+  }),
   actions: {
     changeToDayView(date){
       this.get('changeDate')(date);

--- a/addon/components/ilios-calendar-pre-work-event.js
+++ b/addon/components/ilios-calendar-pre-work-event.js
@@ -1,0 +1,13 @@
+import Component from '@ember/component';
+import { inject as service } from '@ember/service';
+import layout from '../templates/components/ilios-calendar-pre-work-event';
+import { computed } from '@ember/object';
+
+export default Component.extend({
+  layout,
+  router: service(),
+  tagName: '',
+  postrequisiteLink: computed('event.postrequisiteSlug', function () {
+    return this.router.urlFor('events', this.event.postrequisiteSlug);
+  }),
+});

--- a/addon/components/ilios-calendar-pre-work-events.js
+++ b/addon/components/ilios-calendar-pre-work-events.js
@@ -1,0 +1,8 @@
+import Component from '@ember/component';
+import layout from '../templates/components/ilios-calendar-pre-work-events';
+
+export default Component.extend({
+  layout,
+  events: null,
+  tagName: '',
+});

--- a/addon/components/ilios-calendar-week.js
+++ b/addon/components/ilios-calendar-week.js
@@ -20,8 +20,23 @@ export default Component.extend({
       this.$(".el-calendar .week").scrollTop(500);
     });
   },
-  singleDayEvents: computed('calendarEvents.[]', function(){
-    const events = this.get('calendarEvents');
+  ilmPreWorkEvents: computed('calendarEvents.[]', function () {
+    const calendarEvents = this.calendarEvents || [];
+    const preWork =  calendarEvents.reduce((arr, eventObject) => {
+      return arr.pushObjects(eventObject.prerequisites);
+    }, []);
+
+    return preWork.filter(ev => ev.ilmSession);
+  }),
+
+  nonIlmPreWorkEvents: computed('calendarEvents.[]', function () {
+    const calendarEvents = this.calendarEvents || [];
+    return calendarEvents.filter(ev => {
+      return ev.postrequisites.length === 0 && !ev.ilmSession;
+    });
+  }),
+  singleDayEvents: computed('nonIlmPreWorkEvents.[]', function(){
+    const events = this.get('nonIlmPreWorkEvents');
     if(isEmpty(events)){
       return [];
     }
@@ -29,8 +44,8 @@ export default Component.extend({
       event => moment(event.startDate).isSame(moment(event.endDate), 'day')
     );
   }),
-  multiDayEventsList: computed('calendarEvents.[]', function(){
-    const events = this.get('calendarEvents');
+  multiDayEventsList: computed('nonIlmPreWorkEvents.[]', function(){
+    const events = this.get('nonIlmPreWorkEvents');
     if(isEmpty(events)){
       return [];
     }

--- a/addon/components/lm-type-icon.js
+++ b/addon/components/lm-type-icon.js
@@ -9,6 +9,7 @@ export default Component.extend({
   mimetype: null,
   tagName: 'span',
   classNames: ['lm-type-icon'],
+  'data-test-lm-type-icon': true,
   icon: computed('type', 'mimetype', function() {
     let type = this.get('type');
     let mimetype = this.get('mimetype') || '';

--- a/addon/components/single-event.js
+++ b/addon/components/single-event.js
@@ -9,6 +9,7 @@ export default Component.extend({
   layout,
   store: service(),
   intl: service(),
+  router: service(),
   event: null,
   classNames: ['single-event'],
   'data-test-single-event': true,
@@ -168,14 +169,9 @@ export default Component.extend({
     return daysSinceLastUpdate < 6;
   }),
 
-  offeredAt: computed('intl.locale', 'event.startDate', 'event.ilmSession', 'event.postrequisites', function(){
-    const intl = this.get('intl');
-    const event = this.get('event');
-    if (event.postrequisites.length) {
-      const postreq = event.postrequisites[0];
-      return intl.t('general.dueBefore', { name: postreq.name, date: moment(postreq.startDate).format("dddd, MMMM Do YYYY, h:mm a") });
-    } else {
-      return intl.t('general.offeredAt', { date: moment(event.startDate).format("dddd, MMMM Do YYYY, h:mm a") });
+  postrequisiteLink: computed('event.postrequisiteSlug', function(){
+    if (this.event.postrequisites.length) {
+      return this.router.urlFor('events', this.event.postrequisites[0].slug);
     }
   }),
 

--- a/addon/components/single-event.js
+++ b/addon/components/single-event.js
@@ -11,6 +11,7 @@ export default Component.extend({
   intl: service(),
   event: null,
   classNames: ['single-event'],
+  'data-test-single-event': true,
 
   taughtBy: computed('intl.locale', 'event.instructors', function(){
     const instructors = this.get('event.instructors');
@@ -165,6 +166,17 @@ export default Component.extend({
     const today = moment();
     const daysSinceLastUpdate = today.diff(lastModifiedDate, 'days');
     return daysSinceLastUpdate < 6;
+  }),
+
+  offeredAt: computed('intl.locale', 'event.startDate', 'event.ilmSession', 'event.postrequisites', function(){
+    const intl = this.get('intl');
+    const event = this.get('event');
+    if (event.postrequisites.length) {
+      const postreq = event.postrequisites[0];
+      return intl.t('general.dueBefore', { name: postreq.name, date: moment(postreq.startDate).format("dddd, MMMM Do YYYY, h:mm a") });
+    } else {
+      return intl.t('general.offeredAt', { date: moment(event.startDate).format("dddd, MMMM Do YYYY, h:mm a") });
+    }
   }),
 
   /**

--- a/addon/components/week-glance-event.js
+++ b/addon/components/week-glance-event.js
@@ -1,0 +1,12 @@
+import Component from '@ember/component';
+import layout from '../templates/components/week-glance-event';
+
+export default Component.extend({
+  layout,
+  tagName: '',
+  actions: {
+    sortString(a, b){
+      return a.localeCompare(b);
+    }
+  }
+});

--- a/addon/components/week-glance-pre-work.js
+++ b/addon/components/week-glance-pre-work.js
@@ -1,9 +1,7 @@
 import Component from '@ember/component';
-import { inject as service } from '@ember/service';
 import layout from '../templates/components/week-glance-pre-work';
 
 export default Component.extend({
   layout,
-  router: service(),
   tagName: ''
 });

--- a/addon/components/week-glance-pre-work.js
+++ b/addon/components/week-glance-pre-work.js
@@ -1,7 +1,9 @@
 import Component from '@ember/component';
+import { inject as service } from '@ember/service';
 import layout from '../templates/components/week-glance-pre-work';
 
 export default Component.extend({
   layout,
+  router: service(),
   tagName: ''
 });

--- a/addon/components/week-glance-pre-work.js
+++ b/addon/components/week-glance-pre-work.js
@@ -1,0 +1,7 @@
+import Component from '@ember/component';
+import layout from '../templates/components/week-glance-pre-work';
+
+export default Component.extend({
+  layout,
+  tagName: ''
+});

--- a/addon/components/week-glance.js
+++ b/addon/components/week-glance.js
@@ -84,4 +84,11 @@ export default Component.extend({
 
     return preWork.filter(ev => ev.ilmSession);
   }),
+
+  nonIlmPreWorkEvents: computed('publishedWeekEvents.[]', async function () {
+    const publishedWeekEvents = await this.get('publishedWeekEvents');
+    return publishedWeekEvents.filter(ev => {
+      return ev.postrequisites.length === 0 && !ev.ilmSession;
+    });
+  }),
 });

--- a/addon/components/week-glance.js
+++ b/addon/components/week-glance.js
@@ -75,4 +75,13 @@ export default Component.extend({
       return !ev.isBlanked && ev.isPublished && !ev.isScheduled;
     });
   }),
+
+  ilmPreWork: computed('publishedWeekEvents.[]', async function () {
+    const publishedWeekEvents = await this.get('publishedWeekEvents');
+    const preWork =  publishedWeekEvents.reduce((arr, eventObject) => {
+      return arr.pushObjects(eventObject.prerequisites);
+    }, []);
+
+    return preWork.filter(ev => ev.ilmSession);
+  }),
 });

--- a/addon/components/week-glance.js
+++ b/addon/components/week-glance.js
@@ -75,14 +75,4 @@ export default Component.extend({
       return !ev.isBlanked && ev.isPublished && !ev.isScheduled;
     });
   }),
-
-  ilmEvents: computed('publishedWeekEvents', async function () {
-    const events = await this.get('publishedWeekEvents');
-    return events.filter(ev => ('ilmSession' in ev));
-  }),
-
-  offeringEvents: computed('publishedWeekEvents', async function () {
-    const events = await this.get('publishedWeekEvents');
-    return events.filter(ev => ('offering' in ev));
-  }),
 });

--- a/addon/components/week-glance.js
+++ b/addon/components/week-glance.js
@@ -19,7 +19,7 @@ export default Component.extend({
   collapsible: true,
   collapsed: true,
   showFullTitle: false,
-
+  'data-test-week-glance': true,
   midnightAtTheStartOfThisWeek: computed('intl.locale', 'year', 'week', 'startOfWeek', function(){
     this.get('intl'); //we need to use the service so the CP will re-fire
     const year = this.get('year');
@@ -75,9 +75,14 @@ export default Component.extend({
       return !ev.isBlanked && ev.isPublished && !ev.isScheduled;
     });
   }),
-  actions: {
-    sortString(a, b){
-      return a.localeCompare(b);
-    }
-  }
+
+  ilmEvents: computed('publishedWeekEvents', async function () {
+    const events = await this.get('publishedWeekEvents');
+    return events.filter(ev => ('ilmSession' in ev));
+  }),
+
+  offeringEvents: computed('publishedWeekEvents', async function () {
+    const events = await this.get('publishedWeekEvents');
+    return events.filter(ev => ('offering' in ev));
+  }),
 });

--- a/addon/mixins/events.js
+++ b/addon/mixins/events.js
@@ -91,4 +91,26 @@ export default Mixin.create({
     const cohorts = await course.get('cohorts');
     return cohorts.toArray().mapBy('id');
   },
+
+  /**
+   * Parses event and does some transformation
+   * @method getEventForSlug
+   * @param {String} slug
+   * @return {Promise.<Object>}
+   */
+  createEventFromData(obj) {
+    obj.isBlanked = !obj.offering && !obj.ilmSession;
+    obj.slug = this.getSlugForEvent(obj);
+    obj.prerequisites = obj.prerequisites.map(prereq => {
+      const rhett = this.createEventFromData(prereq);
+      rhett.startDate = obj.startDate;
+      rhett.postrequisiteName = obj.name;
+      rhett.postrequisiteSlug = obj.slug;
+
+      return rhett;
+    }).sortBy('startDate', 'name');
+    obj.postrequisites = obj.postrequisites.map(postreq => this.createEventFromData(postreq)).sortBy('startDate', 'name');
+
+    return obj;
+  },
 });

--- a/addon/services/school-events.js
+++ b/addon/services/school-events.js
@@ -31,10 +31,7 @@ export default Service.extend(EventMixin, {
     const commonAjax = this.get('commonAjax');
     const data = await commonAjax.request(url);
 
-    return data.events.map(event => {
-      event.slug = this.getSlugForEvent(event);
-      return event;
-    }).sortBy('startDate');
+    return data.events.map(obj => this.createEventFromData(obj)).sortBy('startDate', 'name');
   },
 
   /**

--- a/addon/services/user-events.js
+++ b/addon/services/user-events.js
@@ -38,29 +38,6 @@ export default Service.extend(EventMixin, {
     return data.userEvents.map(obj => this.createEventFromData(obj)).sortBy('startDate', 'name');
   },
 
-
-
-  /**
-   * Parses event and does some transformation
-   * @method getEventForSlug
-   * @param {String} slug
-   * @return {Promise.<Object>}
-   */
-  createEventFromData(obj) {
-    obj.isBlanked = !obj.offering && !obj.ilmSession;
-    obj.slug = this.getSlugForEvent(obj);
-    obj.prerequisites = obj.prerequisites.map(prereq => {
-      const rhett = this.createEventFromData(prereq);
-      rhett.startDate = obj.startDate;
-      rhett.postrequisiteName = obj.name;
-
-      return rhett;
-    }).sortBy('startDate', 'name');
-    obj.postrequisites = obj.postrequisites.map(postreq => this.createEventFromData(postreq)).sortBy('startDate', 'name');
-
-    return obj;
-  },
-
   /**
    * Retrieves and event by it's given slug.
    * @method getEventForSlug

--- a/addon/services/user-events.js
+++ b/addon/services/user-events.js
@@ -49,7 +49,13 @@ export default Service.extend(EventMixin, {
   createEventFromData(obj) {
     obj.isBlanked = !obj.offering && !obj.ilmSession;
     obj.slug = this.getSlugForEvent(obj);
-    obj.prerequisites = obj.prerequisites.map(prereq => this.createEventFromData(prereq)).sortBy('startDate', 'name');
+    obj.prerequisites = obj.prerequisites.map(prereq => {
+      const rhett = this.createEventFromData(prereq);
+      rhett.startDate = obj.startDate;
+      rhett.postrequisiteName = obj.name;
+
+      return rhett;
+    }).sortBy('startDate', 'name');
     obj.postrequisites = obj.postrequisites.map(postreq => this.createEventFromData(postreq)).sortBy('startDate', 'name');
 
     return obj;

--- a/addon/services/user-events.js
+++ b/addon/services/user-events.js
@@ -41,7 +41,7 @@ export default Service.extend(EventMixin, {
 
 
   /**
-   * Retrieves and event by it's given slug.
+   * Parses event and does some transformation
    * @method getEventForSlug
    * @param {String} slug
    * @return {Promise.<Object>}

--- a/addon/services/user-events.js
+++ b/addon/services/user-events.js
@@ -35,11 +35,24 @@ export default Service.extend(EventMixin, {
     const commonAjax = this.get('commonAjax');
     const data = await commonAjax.request(url);
 
-    return data.userEvents.map(event => {
-      event.isBlanked = !event.offering && !event.ilmSession;
-      event.slug = this.getSlugForEvent(event);
-      return event;
-    }).sortBy('startDate', 'name');
+    return data.userEvents.map(obj => this.createEventFromData(obj)).sortBy('startDate', 'name');
+  },
+
+
+
+  /**
+   * Retrieves and event by it's given slug.
+   * @method getEventForSlug
+   * @param {String} slug
+   * @return {Promise.<Object>}
+   */
+  createEventFromData(obj) {
+    obj.isBlanked = !obj.offering && !obj.ilmSession;
+    obj.slug = this.getSlugForEvent(obj);
+    obj.prerequisites = obj.prerequisites.map(prereq => this.createEventFromData(prereq)).sortBy('startDate', 'name');
+    obj.postrequisites = obj.postrequisites.map(postreq => this.createEventFromData(postreq)).sortBy('startDate', 'name');
+
+    return obj;
   },
 
   /**

--- a/addon/templates/components/dashboard-week.hbs
+++ b/addon/templates/components/dashboard-week.hbs
@@ -1,4 +1,4 @@
-<div class="weeklylink">
+<div class="weeklylink" data-test-weekly-link>
   {{t "general.view"}}:
   {{#link-to
     "weeklyevents"

--- a/addon/templates/components/ilios-calendar-day.hbs
+++ b/addon/templates/components/ilios-calendar-day.hbs
@@ -35,8 +35,9 @@
   </div>
 {{/el-daily-calendar}}
 
+<IliosCalendarPreWorkEvents @events={{ilmPreWorkEvents}} />
+
 {{ilios-calendar-multiday-events
-  multidayEvents=multidayEvents
-  events=multiDayEventsList
+  events=multiDayEvents
   selectEvent=(action selectEvent event)
 }}

--- a/addon/templates/components/ilios-calendar-month.hbs
+++ b/addon/templates/components/ilios-calendar-month.hbs
@@ -1,4 +1,4 @@
-{{#el-monthly-calendar date=date events=calendarEvents as |weeks|}}
+{{#el-monthly-calendar date=date events=nonIlmPreWorkEvents as |weeks|}}
   <div class="row month-titles">
     <div class="cell">
     </div>
@@ -63,3 +63,5 @@
     </div>
   {{/each}}
 {{/el-monthly-calendar}}
+
+<IliosCalendarPreWorkEvents @events={{ilmPreWorkEvents}} />

--- a/addon/templates/components/ilios-calendar-pre-work-event.hbs
+++ b/addon/templates/components/ilios-calendar-pre-work-event.hbs
@@ -1,0 +1,18 @@
+<div class="ilios-calendar-pre-work-event" data-test-ilios-calendar-pre-work-event>
+  <h4>
+    <span class="title" data-test-event-title>
+      {{#link-to "events" @event.slug}}
+        {{@event.name}}
+      {{/link-to}}
+    </span>
+    <span class="date" data-test-date>
+      {{t
+        "general.dueBefore"
+        name=@event.postrequisiteName
+        date=(format-date @event.startDate)
+        link=postrequisiteLink
+        htmlSafe=true
+      }}
+    </span>
+  </h4>
+</div>

--- a/addon/templates/components/ilios-calendar-pre-work-events.hbs
+++ b/addon/templates/components/ilios-calendar-pre-work-events.hbs
@@ -1,0 +1,10 @@
+{{#if events.length}}
+  <div class="ilios-calendar-pre-work-events">
+    <h4>{{t "general.preWork"}}</h4>
+    <ul>
+      {{#each events as |event|}}
+        <IliosCalendarPreWorkEvent @event={{event}} />
+      {{/each}}
+    </ul>
+  </div>
+{{/if}}

--- a/addon/templates/components/ilios-calendar-week.hbs
+++ b/addon/templates/components/ilios-calendar-week.hbs
@@ -54,6 +54,8 @@
   </div>
 {{/el-weekly-calendar}}
 
+<IliosCalendarPreWorkEvents @events={{ilmPreWorkEvents}} />
+
 {{ilios-calendar-multiday-events
   events=multiDayEventsList
   selectEvent=(action "selectEvent")

--- a/addon/templates/components/single-event.hbs
+++ b/addon/templates/components/single-event.hbs
@@ -10,8 +10,27 @@
       {{/if}}
       {{event.courseTitle}} - <em>{{event.name}}</em>
     </h1>
+
     <div class="single-event-offered-at" data-test-offered-at>
-      {{offeredAt}}
+      {{#if (gt @event.postrequisites.length 0)}}
+        <p>
+          {{t
+            "general.dueBefore"
+            name=(get (object-at 0 @event.postrequisites) "name")
+            date=(moment-format (get (object-at 0 @event.postrequisites) "startDate") "dddd, MMMM Do YYYY, h:mm a")
+            link=postrequisiteLink
+            htmlSafe=true
+          }}
+        </p>
+      {{/if}}
+      {{#unless @event.ilmSession}}
+        <p>
+          {{t
+            "general.offeredAt"
+            date=(moment-format @event.startDate "dddd, MMMM Do YYYY, h:mm a")
+          }}
+        </p>
+      {{/unless}}
     </div>
     <div class="single-event-location">{{event.location}}</div>
     {{#if taughtBy}}

--- a/addon/templates/components/single-event.hbs
+++ b/addon/templates/components/single-event.hbs
@@ -50,6 +50,20 @@
       {{! template-lint-disable no-triple-curlies }}
       {{{event.sessionDescription}}}<br>
     {{/if}}
+    {{#if @event.prerequisites.length}}
+      <p class="pre-work" data-test-pre-work>
+        <h5>{{t "general.preWork"}}</h5>
+        <ol>
+          {{#each @event.prerequisites as |event|}}
+            <li>
+              {{#link-to "events" event.slug}}
+                {{event.name}}
+              {{/link-to}}
+            </li>
+          {{/each}}
+        </ol>
+      </p>
+    {{/if}}
   </div>
 
   <fieldset>

--- a/addon/templates/components/single-event.hbs
+++ b/addon/templates/components/single-event.hbs
@@ -1,6 +1,6 @@
 {{#if event}}
   <div class="single-event-summary">
-    <h1>
+    <h1 data-test-title>
       {{#if recentlyUpdated}}
         {{fa-icon
           "exclamation-circle"
@@ -10,11 +10,8 @@
       {{/if}}
       {{event.courseTitle}} - <em>{{event.name}}</em>
     </h1>
-    <div class="single-event-offered-at">
-      {{t
-        "general.offeredAt"
-        date=(moment-format event.startDate "dddd, MMMM Do YYYY, h:mm a")
-      }}
+    <div class="single-event-offered-at" data-test-offered-at>
+      {{offeredAt}}
     </div>
     <div class="single-event-location">{{event.location}}</div>
     {{#if taughtBy}}

--- a/addon/templates/components/week-glance-event.hbs
+++ b/addon/templates/components/week-glance-event.hbs
@@ -1,0 +1,115 @@
+<div class="event" data-test-week-glance-event>
+  <h4>
+    <span class="title" data-test-event-title>
+      {{#link-to "events" @event.slug}}
+        {{@event.name}}
+      {{/link-to}}
+    </span>
+    <span class="date" data-test-date>
+      {{#if @event.ilmSession}}
+        <span class="ilm-due">{{t "general.dueBy"}}</span>
+      {{/if}}
+      {{moment-format @event.startDate "dddd h:mma"}}
+    </span>
+  </h4>
+  <p>
+    <span class="sessiontype" data-test-session-type>
+      {{@event.sessionTypeTitle}}
+    </span>
+    {{#if @event.location}}
+      <span class="location" data-test-location>
+        - {{@event.location}}
+      </span>
+    {{/if}}
+    <span class="session-attributes" data-test-session-attributes>
+      {{#if @event.attireRequired}}
+        {{fa-icon
+          "black-tie"
+          prefix="fab"
+          ariaHidden=false
+          title=(t "general.whitecoatsSlashSpecialAttire")
+        }}
+      {{/if}}
+      {{#if @event.equipmentRequired}}
+        {{fa-icon
+          "flask"
+          ariaHidden=false
+          title=(t "general.specialEquipment")
+        }}
+      {{/if}}
+      {{#if @event.attendanceRequired}}
+        {{fa-icon
+          "calendar-check"
+          ariaHidden=false
+          title=(t "general.attendanceIsRequired")
+        }}
+      {{/if}}
+      {{#if @event.supplemental}}
+        {{fa-icon
+          "calendar-minus"
+          ariaHidden=false
+          title=(t "general.supplementalCurriculum")
+        }}
+      {{/if}}
+    </span>
+  </p>
+  {{#if @event.instructors.length}}
+    <div class="instructors" data-test-instructors>
+      <label>{{t "general.instructors"}}:</label>
+      {{join ", " (sort-by (action "sortString") @event.instructors)}}
+    </div>
+  {{/if}}
+  {{#if @event.sessionDescription.length}}
+    <p class="description" data-test-description>
+      {{big-text text=@event.sessionDescription length=50}}
+    </p>
+  {{/if}}
+  <ul class="learning-materials" data-test-learning-materials>
+    {{#each @event.learningMaterials as |lm|}}
+      <li class="learning-material"  data-test-learning-material>
+        {{#if lm.isBlanked}}
+          <span class="lm-type-icon" data-test-type-icon>{{fa-icon "clock" title=(t "general.timedRelease")}}</span>
+          <span data-test-material-title>{{lm.title}}</span>
+        {{else}}
+          {{lm-type-icon type=(lm-type lm) mimetype=lm.mimetype}}
+          {{#if lm.absoluteFileUri}}
+            {{#if (eq lm.mimetype "application/pdf")}}
+              <a href="{{lm.absoluteFileUri}}?inline" data-test-material-title>
+                {{lm.title}}
+              </a>
+              <a href={{lm.absoluteFileUri}} target="_blank" rel="noopener">
+                {{fa-icon "download" title=(t "general.download")}}
+              </a>
+            {{else}}
+              <a
+                href={{lm.absoluteFileUri}}
+                target="_blank"
+                rel="noopener"
+                data-test-material-title
+              >
+                {{lm.title}}
+              </a>
+            {{/if}}
+          {{else if lm.link}}
+            <a href={{lm.link}} target="_blank" rel="noopener" data-test-material-title>{{lm.title}}</a>
+          {{else}}
+            <span data-test-material-title>{{lm.title}}</span>
+            <ul data-test-citation>
+              <li><small>{{lm.citation}}</small></li>
+            </ul>
+          {{/if}}
+          {{#if lm.publicNotes}}
+            <p class="public-notes" data-test-public-notes>{{big-text text=lm.publicNotes length=50}}</p>
+          {{/if}}
+        {{/if}}
+        <span class="timed-release-info" data-test-time-release-info>
+          {{timed-release-schedule
+            startDate=lm.startDate
+            endDate=lm.endDate
+            showNoSchedule=false
+          }}
+        </span>
+      </li>
+    {{/each}}
+  </ul>
+</div>

--- a/addon/templates/components/week-glance-event.hbs
+++ b/addon/templates/components/week-glance-event.hbs
@@ -1,5 +1,5 @@
 <div class="event" data-test-week-glance-event>
-  <h4>
+  <h4 id={{concat "event" @event.slug}}>
     <span class="title" data-test-event-title>
       {{#link-to "events" @event.slug}}
         {{@event.name}}

--- a/addon/templates/components/week-glance-event.hbs
+++ b/addon/templates/components/week-glance-event.hbs
@@ -12,6 +12,20 @@
       {{moment-format @event.startDate "dddd h:mma"}}
     </span>
   </h4>
+  {{#if @event.prerequisites.length}}
+    <p class="pre-work" data-test-pre-work>
+      <h5>{{t "general.preWork"}}</h5>
+      <ol>
+        {{#each @event.prerequisites as |event|}}
+          <li>
+            {{#link-to "events" event.slug}}
+              {{event.name}}
+            {{/link-to}}
+          </li>
+        {{/each}}
+      </ol>
+    </p>
+  {{/if}}
   <p>
     <span class="sessiontype" data-test-session-type>
       {{@event.sessionTypeTitle}}

--- a/addon/templates/components/week-glance-event.hbs
+++ b/addon/templates/components/week-glance-event.hbs
@@ -14,7 +14,7 @@
   </h4>
   {{#if @event.prerequisites.length}}
     <p class="pre-work" data-test-pre-work>
-      <h5>{{t "general.preWork"}}</h5>
+      <strong>{{t "general.preWork"}}</strong>:
       <ol>
         {{#each @event.prerequisites as |event|}}
           <li>

--- a/addon/templates/components/week-glance-pre-work.hbs
+++ b/addon/templates/components/week-glance-pre-work.hbs
@@ -10,6 +10,8 @@
         "general.dueBefore"
         name=@event.postrequisiteName
         date=(format-date @event.startDate)
+        link=(concat "#event" @event.postrequisiteSlug)
+        htmlSafe=true
       }}
     </span>
   </h4>

--- a/addon/templates/components/week-glance-pre-work.hbs
+++ b/addon/templates/components/week-glance-pre-work.hbs
@@ -6,10 +6,11 @@
       {{/link-to}}
     </span>
     <span class="date" data-test-date>
-      {{#if @event.ilmSession}}
-        <span class="ilm-due">{{t "general.dueBy"}}</span>
-      {{/if}}
-      {{moment-format @event.startDate "dddd h:mma"}}
+      {{t
+        "general.dueBefore"
+        name=@event.postrequisiteName
+        date=(format-date @event.startDate)
+      }}
     </span>
   </h4>
 </div>

--- a/addon/templates/components/week-glance-pre-work.hbs
+++ b/addon/templates/components/week-glance-pre-work.hbs
@@ -1,0 +1,15 @@
+<div class="week-glance-pre-work" data-test-week-glance-pre-work>
+  <h4>
+    <span class="title" data-test-event-title>
+      {{#link-to "events" @event.slug}}
+        {{@event.name}}
+      {{/link-to}}
+    </span>
+    <span class="date" data-test-date>
+      {{#if @event.ilmSession}}
+        <span class="ilm-due">{{t "general.dueBy"}}</span>
+      {{/if}}
+      {{moment-format @event.startDate "dddd h:mma"}}
+    </span>
+  </h4>
+</div>

--- a/addon/templates/components/week-glance.hbs
+++ b/addon/templates/components/week-glance.hbs
@@ -11,6 +11,17 @@
 </h3>
 {{#liquid-unless collapsed class="vertical"}}
   {{#if (is-fulfilled publishedWeekEvents)}}
+    <div class="ilm-pre-work">
+      <h4>{{t "general.preWork"}}</h4>
+      {{#if (gt (get (await ilmPreWork) "length") 0)}}
+        {{#each (await ilmPreWork) as |event|}}
+          <WeekGlancePreWork @event={{event}} />
+        {{/each}}
+      {{else}}
+        <p>{{t "general.none"}}</p>
+      {{/if}}
+    </div>
+
     {{#if (gt (get (await publishedWeekEvents) "length") 0)}}
       {{#each (await publishedWeekEvents) as |event|}}
         <WeekGlanceEvent @event={{event}} />

--- a/addon/templates/components/week-glance.hbs
+++ b/addon/templates/components/week-glance.hbs
@@ -11,23 +11,10 @@
 </h3>
 {{#liquid-unless collapsed class="vertical"}}
   {{#if (is-fulfilled publishedWeekEvents)}}
-    <div class="ilm-events" data-test-ilm-events>
-      <h4>{{t "general.independentLearningActivities"}}</h4>
-      {{#if (gt (get (await ilmEvents) "length") 0)}}
-        {{#each (await ilmEvents) as |event|}}
-          <WeekGlanceEvent @event={{event}} />
-        {{/each}}
-      {{else}}
-        <p>{{t "general.none"}}</p>
-      {{/if}}
-    </div>
-
-    {{#if (gt (get (await offeringEvents) "length") 0)}}
-      <div class="ilm-events" data-test-offering-events>
-        {{#each (await offeringEvents) as |event|}}
-          <WeekGlanceEvent @event={{event}} />
-        {{/each}}
-      </div>
+    {{#if (gt (get (await publishedWeekEvents) "length") 0)}}
+      {{#each (await publishedWeekEvents) as |event|}}
+        <WeekGlanceEvent @event={{event}} />
+      {{/each}}
     {{else}}
       <p>{{t "general.none"}}</p>
     {{/if}}

--- a/addon/templates/components/week-glance.hbs
+++ b/addon/templates/components/week-glance.hbs
@@ -12,8 +12,8 @@
 {{#liquid-unless collapsed class="vertical"}}
   {{#if (is-fulfilled publishedWeekEvents)}}
     <div class="ilm-pre-work">
-      <h4>{{t "general.preWork"}}</h4>
       {{#if (gt (get (await ilmPreWork) "length") 0)}}
+        <h4>{{t "general.preWork"}}</h4>
         {{#each (await ilmPreWork) as |event|}}
           <WeekGlancePreWork @event={{event}} />
         {{/each}}

--- a/addon/templates/components/week-glance.hbs
+++ b/addon/templates/components/week-glance.hbs
@@ -17,8 +17,6 @@
         {{#each (await ilmPreWork) as |event|}}
           <WeekGlancePreWork @event={{event}} />
         {{/each}}
-      {{else}}
-        <p>{{t "general.none"}}</p>
       {{/if}}
     </div>
 

--- a/addon/templates/components/week-glance.hbs
+++ b/addon/templates/components/week-glance.hbs
@@ -20,8 +20,8 @@
       {{/if}}
     </div>
 
-    {{#if (gt (get (await publishedWeekEvents) "length") 0)}}
-      {{#each (await publishedWeekEvents) as |event|}}
+    {{#if (gt (get (await nonIlmPreWorkEvents) "length") 0)}}
+      {{#each (await nonIlmPreWorkEvents) as |event|}}
         <WeekGlanceEvent @event={{event}} />
       {{/each}}
     {{else}}

--- a/addon/templates/components/week-glance.hbs
+++ b/addon/templates/components/week-glance.hbs
@@ -1,6 +1,7 @@
 <h3
   class="{{if collapsible "clickable collapsible"}} {{if collapsed "collapsed" "expanded"}}"
   role="button"
+  data-test-week-title
   {{action (optional toggleCollapsed) collapsed}}
 >
   {{title}}
@@ -10,119 +11,23 @@
 </h3>
 {{#liquid-unless collapsed class="vertical"}}
   {{#if (is-fulfilled publishedWeekEvents)}}
-    {{#if (gt (get (await publishedWeekEvents) "length") 0)}}
-      {{#each (await publishedWeekEvents) as |event|}}
-        <div class="event">
-          <h4>
-            <span class="title">
-              {{#link-to "events" event.slug}}
-                {{event.name}}
-              {{/link-to}}
-            </span>
-            <span class="date">
-              {{#if event.ilmSession}}
-                <span class="ilm-due">{{t "general.dueBy"}}</span>
-              {{/if}}
-              {{moment-format event.startDate "dddd h:mma"}}
-            </span>
-          </h4>
-          <p>
-            <span class="sessiontype">
-              {{event.sessionTypeTitle}}
-            </span>
-            {{#if event.location}}
-              <span class="location">
-                - {{event.location}}
-              </span>
-            {{/if}}
-            <span class="session-attributes">
-              {{#if event.attireRequired}}
-                {{fa-icon
-                  "black-tie"
-                  prefix="fab"
-                  ariaHidden=false
-                  title=(t "general.whitecoatsSlashSpecialAttire")
-                }}
-              {{/if}}
-              {{#if event.equipmentRequired}}
-                {{fa-icon
-                  "flask"
-                  ariaHidden=false
-                  title=(t "general.specialEquipment")
-                }}
-              {{/if}}
-              {{#if event.attendanceRequired}}
-                {{fa-icon
-                  "calendar-check"
-                  ariaHidden=false
-                  title=(t "general.attendanceIsRequired")
-                }}
-              {{/if}}
-              {{#if event.supplemental}}
-                {{fa-icon
-                  "calendar-minus"
-                  ariaHidden=false
-                  title=(t "general.supplementalCurriculum")
-                }}
-              {{/if}}
-            </span>
-          </p>
-          {{#if event.instructors.length}}
-            <div class="instructors">
-              <label>{{t "general.instructors"}}:</label>
-              {{join ", " (sort-by (action "sortString") event.instructors)}}
-            </div>
-          {{/if}}
-          {{#if event.sessionDescription.length}}
-            <p class="description">
-              {{big-text text=event.sessionDescription length=50}}
-            </p>
-          {{/if}}
-          <ul class="learning-materials">
-            {{#each event.learningMaterials as |lm|}}
-              <li class="learning-material">
-                {{#if lm.isBlanked}}
-                  <span class="lm-type-icon">{{fa-icon "clock" title=(t "general.timedRelease")}}</span>
-                  {{lm.title}}
-                {{else}}
-                  {{lm-type-icon type=(lm-type lm) mimetype=lm.mimetype}}
-                  {{#if lm.absoluteFileUri}}
-                    {{#if (eq lm.mimetype "application/pdf")}}
-                      <a href="{{lm.absoluteFileUri}}?inline">
-                        {{lm.title}}
-                      </a>
-                      <a href={{lm.absoluteFileUri}} target="_blank" rel="noopener">
-                        {{fa-icon "download" title=(t "general.download")}}
-                      </a>
-                    {{else}}
-                      <a href={{lm.absoluteFileUri}} target="_blank" rel="noopener">
-                        {{lm.title}}
-                      </a>
-                    {{/if}}
-                  {{else if lm.link}}
-                    <a href={{lm.link}} target="_blank" rel="noopener">{{lm.title}}</a>
-                  {{else}}
-                    {{lm.title}}
-                    <ul>
-                      <li><small>{{lm.citation}}</small></li>
-                    </ul>
-                  {{/if}}
-                  {{#if lm.publicNotes}}
-                    <p class="public-notes">{{big-text text=lm.publicNotes length=50}}</p>
-                  {{/if}}
-                {{/if}}
-                <span class="timed-release-info">
-                  {{timed-release-schedule
-                    startDate=lm.startDate
-                    endDate=lm.endDate
-                    showNoSchedule=false
-                  }}
-                </span>
-              </li>
-            {{/each}}
-          </ul>
-        </div>
-      {{/each}}
+    <div class="ilm-events" data-test-ilm-events>
+      <h4>{{t "general.independentLearningActivities"}}</h4>
+      {{#if (gt (get (await ilmEvents) "length") 0)}}
+        {{#each (await ilmEvents) as |event|}}
+          <WeekGlanceEvent @event={{event}} />
+        {{/each}}
+      {{else}}
+        <p>{{t "general.none"}}</p>
+      {{/if}}
+    </div>
+
+    {{#if (gt (get (await offeringEvents) "length") 0)}}
+      <div class="ilm-events" data-test-offering-events>
+        {{#each (await offeringEvents) as |event|}}
+          <WeekGlanceEvent @event={{event}} />
+        {{/each}}
+      </div>
     {{else}}
       <p>{{t "general.none"}}</p>
     {{/if}}

--- a/app/components/ilios-calendar-pre-work-event.js
+++ b/app/components/ilios-calendar-pre-work-event.js
@@ -1,0 +1,1 @@
+export { default } from 'ilios-common/components/ilios-calendar-pre-work-event';

--- a/app/components/ilios-calendar-pre-work-events.js
+++ b/app/components/ilios-calendar-pre-work-events.js
@@ -1,0 +1,1 @@
+export { default } from 'ilios-common/components/ilios-calendar-pre-work-events';

--- a/app/components/week-glance-event.js
+++ b/app/components/week-glance-event.js
@@ -1,0 +1,1 @@
+export { default } from 'ilios-common/components/week-glance-event';

--- a/app/components/week-glance-pre-work.js
+++ b/app/components/week-glance-pre-work.js
@@ -1,0 +1,1 @@
+export { default } from 'ilios-common/components/week-glance-pre-work';

--- a/app/styles/ilios-common/components.scss
+++ b/app/styles/ilios-common/components.scss
@@ -50,6 +50,7 @@
 @import 'components/ilios-calendar-day';
 @import 'components/ilios-calendar-month';
 @import 'components/ilios-calendar-multiday-events';
+@import 'components/ilios-calendar-pre-work-events';
 @import 'components/ilios-calendar-week';
 @import 'components/instructor-selection-manager';
 @import 'components/leadership-collapsed';

--- a/app/styles/ilios-common/components.scss
+++ b/app/styles/ilios-common/components.scss
@@ -107,4 +107,5 @@
 @import 'components/visualizer-course-vocabularies';
 @import 'components/visualizer-course-vocabulary';
 @import 'components/week-glance';
+@import 'components/week-glance-pre-work';
 @import 'components/weekly-events';

--- a/app/styles/ilios-common/components/ilios-calendar-pre-work-events.scss
+++ b/app/styles/ilios-common/components/ilios-calendar-pre-work-events.scss
@@ -1,0 +1,15 @@
+.ilios-calendar-pre-work-events {
+  border: 1px dotted $ilios-blue;
+  margin-top: 1em;
+  padding: 1em 0;
+
+  h4 {
+    font-size: 1.25em;
+    font-weight: bold;
+    margin-top: 0;
+  }
+
+  ul {
+    margin-left: 1em;
+  }
+}

--- a/app/styles/ilios-common/components/week-glance-pre-work.scss
+++ b/app/styles/ilios-common/components/week-glance-pre-work.scss
@@ -1,0 +1,5 @@
+.week-glance-pre-work {
+  h4 {
+    @include ilios-heading-h6;
+  }
+}

--- a/app/styles/ilios-common/components/week-glance.scss
+++ b/app/styles/ilios-common/components/week-glance.scss
@@ -22,17 +22,6 @@
     }
   }
 
-  .ilm-events {
-    border: 1px solid $ilios-blue;
-    margin-bottom: 2rem;
-    padding-bottom: .5rem;
-    padding-left: .5rem;
-
-    .event {
-      margin-left: .5rem;
-    }
-  }
-
   .event {
     line-height: 1.5;
     margin-bottom: 1em;
@@ -94,6 +83,14 @@
 
     .lm-type-icon {
       color: $dark-grey;
+    }
+
+    .pre-work {
+
+      ol {
+        @include ilios-list-reset;
+        margin-left: 2em;
+      }
     }
   }
 }

--- a/app/styles/ilios-common/components/week-glance.scss
+++ b/app/styles/ilios-common/components/week-glance.scss
@@ -93,4 +93,8 @@
       }
     }
   }
+
+  .ilm-pre-work {
+    padding-bottom: 2rem;
+  }
 }

--- a/app/styles/ilios-common/components/week-glance.scss
+++ b/app/styles/ilios-common/components/week-glance.scss
@@ -22,6 +22,17 @@
     }
   }
 
+  .ilm-events {
+    border: 1px solid $ilios-blue;
+    margin-bottom: 2rem;
+    padding-bottom: .5rem;
+    padding-left: .5rem;
+
+    .event {
+      margin-left: .5rem;
+    }
+  }
+
   .event {
     line-height: 1.5;
     margin-bottom: 1em;

--- a/tests/integration/components/ilios-calendar-month-test.js
+++ b/tests/integration/components/ilios-calendar-month-test.js
@@ -105,7 +105,8 @@ module('Integration | Component | ilios calendar month', function(hooks) {
     click('.day:nth-of-type(1) .clickable');
   });
 
-  let createUserEventObject = function(){
+  let createUserEventObject = function () {
+
     return {
       user: 1,
       name: '',
@@ -116,7 +117,9 @@ module('Integration | Component | ilios calendar month', function(hooks) {
       location: 'Rm. 160',
       lastModified: new Date(),
       isPublished: true,
-      isScheduled: false
+      isScheduled: false,
+      prerequisites: [],
+      postrequisites: [],
     };
   };
 });

--- a/tests/integration/components/ilios-calendar-pre-work-event-test.js
+++ b/tests/integration/components/ilios-calendar-pre-work-event-test.js
@@ -1,0 +1,67 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import moment from 'moment';
+
+import { component } from 'ilios-common/page-objects/components/ilios-calendar-pre-work-event';
+
+const today = moment();
+
+module('Integration | Component | ilios-calendar-pre-work-event', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.owner.setupRouter();
+  }),
+
+  test('it renders', async function (assert) {
+    this.set('event', {
+      name: 'Learn to Learn',
+      slug: 'abc',
+      startDate: today.format(),
+      location: 'Room 123',
+      sessionTypeTitle: 'Lecture',
+      courseExternalId: 'C1',
+      sessionDescription: 'Best <strong>Session</strong> For Sure' + 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur',
+      isBlanked: false,
+      isPublished: true,
+      isScheduled: false,
+      learningMaterials: [
+        {
+          title: 'Citation LM',
+          type: 'citation',
+          required: true,
+          publicNotes: 'This is cool.',
+          citation: 'citationtext',
+        },
+        {
+          title: 'Link LM',
+          type: 'link',
+          required: false,
+          link: 'http://myhost.com/url2',
+        },
+        {
+          title: 'File LM',
+          type: 'file',
+          filename: 'This is a PDF',
+          mimetype: 'application/pdf',
+          required: true,
+          absoluteFileUri: 'http://myhost.com/url1',
+        },
+      ],
+      attireRequired: true,
+      equipmentRequired: true,
+      attendanceRequired: true,
+      supplemental: true,
+      postrequisiteName: 'reading to read',
+      postrequisiteSlug: '123',
+    });
+    await render(hbs`<IliosCalendarPreWorkEvent @event={{event}} />`);
+
+    assert.equal(component.title, 'Learn to Learn');
+    assert.equal(component.titleUrl, '/events/abc');
+    assert.equal(component.date, `Due Before reading to read (${today.format('M/D/Y')})`);
+    assert.equal(component.url, '/events/123');
+  });
+});

--- a/tests/integration/components/ilios-calendar-pre-work-events-test.js
+++ b/tests/integration/components/ilios-calendar-pre-work-events-test.js
@@ -1,0 +1,14 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | ilios-calendar-pre-work-events', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    await render(hbs`{{ilios-calendar-pre-work-events}}`);
+
+    assert.equal(this.element.textContent.trim(), '');
+  });
+});

--- a/tests/integration/components/single-event-test.js
+++ b/tests/integration/components/single-event-test.js
@@ -1,17 +1,19 @@
 import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, settled } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import moment from 'moment';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { component } from 'ilios-common/page-objects/components/single-event';
 
 module('Integration | Component | ilios calendar single event', function(hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function () {
-    this.server.logging = true;
+  test('it renders', async function(assert) {
+    assert.expect(20);
+
     const now = moment().hour(8).minute(0).second(0);
     const course = this.server.create('course', {
       id: 1,
@@ -22,8 +24,9 @@ module('Integration | Component | ilios calendar single event', function(hooks) 
       title: 'test session',
       course
     });
-    this.sessionLearningMaterials = [
-      this.server.create('session-learning-material', {
+
+    const learningMaterials = [
+      EmberObject.create({
         title: 'Lecture Notes',
         sessionLearningMaterial: '1',
         description: 'Lecture Notes in PDF format',
@@ -34,7 +37,7 @@ module('Integration | Component | ilios calendar single event', function(hooks) 
         publicNotes: 'Lorem Ipsum',
         position: 0,
       }),
-      this.server.create('session-learning-material', {
+      EmberObject.create({
         title: 'Mystery Meat',
         sessionLearningMaterial: '2',
         position: 1,
@@ -42,7 +45,7 @@ module('Integration | Component | ilios calendar single event', function(hooks) 
         endDate: new Date('2013-03-01T01:10:00')
       })
     ];
-    this.ourEvent = EmberObject.create({
+    const ourEvent = this.server.create('userevent', {
       user: 1,
       courseExternalId: 'ext1',
       sessionTypeTitle: 'test type',
@@ -54,7 +57,7 @@ module('Integration | Component | ilios calendar single event', function(hooks) 
       location: 'here',
       instructors: ['Great Teacher'],
       session: 1,
-      learningMaterials: this.sessionLearningMaterials,
+      learningMaterials,
       sessionObjectives: [
         {
           id: 1,
@@ -113,13 +116,9 @@ module('Integration | Component | ilios calendar single event', function(hooks) 
         }
       ],
     });
-  });
 
-  test('it renders', async function(assert) {
-    assert.expect(20);
-    this.set('event', this.ourEvent);
+    this.set('event', ourEvent);
     await render(hbs`{{single-event event=event}}`);
-    await settled();
 
     assert.ok(this.element.querySelector('.single-event-summary').textContent.includes('test course'), 'course title is displayed');
     assert.ok(this.element.querySelector('.single-event-summary').textContent.includes('test session'), 'session title is displayed');
@@ -130,14 +129,14 @@ module('Integration | Component | ilios calendar single event', function(hooks) 
     let sessionLm = this.element.querySelector('.single-event-learningmaterial-list:nth-of-type(1) .single-event-learningmaterial-item:nth-of-type(1)');
     assert.dom(
       this.element.querySelector('.single-event-learningmaterial-item-notes', sessionLm)
-    ).hasText(this.sessionLearningMaterials[0].publicNotes);
+    ).hasText(learningMaterials[0].publicNotes);
     assert.dom(
       this.element.querySelector('.single-event-learningmaterial-item-description', sessionLm)
-    ).hasText(this.sessionLearningMaterials[0].description);
-    assert.ok(this.element.querySelector('.single-event-learningmaterial-item-title', sessionLm).textContent.includes(this.sessionLearningMaterials[0].title));
+    ).hasText(learningMaterials[0].description);
+    assert.ok(this.element.querySelector('.single-event-learningmaterial-item-title', sessionLm).textContent.includes(learningMaterials[0].title));
     sessionLm = this.element.querySelector('.single-event-learningmaterial-list:nth-of-type(1) .single-event-learningmaterial-item:nth-of-type(2)');
     assert.equal(this.element.querySelectorAll('.lm-type-icon .fa-clock', sessionLm).length, 1, 'Timed release icon is visible');
-    assert.ok(this.element.querySelector('.single-event-learningmaterial-item-title', sessionLm).textContent.includes(this.sessionLearningMaterials[0].title));
+    assert.ok(this.element.querySelector('.single-event-learningmaterial-item-title', sessionLm).textContent.includes(learningMaterials[0].title));
     let sessionObjectivesSelector = '.single-event-objective-list > .single-event-objective-list:nth-of-type(1)';
     assert.ok(this.element.querySelector(`${sessionObjectivesSelector} ul.tree > li:nth-of-type(1)`).textContent.trim().startsWith('Competency A (Domain A)'));
     assert.dom(
@@ -160,5 +159,58 @@ module('Integration | Component | ilios calendar single event', function(hooks) 
       this.element.querySelector(`${courseObjectivesSelector} ul.tree > li:nth-of-type(1) li:nth-of-type(2)`)
     ).hasText('Course Objective A');
     assert.ok(this.element.querySelector(`${courseObjectivesSelector} ul.tree > li:nth-of-type(2)`).textContent.trim().startsWith('Domain B (Domain B)'));
+  });
+
+  test('unlinked event date and title are displayed', async function(assert) {
+    assert.expect(2);
+
+    const today = moment().hour(8).minute(0).second(0);
+    this.server.create('userevent', {
+      name: 'Learn to Learn',
+      courseTitle: 'course',
+      startDate: today.format(),
+      isBlanked: false,
+      isPublished: true,
+      isScheduled: false,
+      offering: 1,
+      lastModified: null,
+    });
+
+    this.set('event', this.server.db.userevents[0]);
+    await render(hbs`{{single-event event=event}}`);
+    assert.equal(component.title, 'course - Learn to Learn');
+    assert.equal(component.offeredAt, 'On ' + today.format('dddd, MMMM Do YYYY, h:mm a'));
+  });
+
+  test('postrequisite date and title are displayed', async function(assert) {
+    assert.expect(2);
+
+    const today = moment().hour(8).minute(0).second(0);
+    const tomorrow = today.clone().add(1, 'day');
+    const postReq = EmberObject.create({
+      name: 'postrequisite session',
+      courseTitle: 'course',
+      startDate: tomorrow.format(),
+      isBlanked: false,
+      isPublished: true,
+      isScheduled: false,
+    });
+    this.server.create('userevent', {
+      name: 'Learn to Learn',
+      courseTitle: 'course',
+      startDate: today.format(),
+      isBlanked: false,
+      isPublished: true,
+      isScheduled: false,
+      offering: 1,
+      lastModified: null,
+      postrequisites: [postReq]
+    });
+
+    this.set('event', this.server.db.userevents[0]);
+    await render(hbs`{{single-event event=event}}`);
+    assert.equal(component.title, 'course - Learn to Learn');
+    const formatedDate = tomorrow.format('dddd, MMMM Do YYYY, h:mm a');
+    assert.equal(component.offeredAt, `Due Before postrequisite session (${formatedDate})`);
   });
 });

--- a/tests/integration/components/single-event-test.js
+++ b/tests/integration/components/single-event-test.js
@@ -213,4 +213,44 @@ module('Integration | Component | ilios calendar single event', function(hooks) 
     const formatedDate = tomorrow.format('dddd, MMMM Do YYYY, h:mm a');
     assert.equal(component.offeredAt, `Due Before postrequisite session (${formatedDate})`);
   });
+
+  test('prequisites are displayed', async function(assert) {
+    assert.expect(6);
+
+    const today = moment().hour(8).minute(0).second(0);
+    const prereq1 = EmberObject.create({
+      name: 'prework 1',
+      startDate: today.clone().subtract(1, 'day').format(),
+      isBlanked: false,
+      isPublished: true,
+      isScheduled: false,
+    });
+    const prereq2 = EmberObject.create({
+      name: 'prework 2',
+      startDate: today.clone().subtract(3, 'days').format(),
+      isBlanked: false,
+      isPublished: true,
+      isScheduled: false,
+    });
+    this.server.create('userevent', {
+      name: 'Learn to Learn',
+      courseTitle: 'course',
+      startDate: today.format(),
+      isBlanked: false,
+      isPublished: true,
+      isScheduled: false,
+      offering: 1,
+      lastModified: null,
+      prerequisites: [prereq1, prereq2]
+    });
+
+    this.set('event', this.server.db.userevents[0]);
+    await render(hbs`{{single-event event=event}}`);
+    assert.equal(component.title, 'course - Learn to Learn');
+    assert.equal(component.preWork.length, 2);
+    assert.equal(component.preWork[0].title, 'prework 1');
+    assert.ok(component.preWork[0].hasLink);
+    assert.equal(component.preWork[1].title, 'prework 2');
+    assert.ok(component.preWork[1].hasLink);
+  });
 });

--- a/tests/integration/components/week-glance-event-test.js
+++ b/tests/integration/components/week-glance-event-test.js
@@ -197,4 +197,30 @@ module('Integration | Component | week-glance-event', function(hooks) {
     assert.notOk(component.hasInstructors);
     assert.equal(component.sessionAttributes.length, 4);
   });
+
+  test('it renders prework', async function (assert) {
+    this.set('event', {
+      name: 'Learn to Learn',
+      startDate: today.format(),
+      location: 'Room 123',
+      sessionTypeTitle: 'Lecture',
+      courseExternalId: 'C1',
+      sessionDescription: 'Best <strong>Session</strong> For Sure' + 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur',
+      isBlanked: false,
+      isPublished: true,
+      isScheduled: false,
+      prerequisites: [
+        { name: 'prework 1', slug: 'e1' },
+        { name: 'prework 2', slug: 'e2' },
+      ]
+    });
+    await render(hbs`<WeekGlanceEvent @event={{event}} />`);
+
+    assert.equal(component.title, 'Learn to Learn');
+    assert.equal(component.preWork.length, 2);
+    assert.equal(component.preWork[0].title, 'prework 1');
+    assert.ok(component.preWork[0].hasLink);
+    assert.equal(component.preWork[1].title, 'prework 2');
+    assert.ok(component.preWork[1].hasLink);
+  });
 });

--- a/tests/integration/components/week-glance-event-test.js
+++ b/tests/integration/components/week-glance-event-test.js
@@ -1,0 +1,200 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import moment from 'moment';
+
+import { component } from 'ilios-common/page-objects/components/week-glance-event';
+
+const today = moment();
+
+module('Integration | Component | week-glance-event', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders with some stuff', async function (assert) {
+    this.set('event', {
+      name: 'Learn to Learn',
+      startDate: today.format(),
+      location: 'Room 123',
+      sessionTypeTitle: 'Lecture',
+      courseExternalId: 'C1',
+      sessionDescription: 'Best <strong>Session</strong> For Sure' + 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur',
+      isBlanked: false,
+      isPublished: true,
+      isScheduled: false,
+      learningMaterials: [
+        {
+          title: 'Citation LM',
+          type: 'citation',
+          required: true,
+          publicNotes: 'This is cool.',
+          citation: 'citationtext',
+        },
+        {
+          title: 'Link LM',
+          type: 'link',
+          required: false,
+          link: 'http://myhost.com/url2',
+        },
+        {
+          title: 'File LM',
+          type: 'file',
+          filename: 'This is a PDF',
+          mimetype: 'application/pdf',
+          required: true,
+          absoluteFileUri: 'http://myhost.com/url1',
+        },
+      ],
+      attireRequired: true,
+      equipmentRequired: true,
+      attendanceRequired: true,
+      supplemental: true,
+    });
+    await render(hbs`<WeekGlanceEvent @event={{event}} />`);
+
+    assert.equal(component.title, 'Learn to Learn');
+    assert.equal(component.sessionType, 'Lecture');
+    assert.equal(component.location, '- Room 123');
+    assert.ok(component.hasDescription);
+    assert.equal(component.description, 'Best Session For SureLorem ipsum dolor sit amet, c');
+    assert.equal(component.learningMaterials.length, 3);
+    assert.equal(component.learningMaterials[0].title, 'Citation LM');
+    assert.ok(component.learningMaterials[0].hasTypeIcon);
+    assert.equal(component.learningMaterials[0].typeIconTitle, 'Citation');
+    assert.ok(component.learningMaterials[0].hasCitation);
+    assert.equal(component.learningMaterials[0].citation, 'citationtext');
+    assert.ok(component.learningMaterials[0].hasPublicNotes);
+    assert.equal(component.learningMaterials[0].publicNotes, 'This is cool.');
+
+    assert.equal(component.learningMaterials[1].title, 'Link LM');
+    assert.ok(component.learningMaterials[1].hasTypeIcon);
+    assert.equal(component.learningMaterials[1].typeIconTitle, 'Web Link');
+    assert.notOk(component.learningMaterials[1].hasCitation);
+    assert.notOk(component.learningMaterials[1].hasPublicNotes);
+    assert.equal(component.learningMaterials[1].url, 'http://myhost.com/url2');
+
+    assert.equal(component.learningMaterials[2].title, 'File LM');
+    assert.ok(component.learningMaterials[2].hasTypeIcon);
+    assert.equal(component.learningMaterials[2].typeIconTitle, 'File');
+    assert.notOk(component.learningMaterials[2].hasCitation);
+    assert.notOk(component.learningMaterials[2].hasPublicNotes);
+    assert.equal(component.learningMaterials[2].url, 'http://myhost.com/url1?inline');
+
+    assert.notOk(component.hasInstructors);
+    assert.equal(component.sessionAttributes.length, 4);
+    assert.ok(component.sessionAttributes[0].attire);
+    assert.ok(component.sessionAttributes[1].equipment);
+    assert.ok(component.sessionAttributes[2].attendance);
+    assert.ok(component.sessionAttributes[3].supplemental);
+  });
+
+  test('it renders with other stuff', async function (assert) {
+    this.set('event', {
+      name: 'Finding the Point in Life',
+      startDate: today.format(),
+      location: 'Room 456',
+      sessionTypeTitle: 'Independent Learning',
+      isBlanked: false,
+      isPublished: true,
+      isScheduled: false,
+      learningMaterials: [
+        {
+          title: 'Great Slides',
+          required: true,
+          type: 'file',
+          filename: 'This is another PDF',
+          mimetype: 'application/pdf',
+          absoluteFileUri: 'http://myhost.com/url1',
+          publicNotes: 'slide notes',
+        },
+      ],
+      instructors: [
+        'Second Person',
+        'First Person',
+      ],
+      attireRequired: false,
+      equipmentRequired: false,
+      attendanceRequired: false,
+      supplemental: false,
+    });
+    await render(hbs`<WeekGlanceEvent @event={{event}} />`);
+
+    assert.equal(component.title, 'Finding the Point in Life');
+    assert.equal(component.sessionType, 'Independent Learning');
+    assert.equal(component.location, '- Room 456');
+    assert.notOk(component.hasDescription);
+    assert.equal(component.learningMaterials.length, 1);
+    assert.equal(component.learningMaterials[0].title, 'Great Slides');
+    assert.ok(component.learningMaterials[0].hasTypeIcon);
+    assert.equal(component.learningMaterials[0].typeIconTitle, 'File');
+    assert.notOk(component.learningMaterials[0].hasCitation);
+    assert.ok(component.learningMaterials[0].hasPublicNotes);
+    assert.equal(component.learningMaterials[0].publicNotes, 'slide notes');
+    assert.equal(component.learningMaterials[0].url, 'http://myhost.com/url1?inline');
+
+    assert.ok(component.hasInstructors);
+    assert.equal(component.instructors, 'Instructors: First Person, Second Person');
+    assert.equal(component.sessionAttributes.length, 0);
+  });
+  test('it renders schedule materials', async function (assert) {
+    this.set('event', {
+      name: 'Schedule some materials',
+      startDate: today.format(),
+      location: 'Room 123',
+      sessionTypeTitle: 'Lecture',
+      courseExternalId: 'C1',
+      sessionDescription: 'Best <strong>Session</strong> For Sure' + 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur',
+      isBlanked: false,
+      isPublished: true,
+      isScheduled: false,
+      learningMaterials: [
+        {
+          title: 'In the window',
+          type: 'citation',
+          required: true,
+          isBlanked: false,
+          citation: 'citationtext',
+          endDate: today.clone().add(1, 'day').toDate(),
+          startDate: today.clone().subtract(1, 'day').toDate(),
+        },
+        {
+          title: 'Too Early',
+          type: 'citation',
+          required: true,
+          isBlanked: true,
+          citation: 'citationtext',
+          startDate: moment('2001-12-31').toDate(),
+        },
+        {
+          title: 'Too Late',
+          type: 'citation',
+          required: true,
+          isBlanked: true,
+          citation: 'citationtext',
+          endDate: moment('2035-06-01').toDate(),
+        },
+      ],
+      attireRequired: true,
+      equipmentRequired: true,
+      attendanceRequired: true,
+      supplemental: true,
+    });
+    await render(hbs`<WeekGlanceEvent @event={{event}} />`);
+
+    assert.equal(component.title, 'Schedule some materials');
+    assert.equal(component.sessionType, 'Lecture');
+    assert.equal(component.location, '- Room 123');
+    assert.ok(component.hasDescription);
+    assert.equal(component.description, 'Best Session For Sure' + 'Lorem ipsum dolor sit amet, c');
+    assert.equal(component.learningMaterials.length, 3);
+    assert.equal(component.learningMaterials[0].title, 'In the window');
+    assert.ok(component.learningMaterials[0].timedReleaseInfo.length > 0);
+    assert.equal(component.learningMaterials[1].title, 'Too Early');
+    assert.ok(component.learningMaterials[1].timedReleaseInfo.length === 0);
+    assert.equal(component.learningMaterials[2].title, 'Too Late');
+    assert.ok(component.learningMaterials[2].timedReleaseInfo.length > 0);
+
+    assert.notOk(component.hasInstructors);
+    assert.equal(component.sessionAttributes.length, 4);
+  });
+});

--- a/tests/integration/components/week-glance-pre-work-test.js
+++ b/tests/integration/components/week-glance-pre-work-test.js
@@ -1,0 +1,57 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import moment from 'moment';
+
+import { component } from 'ilios-common/page-objects/components/week-glance-pre-work';
+
+const today = moment();
+
+module('Integration | Component | week-glance-pre-work', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    this.set('event', {
+      name: 'Learn to Learn',
+      startDate: today.format(),
+      location: 'Room 123',
+      sessionTypeTitle: 'Lecture',
+      courseExternalId: 'C1',
+      sessionDescription: 'Best <strong>Session</strong> For Sure' + 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur',
+      isBlanked: false,
+      isPublished: true,
+      isScheduled: false,
+      learningMaterials: [
+        {
+          title: 'Citation LM',
+          type: 'citation',
+          required: true,
+          publicNotes: 'This is cool.',
+          citation: 'citationtext',
+        },
+        {
+          title: 'Link LM',
+          type: 'link',
+          required: false,
+          link: 'http://myhost.com/url2',
+        },
+        {
+          title: 'File LM',
+          type: 'file',
+          filename: 'This is a PDF',
+          mimetype: 'application/pdf',
+          required: true,
+          absoluteFileUri: 'http://myhost.com/url1',
+        },
+      ],
+      attireRequired: true,
+      equipmentRequired: true,
+      attendanceRequired: true,
+      supplemental: true,
+    });
+    await render(hbs`<WeekGlancePreWork @event={{event}} />`);
+
+    assert.equal(component.title, 'Learn to Learn');
+  });
+});

--- a/tests/integration/components/week-glance-pre-work-test.js
+++ b/tests/integration/components/week-glance-pre-work-test.js
@@ -49,9 +49,13 @@ module('Integration | Component | week-glance-pre-work', function(hooks) {
       equipmentRequired: true,
       attendanceRequired: true,
       supplemental: true,
+      postrequisiteName: 'reading to read',
+      postrequisiteSlug: '123',
     });
     await render(hbs`<WeekGlancePreWork @event={{event}} />`);
 
     assert.equal(component.title, 'Learn to Learn');
+    assert.equal(component.date, `Due Before reading to read (${today.format('M/D/Y')})`);
+    assert.equal(component.url, '#event123');
   });
 });

--- a/tests/integration/components/week-glance-test.js
+++ b/tests/integration/components/week-glance-test.js
@@ -3,84 +3,31 @@ import Service from '@ember/service';
 import moment from 'moment';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import {
-  render,
-  find,
-  settled,
-  click
-} from '@ember/test-helpers';
+import { render, settled, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 const { resolve } = RSVP;
 
 const today = moment('2019-01-15');
 
+import { component } from 'ilios-common/page-objects/components/week-glance';
+
 const mockEvents = [
   {
     name: 'Learn to Learn',
     startDate: today.format(),
-    location: 'Room 123',
-    sessionTypeTitle: 'Lecture',
-    courseExternalId: 'C1',
-    sessionDescription: 'Best <strong>Session</strong> For Sure' + 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur',
     isBlanked: false,
     isPublished: true,
     isScheduled: false,
-    learningMaterials: [
-      {
-        title: 'Citation LM',
-        type: 'citation',
-        required: true,
-        publicNotes: 'This is cool.',
-        citation: 'citationtext',
-      },
-      {
-        title: 'Link LM',
-        type: 'link',
-        required: false,
-        link: 'http://myhost.com/url2',
-      },
-      {
-        title: 'File LM',
-        type: 'file',
-        filename: 'This is a PDF',
-        mimetype: 'application/pdf',
-        required: true,
-        absoluteFileUri: 'http://myhost.com/url1',
-      },
-    ],
-    attireRequired: true,
-    equipmentRequired: true,
-    attendanceRequired: true,
-    supplemental: true,
+    offering: 1,
   },
   {
     name: 'Finding the Point in Life',
     startDate: today.format(),
-    location: 'Room 456',
-    sessionTypeTitle: 'Independent Learning',
     isBlanked: false,
     isPublished: true,
     isScheduled: false,
-    learningMaterials: [
-      {
-        title: 'Great Slides',
-        required: true,
-        type: 'file',
-        filename: 'This is another PDF',
-        mimetype: 'application/pdf',
-        absoluteFileUri: 'http://myhost.com/url1',
-        publicNotes: 'slide notes',
-      },
-    ],
-    instructors: [
-      'Second Person',
-      'First Person',
-    ],
-    attireRequired: false,
-    equipmentRequired: false,
-    attendanceRequired: false,
-    supplemental: false,
+    ilmSession: 1,
   },
   {
     name: 'Blank',
@@ -102,43 +49,10 @@ const mockEvents = [
     name: 'Schedule some materials',
     startDate: today.format(),
     location: 'Room 123',
-    sessionTypeTitle: 'Lecture',
-    courseExternalId: 'C1',
-    sessionDescription: 'Best <strong>Session</strong> For Sure' + 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur',
     isBlanked: false,
     isPublished: true,
     isScheduled: false,
-    learningMaterials: [
-      {
-        title: 'In the window',
-        type: 'citation',
-        required: true,
-        isBlanked: false,
-        citation: 'citationtext',
-        endDate: today.clone().add(1, 'day').toDate(),
-        startDate: today.clone().subtract(1, 'day').toDate(),
-      },
-      {
-        title: 'Too Early',
-        type: 'citation',
-        required: true,
-        isBlanked: true,
-        citation: 'citationtext',
-        startDate: moment('2001-12-31').toDate(),
-      },
-      {
-        title: 'Too Late',
-        type: 'citation',
-        required: true,
-        isBlanked: true,
-        citation: 'citationtext',
-        endDate: moment('2035-06-01').toDate(),
-      },
-    ],
-    attireRequired: true,
-    equipmentRequired: true,
-    attendanceRequired: true,
-    supplemental: true,
+    offering: 1,
   },
 ];
 const userEventsMock = Service.extend({
@@ -177,7 +91,7 @@ module('Integration | Component | week glance', function(hooks) {
   };
 
   test('it renders with events', async function(assert) {
-    assert.expect(40);
+    assert.expect(6);
     this.owner.register('service:user-events', userEventsMock);
     this.userEvents = this.owner.lookup('service:user-events');
     this.set('today', today);
@@ -188,99 +102,15 @@ module('Integration | Component | week glance', function(hooks) {
       year=(moment-format today 'YYYY')
       week=(moment-format today 'W')
     }}`);
-    const title = 'h3';
-    const events = '.event';
-    const firstEvent = `${events}:nth-of-type(1)`;
-    const secondEvent = `${events}:nth-of-type(2)`;
-    const thirdEvent = `${events}:nth-of-type(3)`;
-
-    const firstEventTitle = `${firstEvent} .title`;
-    const firstSessionType = `${firstEvent} .sessiontype`;
-    const firstLocation = `${firstEvent} .location`;
-    const firstDescription = `${firstEvent} .description`;
-    const firstLearningMaterials = `${firstEvent} .learning-material`;
-    const firstLm1 = `${firstLearningMaterials}:nth-of-type(1)`;
-    const firstLm1TypeIcon = `${firstLm1} .fa-paragraph`;
-    const firstLm1IconTitle = `${firstLm1TypeIcon} title`;
-    const firstLm1Notes = `${firstLm1} .public-notes`;
-    const firstLm2 = `${firstLearningMaterials}:nth-of-type(2)`;
-    const firstLm2TypeIcon = `${firstLm2} .fa-link`;
-    const firstLm2IconTitle = `${firstLm2TypeIcon} title`;
-    const firstLm2Notes = `${firstLm2} .public-notes`;
-    const firstLm2Link = `${firstLm2} a`;
-    const firstLm3 = `${firstLearningMaterials}:nth-of-type(3)`;
-    const firstLm3Link = `${firstLm3} a:nth-of-type(1)`;
-    const firstLm3TypeIcon = `${firstLm3} .fa-file-pdf`;
-    const firstLm3IconTitle = `${firstLm3TypeIcon} title`;
-    const firstLm3DownloadLink = `${firstLm3} a:nth-of-type(2)`;
-    const firstInstructors = `${firstEvent} .instructors`;
-    const firstAttributes = `${firstEvent} .session-attributes svg`;
-    const secondEventTitle = `${secondEvent} .title`;
-    const secondSessionType = `${secondEvent} .sessiontype`;
-    const secondLocation = `${secondEvent} .location`;
-    const secondDescription = `${secondEvent} .description`;
-    const secondLearningMaterials = `${secondEvent} .learning-material`;
-    const secondLm1 = `${secondLearningMaterials}:nth-of-type(1)`;
-    const secondLm1Link = `${secondLm1} a`;
-    const secondLm1TypeIcon = `${secondLm1} .fa-file-pdf`;
-    const secondLm1Notes = `${secondLm1} .public-notes`;
-    const secondInstructors = `${secondEvent} .instructors`;
-    const secondAttributes = `${secondEvent} .session-attributes i`;
-    const thirdEventTitle = `${thirdEvent} .title`;
-    const thirdLearningMaterials = `${thirdEvent} .learning-material`;
-    const thirdLm1 = `${thirdLearningMaterials}:nth-of-type(1)`;
-    const thirdLm1Schedule = `${thirdLm1} .timed-release-info`;
-    const thirdLm2 = `${thirdLearningMaterials}:nth-of-type(2)`;
-    const thirdLm2Schedule = `${thirdLm2} .timed-release-info`;
-    const thirdLm3 = `${thirdLearningMaterials}:nth-of-type(3)`;
-    const thirdLm3Schedule = `${thirdLm3} .timed-release-info`;
 
 
-    await settled();
+    assert.equal(component.title, getTitle(true));
+    assert.equal(component.ilmEvents.length, 1);
+    assert.equal(component.ilmEvents[0].title, 'Finding the Point in Life');
 
-    const expectedTitle = getTitle(true);
-    assert.equal(this.element.querySelector(title).textContent.replace(/[\t\n\s]+/g, ""), expectedTitle.replace(/[\t\n\s]+/g, ""));
-    assert.equal(this.element.querySelectorAll(events).length, 3, 'Blank events are not shown');
-    assert.dom(firstEventTitle).hasText('Learn to Learn');
-    assert.dom(firstSessionType).hasText('Lecture');
-    assert.dom(firstLocation).hasText('- Room 123');
-    assert.dom(firstDescription).hasText('Best Session For SureLorem ipsum dolor sit amet, c');
-    assert.equal(find(firstLm1).textContent.replace(/[\t\n\s]+/g, ""), 'CitationCitationLMcitationtextThisiscool.');
-    assert.dom(firstLm1TypeIcon).exists({ count: 1 }, 'LM type icon is present.');
-    assert.dom(firstLm1IconTitle).hasText('Citation', 'LM type icon has correct title.');
-    assert.equal(find(firstLm1Notes).textContent.replace(/[\t\n\s]+/g, ""), 'Thisiscool.');
-    assert.ok(find(firstLm2).textContent.includes('Link LM'));
-    assert.dom(firstLm2TypeIcon).exists({ count: 1 }, 'LM type icon is present.');
-    assert.dom(firstLm2IconTitle).hasText('Web Link', 'LM type icon has correct title.');
-    assert.dom(firstLm2Notes).doesNotExist();
-    assert.equal(find(firstLm2Link).href, 'http://myhost.com/url2');
-    assert.ok(find(firstLm3).textContent.includes('File LM'));
-    assert.dom(firstLm3TypeIcon).exists({ count: 1 }, 'LM type icon is present.');
-    assert.dom(firstLm3IconTitle).hasText('File', 'LM type icon has correct title.');
-    assert.equal(find(firstLm3Link).href, 'http://myhost.com/url1?inline');
-    assert.equal(find(firstLm3DownloadLink).href, 'http://myhost.com/url1');
-    assert.dom(firstInstructors).doesNotExist('No Instructors leaves and empty spot');
-    assert.dom(firstAttributes).exists({ count: 4 }, 'All attributes flags show up');
-    assert.dom(this.element.querySelector('.fa-black-tie title')).hasText('Whitecoats / special attire');
-    assert.dom(this.element.querySelector('.fa-flask title')).hasText('Special Equipment');
-    assert.dom(this.element.querySelector('.fa-calendar-check title')).hasText('Attendance is required');
-
-    assert.dom(secondEventTitle).hasText('Finding the Point in Life');
-    assert.dom(secondSessionType).hasText('Independent Learning');
-    assert.dom(secondLocation).hasText('- Room 456');
-    assert.dom(secondDescription).doesNotExist('Empty Description is Empty');
-    assert.dom(secondLm1TypeIcon).exists({ count: 1 }, 'LM type icon is present.');
-    assert.ok(find(secondLm1Link).textContent.includes('Great Slides'));
-    assert.dom(secondLm1Notes).hasText('slide notes');
-    assert.equal(find(secondLm1Link).href, 'http://myhost.com/url1?inline');
-    assert.equal(find(secondInstructors).textContent.replace(/[\t\n\s]+/g, ""), 'Instructors:FirstPerson,SecondPerson', 'Instructors sorted and formated correctly');
-    assert.dom(secondAttributes).doesNotExist('no attributes flags show up');
-
-    assert.dom(thirdEventTitle).hasText('Schedule some materials');
-    assert.dom(thirdLearningMaterials).exists({ count: 3 }, 'all lms are visible');
-    assert.dom(thirdLm1Schedule).exists({ count: 1 }, 'event in between says something');
-    assert.dom(thirdLm2Schedule).exists({ count: 1 }, 'early LM says something');
-    assert.dom(thirdLm3Schedule).exists({ count: 1 }, 'late LM says something');
+    assert.equal(component.offeringEvents.length, 2);
+    assert.equal(component.offeringEvents[0].title, 'Learn to Learn');
+    assert.equal(component.offeringEvents[1].title, 'Schedule some materials');
   });
 
   test('it renders blank', async function(assert) {

--- a/tests/integration/services/school-events-test.js
+++ b/tests/integration/services/school-events-test.js
@@ -31,12 +31,16 @@ module('Integration | Service | school events', function(hooks) {
     const event1 = {
       offering: 1,
       startDate: '2011-04-21',
-      school: 7
+      school: 7,
+      prerequisites: [],
+      postrequisites: [],
     };
     const event2 = {
       ilmSession: 3,
       startDate: '2008-09-02',
-      school: 7
+      school: 7,
+      prerequisites: [],
+      postrequisites: [],
     };
     const from = moment('20150305', 'YYYYMMDD').hour(0);
     const to = from.clone().hour(24);
@@ -85,11 +89,15 @@ module('Integration | Service | school events', function(hooks) {
       offering: 1,
       startDate: '2011-04-21',
       school: 7,
+      prerequisites: [],
+      postrequisites: [],
     };
     const event2 = {
       ilmSession: 3,
       startDate: '2008-09-02',
-      school: 7
+      school: 7,
+      prerequisites: [],
+      postrequisites: [],
     };
     this.commonAjax.reopen({
       request(url) {
@@ -112,11 +120,15 @@ module('Integration | Service | school events', function(hooks) {
       offering: 1,
       startDate: '2011-04-21',
       school: 7,
+      prerequisites: [],
+      postrequisites: [],
     };
     const event2 = {
       ilmSession: 3,
       startDate: '2008-09-02',
-      school: 7
+      school: 7,
+      prerequisites: [],
+      postrequisites: [],
     };
     this.commonAjax.reopen({
       request(url) {
@@ -139,7 +151,9 @@ module('Integration | Service | school events', function(hooks) {
     const event = {
       startDate: moment('2013-01-21').toDate(),
       offering: 1,
-      school: 2
+      school: 2,
+      prerequisites: [],
+      postrequisites: [],
     };
     assert.equal(service.getSlugForEvent(event), 'S0220130121O1');
   });
@@ -150,7 +164,9 @@ module('Integration | Service | school events', function(hooks) {
     const event = {
       startDate: moment('2014-10-30').toDate(),
       ilmSession: 1,
-      school: 10
+      school: 10,
+      prerequisites: [],
+      postrequisites: [],
     };
     assert.equal(service.getSlugForEvent(event), 'S1020141030I1');
   });

--- a/tests/integration/services/user-events-test.js
+++ b/tests/integration/services/user-events-test.js
@@ -39,14 +39,20 @@ module('Integration | Service | user events', function(hooks) {
     assert.expect(10);
     const event1 = {
       offering: 1,
-      startDate: '2011-04-21'
+      startDate: '2011-04-21',
+      prerequisites: [],
+      postrequisites: [],
     };
     const event2 = {
       ilmSession: 3,
-      startDate: '2008-09-02'
+      startDate: '2008-09-02',
+      prerequisites: [],
+      postrequisites: [],
     };
     const event3 = {
-      startDate: '2015-11-20'
+      startDate: '2015-11-20',
+      prerequisites: [],
+      postrequisites: [],
     };
     const from = moment('20150305', 'YYYYMMDD').hour(0);
     const to = from.clone().hour(24);
@@ -117,12 +123,16 @@ module('Integration | Service | user events', function(hooks) {
     const event1 = {
       name: 'Zeppelin',
       offering: 1,
-      startDate: '2011-04-21'
+      startDate: '2011-04-21',
+      prerequisites: [],
+      postrequisites: [],
     };
     const event2 = {
       name: 'Aardvark',
       offering: 2,
-      startDate: '2011-04-21'
+      startDate: '2011-04-21',
+      prerequisites: [],
+      postrequisites: [],
     };
 
     const from = moment('20110421', 'YYYYMMDD').hour(0);
@@ -147,11 +157,15 @@ module('Integration | Service | user events', function(hooks) {
     assert.expect(2);
     const event1 = {
       offering: 1,
-      startDate: '2011-04-21'
+      startDate: '2011-04-21',
+      prerequisites: [],
+      postrequisites: [],
     };
     const event2 = {
       ilmSession: 3,
-      startDate: '2008-09-02'
+      startDate: '2008-09-02',
+      prerequisites: [],
+      postrequisites: [],
     };
     this.commonAjax.reopen({
       request(url) {
@@ -172,11 +186,15 @@ module('Integration | Service | user events', function(hooks) {
     assert.expect(2);
     const event1 = {
       offering: 1,
-      startDate: '2011-04-21'
+      startDate: '2011-04-21',
+      prerequisites: [],
+      postrequisites: [],
     };
     const event2 = {
       ilmSession: 3,
-      startDate: '2008-09-02'
+      startDate: '2008-09-02',
+      prerequisites: [],
+      postrequisites: [],
     };
     this.commonAjax.reopen({
       request(url) {
@@ -198,7 +216,9 @@ module('Integration | Service | user events', function(hooks) {
     const service = this.owner.lookup('service:user-events');
     const event = {
       startDate: moment('2013-01-21').toDate(),
-      offering: 1
+      offering: 1,
+      prerequisites: [],
+      postrequisites: [],
     };
     assert.equal(service.getSlugForEvent(event), 'U20130121O1');
   });
@@ -208,7 +228,9 @@ module('Integration | Service | user events', function(hooks) {
     const service = this.owner.lookup('service:user-events');
     const event = {
       startDate: moment('2014-10-30').toDate(),
-      ilmSession: 1
+      ilmSession: 1,
+      prerequisites: [],
+      postrequisites: [],
     };
     assert.equal(service.getSlugForEvent(event), 'U20141030I1');
   });

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -190,8 +190,9 @@ general:
   ownedBy: "owned by {owner}"
   owner: Owner
   parentCount: "{count, plural, =1 {1 has a parent} other {# have parents}}"
-  prerequisites: "Prerequisites"
   parentObjectives: "Parent Objectives"
+  prerequisites: "Prerequisites"
+  preWork: "PreWork"
   printSummary: "Print Summary"
   program: Program
   programAndCohort: "Program/Cohort"

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -82,6 +82,7 @@ general:
   displayName: "Display Name"
   done: Done
   download: Download
+  dueBefore: "Due Before {name} ({date})"
   dueBy: "Due By"
   duePriorTo: "Due prior to"
   dueThisDay: "Due this day"

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -115,6 +115,7 @@ general:
   include: Include
   incompleteSessions: "Sessions Incomplete: cannot publish"
   independentLearning: "Independent Learning"
+  independentLearningActivities: "Independent Learning Activities"
   instructionalNotes: "Instructional Notes"
   instructorGroups: "Instructor Groups"
   instructors: Instructors

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -82,7 +82,7 @@ general:
   displayName: "Display Name"
   done: Done
   download: Download
-  dueBefore: "Due Before {name} ({date})"
+  dueBefore: "Due Before <a href='{link}'>{name}</a> ({date})"
   dueBy: "Due By"
   duePriorTo: "Due prior to"
   dueThisDay: "Due this day"

--- a/translations/es.yaml
+++ b/translations/es.yaml
@@ -115,6 +115,7 @@ general:
   include: Incluir
   incompleteSessions: "Sesiónes Incompletas: No se pueden publicar"
   independentLearning: "Aprendizaje Independiente"
+  independentLearningActivities: "Aprendizaje Independiente Actividades"
   instructionalNotes: "Notes para la Instrucción"
   instructorGroups: "Grupos de Instructores"
   instructors: Instructores

--- a/translations/es.yaml
+++ b/translations/es.yaml
@@ -82,6 +82,7 @@ general:
   displayName: "Nombre de Mostrar"
   done: Acabado
   download: Descargar
+  dueBefore: "Debido antes de {name} ({date})"
   dueBy: "Debido Por"
   duePriorTo: "Debido antes de"
   dueThisDay: "Debido por esta fecha"

--- a/translations/es.yaml
+++ b/translations/es.yaml
@@ -82,7 +82,7 @@ general:
   displayName: "Nombre de Mostrar"
   done: Acabado
   download: Descargar
-  dueBefore: "Debido antes de {name} ({date})"
+  dueBefore: "Debido antes de <a href='{link}'>{name}</a> ({date})"
   dueBy: "Debido Por"
   duePriorTo: "Debido antes de"
   dueThisDay: "Debido por esta fecha"

--- a/translations/es.yaml
+++ b/translations/es.yaml
@@ -192,6 +192,7 @@ general:
   parentCount: "{count, plural, =1 {1 tiene un Principal objectivo} other {# tienen Objectivos Principales}}"
   parentObjectives: "Objetivos de Matriz"
   prerequisites: "Prerrequisitos"
+  preWork: "Pre Trabajo"
   printSummary: "Sumario Printado"
   program: Programa
   programAndCohort: "Programa/Clase de La Graduación"

--- a/translations/fr.yaml
+++ b/translations/fr.yaml
@@ -82,6 +82,7 @@ general:
   displayName: "Nom d’Affichage"
   done: Fini
   download: "Télécharger"
+  dueBefore: "Avant {name} ({date})"
   dueBy: Avant
   duePriorTo: "Dû avant"
   dueThisDay: "Dû ce jour-là"

--- a/translations/fr.yaml
+++ b/translations/fr.yaml
@@ -115,6 +115,7 @@ general:
   include: Inclure
   incompleteSessions: "Séances incomplète: ne peut être pas publiée"
   independentLearning: "Apprentissage autonome"
+  independentLearningActivities: "Apprentissage autonome Activités"
   instructionalNotes: "Notes Didactiques"
   instructorGroups: "Groupes des Instructeurs"
   instructors: Instructeurs

--- a/translations/fr.yaml
+++ b/translations/fr.yaml
@@ -192,6 +192,7 @@ general:
   parentCount: "{count, plural, =1 {1 a un objectif mère} other {# ont des objectifs mères}}"
   parentObjectives: "Objectifs Mères"
   prerequisites: "Conditions préalables"
+  preWork: "Préalable"
   printSummary: "Empreinte Résumé"
   program: "Diplôme"
   programAndCohort: "Diplôme et Cohortes"

--- a/translations/fr.yaml
+++ b/translations/fr.yaml
@@ -82,7 +82,7 @@ general:
   displayName: "Nom d’Affichage"
   done: Fini
   download: "Télécharger"
-  dueBefore: "Avant {name} ({date})"
+  dueBefore: "Avant <a href='{link}'>{name}</a> ({date})"
   dueBy: Avant
   duePriorTo: "Dû avant"
   dueThisDay: "Dû ce jour-là"


### PR DESCRIPTION
Refs ilios/frontend#1323
Adds prework section to week at a glance events

WIP:
- [x] Extract ILM prework into the top of the week at a glance
- [x] Sort out what should display when a lot of offerings are present in a prequisite 
- [x] Requires https://github.com/ilios/ilios/pull/2292
- [x] On single event view when and offering is prework it should display the offering date and then on the next line show the due prior to date.
- [x] In single event view the name of the postrequisite should be a link to that single event
- [x] Each event in week at a glance has a prework title and that should be the same size as otehr second level elements.
- [x] When there is no pre-work for a week the section should be removed instead of saying 'none`.