### PR TITLE
move slug generation functionality into mixin.

### DIFF
--- a/addon/services/school-events.js
+++ b/addon/services/school-events.js
@@ -31,7 +31,7 @@ export default Service.extend(EventMixin, {
     const commonAjax = this.get('commonAjax');
     const data = await commonAjax.request(url);
 
-    return data.events.map(obj => this.createEventFromData(obj)).sortBy('startDate', 'name');
+    return data.events.map(obj => this.createEventFromData(obj, false)).sortBy('startDate', 'name');
   },
 
   /**
@@ -57,29 +57,5 @@ export default Service.extend(EventMixin, {
         return parseInt(event.ilmSession, 10) === id;
       }
     });
-  },
-
-  /**
-   * Generates a slug for a given event.
-   * @method getSlugForEvent
-   * @param {Object} event
-   * @return {String}
-   */
-  getSlugForEvent(event){
-    let slug = 'S';
-    let schoolId = parseInt(event.school, 10).toString();
-    //always use a two digit schoolId
-    if(schoolId.length === 1){
-      schoolId = '0' + schoolId;
-    }
-    slug += schoolId;
-    slug += moment(event.startDate).format('YYYYMMDD');
-    if(event.offering){
-      slug += 'O' + event.offering;
-    }
-    if(event.ilmSession){
-      slug += 'I' + event.ilmSession;
-    }
-    return slug;
   },
 });

--- a/addon/services/user-events.js
+++ b/addon/services/user-events.js
@@ -35,7 +35,7 @@ export default Service.extend(EventMixin, {
     const commonAjax = this.get('commonAjax');
     const data = await commonAjax.request(url);
 
-    return data.userEvents.map(obj => this.createEventFromData(obj)).sortBy('startDate', 'name');
+    return data.userEvents.map(obj => this.createEventFromData(obj, true)).sortBy('startDate', 'name');
   },
 
   /**

--- a/tests/integration/services/school-events-test.js
+++ b/tests/integration/services/school-events-test.js
@@ -144,30 +144,4 @@ module('Integration | Service | school events', function(hooks) {
       assert.equal(event, event2);
     });
   });
-
-  test('getSlugForEvent - offering', function(assert) {
-    assert.expect(1);
-    const service = this.owner.lookup('service:school-events');
-    const event = {
-      startDate: moment('2013-01-21').toDate(),
-      offering: 1,
-      school: 2,
-      prerequisites: [],
-      postrequisites: [],
-    };
-    assert.equal(service.getSlugForEvent(event), 'S0220130121O1');
-  });
-
-  test('getSlugForEvent - ILM', function(assert) {
-    assert.expect(1);
-    const service = this.owner.lookup('service:school-events');
-    const event = {
-      startDate: moment('2014-10-30').toDate(),
-      ilmSession: 1,
-      school: 10,
-      prerequisites: [],
-      postrequisites: [],
-    };
-    assert.equal(service.getSlugForEvent(event), 'S1020141030I1');
-  });
 });

--- a/tests/integration/services/user-events-test.js
+++ b/tests/integration/services/user-events-test.js
@@ -210,28 +210,4 @@ module('Integration | Service | user events', function(hooks) {
       assert.equal(event, event2);
     });
   });
-
-  test('getSlugForEvent - offering', function(assert) {
-    assert.expect(1);
-    const service = this.owner.lookup('service:user-events');
-    const event = {
-      startDate: moment('2013-01-21').toDate(),
-      offering: 1,
-      prerequisites: [],
-      postrequisites: [],
-    };
-    assert.equal(service.getSlugForEvent(event), 'U20130121O1');
-  });
-
-  test('getSlugForEvent - ILM', function(assert) {
-    assert.expect(1);
-    const service = this.owner.lookup('service:user-events');
-    const event = {
-      startDate: moment('2014-10-30').toDate(),
-      ilmSession: 1,
-      prerequisites: [],
-      postrequisites: [],
-    };
-    assert.equal(service.getSlugForEvent(event), 'U20141030I1');
-  });
 });

--- a/tests/unit/mixins/events-test.js
+++ b/tests/unit/mixins/events-test.js
@@ -3,6 +3,7 @@ import RSVP from 'rsvp';
 import { run } from '@ember/runloop';
 import EventsMixin from 'ilios-common/mixins/events';
 import { module, test } from 'qunit';
+import moment from 'moment';
 
 const { resolve } = RSVP;
 
@@ -154,5 +155,56 @@ module('Unit | Mixin | events', function(hooks) {
       assert.ok(cohortIds.includes(20));
       assert.ok(cohortIds.includes(30));
     });
+  });
+
+  test('getSlugForSchoolEvent - offering', function(assert) {
+    assert.expect(1);
+    const subject = this.subject();
+    const event = {
+      startDate: moment('2013-01-21').toDate(),
+      offering: 1,
+      school: 2,
+      prerequisites: [],
+      postrequisites: [],
+    };
+    assert.equal(subject.getSlugForSchoolEvent(event), 'S0220130121O1');
+  });
+
+  test('getSlugForSchoolEvent - ILM', function(assert) {
+    assert.expect(1);
+    const subject = this.subject();
+    const event = {
+      startDate: moment('2014-10-30').toDate(),
+      ilmSession: 1,
+      school: 10,
+      prerequisites: [],
+      postrequisites: [],
+    };
+    assert.equal(subject.getSlugForSchoolEvent(event), 'S1020141030I1');
+  });
+
+
+  test('getSlugForUserEvent - offering', function(assert) {
+    assert.expect(1);
+    const subject = this.subject();
+    const event = {
+      startDate: moment('2013-01-21').toDate(),
+      offering: 1,
+      prerequisites: [],
+      postrequisites: [],
+    };
+    assert.equal(subject.getSlugForUserEvent(event), 'U20130121O1');
+  });
+
+  test('getSlugForUserEvent - ILM', function(assert) {
+    assert.expect(1);
+    const subject = this.subject();
+    const event = {
+      startDate: moment('2014-10-30').toDate(),
+      ilmSession: 1,
+      prerequisites: [],
+      postrequisites: [],
+    };
+    assert.equal(subject.getSlugForUserEvent(event), 'U20141030I1');
   });
 });


### PR DESCRIPTION
we need those slug-generating functions in the mixin since we want to splash it into other components, like the user-profile-calendar in frontend.

refs ilios/frontend#4290