### PR TITLE
moved remove-html-tags helper unit test from frontend.

### DIFF
--- a/tests/unit/helpers/remove-html-tags-test.js
+++ b/tests/unit/helpers/remove-html-tags-test.js
@@ -1,0 +1,9 @@
+import { removeHtmlTags } from '../../../helpers/remove-html-tags';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | remove html tags');
+
+test('it removes the html tags from a string', function(assert) {
+  let result = removeHtmlTags(["<p>Tags should</p><p> not show up</p>"]);
+  assert.equal(result, "Tags should not show up");
+});


### PR DESCRIPTION
the helper is in common now, but the corresponding test was still hanging around in frontend. 
move it here, where it belongs.