### PR TITLE
Protect against empty objects in the session

### DIFF
--- a/addon/services/current-user.js
+++ b/addon/services/current-user.js
@@ -8,17 +8,10 @@ export default Service.extend({
   store: service(),
   session: service(),
   currentUserId: computed('session.data.authenticated.jwt', function(){
-    const session = this.get('session');
-    if(isEmpty(session)){
+    if (!this.session || !this.session.data || !this.session.data.authenticated || !this.session.data.authenticated.jwt) {
       return null;
     }
-
-    const jwt = session.get('data.authenticated.jwt');
-
-    if(isEmpty(jwt)){
-      return null;
-    }
-    const obj = jwtDecode(jwt);
+    const obj = jwtDecode(this.session.data.authenticated.jwt);
 
     return get(obj, 'user_id');
   }),


### PR DESCRIPTION
If a user has timed out they will have a sessions still, but no
authentication object so we need to protect that as well. Consolidating
all of the checks into a single statement. I thought `.get()` did this for us, but it doesn't seem to.

Fixes ilios/frontend#4406