### PR TITLE
Improve calendar loading

### DIFF
--- a/addon/components/ilios-calendar-day.js
+++ b/addon/components/ilios-calendar-day.js
@@ -13,7 +13,9 @@ export default Component.extend({
   areEventsSelectable: true,
   didInsertElement(){
     run.next(() => {
-      this.$(".el-calendar .week").scrollTop(500);
+      if (!this.isDestroyed && !this.isDestroying && this.element) {
+        this.element.querySelector(".el-calendar .week").scrollTop = 500;
+      }
     });
   },
   ilmPreWorkEvents: computed('calendarEvents.[]', function () {

--- a/addon/components/ilios-calendar-week.js
+++ b/addon/components/ilios-calendar-week.js
@@ -17,7 +17,9 @@ export default Component.extend({
   }),
   didInsertElement(){
     run.next(() => {
-      this.$(".el-calendar .week").scrollTop(500);
+      if (!this.isDestroyed && !this.isDestroying && this.element) {
+        this.element.querySelector(".el-calendar .week").scrollTop = 500;
+      }
     });
   },
   ilmPreWorkEvents: computed('calendarEvents.[]', function () {


### PR DESCRIPTION
Removes the jQuery dependency and also ensures that the calendar hasn't
already been remove from the page before it is scrolled which can happen
when users flip back and forth to another view.

Fixes ilios/frontend#4292