### PR TITLE
Automatically Publish Tags to NPM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,3 +42,10 @@ install:
 
 script:
   - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO
+
+deploy:
+  provider: npm
+  email: jon.johnson@ucsf.edu
+  api_key: $NPM_TOKEN
+  on:
+    tags: true


### PR DESCRIPTION
This allows us to push tags and then not worry about the publish step.