### PR TITLE
Reorganize the way the JWT is found

### DIFF
--- a/addon/services/ajax.js
+++ b/addon/services/ajax.js
@@ -11,12 +11,12 @@ export default AjaxService.extend({
   host: reads('iliosConfig.apiHost'),
 
   headers: computed('session.isAuthenticated', 'session.data.authenticated.jwt', function(){
-    const session = this.get('session');
-    const { jwt } = session.data.authenticated;
     let headers = {};
-
-    if (jwt) {
-      headers['X-JWT-Authorization'] = `Token ${jwt}`;
+    if(this.session){
+      const jwt = this.session.get('data.authenticated.jwt');
+      if (jwt) {
+        headers['X-JWT-Authorization'] = `Token ${jwt}`;
+      }
     }
 
     return headers;


### PR DESCRIPTION
When JWT wasn't set (the user was logged out) this would die horribly.
Instead we need to do some validation steps and get the property in a
better way.

Fixes ilios/frontend#4291