### PR TITLE
Remove greenkeeper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,6 @@ branches:
 
 jobs:
   include:
-    - stage: greenkeeper
-      if: branch =~ ^greenkeeper
-      script:
-        - greenkeeper-lockfile-update
-        - greenkeeper-lockfile-upload
     # runs linting and tests with current locked deps
     - stage: "Tests"
       name: "Tests"
@@ -40,7 +35,6 @@ jobs:
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH
-  - yarn global add greenkeeper-lockfile@1
 
 install:
   - yarn install --no-lockfile --non-interactive

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Ilios Common Code
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/ilios/common.svg)](https://greenkeeper.io/)
-
 ## Shared code repository for:
 
 - [Ilios Frontend](https://github.com/ilios/common)

--- a/package.json
+++ b/package.json
@@ -123,23 +123,5 @@
   "pre-commit": [
     "lint:hbs",
     "lint:js"
-  ],
-  "greenkeeper": {
-    "ignore": [
-      "ember-cli-babel",
-      "ember-cli-dependency-checker",
-      "ember-cli-htmlbars-inline-precompile",
-      "ember-cli-htmlbars",
-      "ember-cli-inject-live-reload",
-      "ember-qunit",
-      "ember-cli-sri",
-      "ember-cli-uglify",
-      "ember-export-application-global",
-      "ember-load-initializers",
-      "ember-maybe-import-regenerator",
-      "ember-resolver",
-      "loader.js",
-      "qunit-dom"
-    ]
-  }
+  ]
 }


### PR DESCRIPTION
Making a move to dependabot which has a better build server and
configuration system so I'm removing GK first to avoid double dependency
management hell.