### PR TITLE
Filter events correctly

### DIFF
--- a/addon/components/ilios-calendar-day.js
+++ b/addon/components/ilios-calendar-day.js
@@ -27,7 +27,7 @@ export default Component.extend({
   nonIlmPreWorkEvents: computed('calendarEvents.[]', function () {
     const calendarEvents = this.calendarEvents || [];
     return calendarEvents.filter(ev => {
-      return ev.postrequisites.length === 0 && !ev.ilmSession;
+      return ev.postrequisites.length === 0 || !ev.ilmSession;
     });
   }),
   singleDayEvents: computed('nonIlmPreWorkEvents.[]', function(){

--- a/addon/components/ilios-calendar-month.js
+++ b/addon/components/ilios-calendar-month.js
@@ -20,7 +20,7 @@ export default Component.extend({
   nonIlmPreWorkEvents: computed('calendarEvents.[]', function () {
     const calendarEvents = this.calendarEvents || [];
     return calendarEvents.filter(ev => {
-      return ev.postrequisites.length === 0 && !ev.ilmSession;
+      return ev.postrequisites.length === 0 || !ev.ilmSession;
     });
   }),
   actions: {

--- a/addon/components/ilios-calendar-week.js
+++ b/addon/components/ilios-calendar-week.js
@@ -32,7 +32,7 @@ export default Component.extend({
   nonIlmPreWorkEvents: computed('calendarEvents.[]', function () {
     const calendarEvents = this.calendarEvents || [];
     return calendarEvents.filter(ev => {
-      return ev.postrequisites.length === 0 && !ev.ilmSession;
+      return ev.postrequisites.length === 0 || !ev.ilmSession;
     });
   }),
   singleDayEvents: computed('nonIlmPreWorkEvents.[]', function(){

--- a/addon/components/week-glance.js
+++ b/addon/components/week-glance.js
@@ -88,7 +88,7 @@ export default Component.extend({
   nonIlmPreWorkEvents: computed('publishedWeekEvents.[]', async function () {
     const publishedWeekEvents = await this.get('publishedWeekEvents');
     return publishedWeekEvents.filter(ev => {
-      return ev.postrequisites.length === 0 && !ev.ilmSession;
+      return ev.postrequisites.length === 0 || !ev.ilmSession;
     });
   }),
 });


### PR DESCRIPTION
Bad && here, was filtering out both events with no postreqs as well as
all ILMs instead of just Ilms with postreqs.

There is testing which covers this, but the PR that broke did not rebase with those tests :(