### PR TITLE
Stop using jQuery to strip HTML tags

### DIFF
--- a/addon/helpers/remove-html-tags.js
+++ b/addon/helpers/remove-html-tags.js
@@ -1,10 +1,10 @@
 /* eslint ember/no-global-jquery: 0 */
 import { helper } from '@ember/component/helper';
-import $ from 'jquery';
+import striptags from 'striptags';
 
 export function removeHtmlTags(params) {
   if (!(params[0] === undefined)) {
-    return $("<p>" + params[0] + "</p>").text();
+    return striptags(params[0]);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "ember-test-selectors": "^2.0.0",
     "ember-truth-helpers": "^2.0.0",
     "liquid-fire": "^0.29.5",
-    "scroll-into-view": "^1.9.3"
+    "scroll-into-view": "^1.9.3",
+    "striptags": "^3.1.1"
   },
   "devDependencies": {
     "@ember/jquery": "^0.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11417,6 +11417,11 @@ strip-json-comments@~1.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-1.0.4.tgz#1e15fbcac97d3ee99bf2d73b4c656b082bbafb91"
   integrity sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=
 
+striptags@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/striptags/-/striptags-3.1.1.tgz#c8c3e7fdd6fb4bb3a32a3b752e5b5e3e38093ebd"
+  integrity sha1-yMPn/db7S7OjKjt1LltePjgJPr0=
+
 styled_string@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/styled_string/-/styled_string-0.0.1.tgz#d22782bd81295459bc4f1df18c4bad8e94dd124a"


### PR DESCRIPTION
Ember is on a quest to remove jQuery, the less we do with it the better.