### PR TITLE
Add a null check when escaping regex

### DIFF
--- a/addon/utils/escape-reg-exp.js
+++ b/addon/utils/escape-reg-exp.js
@@ -1,4 +1,7 @@
 // @link https://developer.mozilla.org/en/docs/Web/JavaScript/Guide/Regular_Expressions#Using_special_characters
-export default function escapeRegExp(string){
+export default function escapeRegExp(string) {
+  if (!string) {
+    return string;
+  }
   return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/tests/unit/utils/escape-reg-exp-test.js
+++ b/tests/unit/utils/escape-reg-exp-test.js
@@ -6,5 +6,7 @@ module('Unit | Utility | escape Regular Expressions special characters', functio
     assert.equal(escapeRegExp('\\^$*+?.()|{}[]'), '\\\\\\^\\$\\*\\+\\?\\.\\(\\)\\|\\{\\}\\[\\]');
     assert.equal(escapeRegExp('abc'), 'abc');
     assert.equal(escapeRegExp('MoneyBag$$$ +1'), 'MoneyBag\\$\\$\\$ \\+1');
+    assert.equal(escapeRegExp(null), null);
+    assert.equal(escapeRegExp(''), '');
   });
 });


### PR DESCRIPTION
So we don't have to put a guard on every invocation of this.