### PR TITLE
Don't use jQuery to trim LM search

### DIFF
--- a/addon-test-support/ilios-common/page-objects/components/learning-materials.js
+++ b/addon-test-support/ilios-common/page-objects/components/learning-materials.js
@@ -9,6 +9,7 @@ import {
   value
 } from 'ember-cli-page-object';
 import meshManager from './mesh-manager';
+import search from './learningmaterial-search';
 import {
   fillInFroalaEditor,
   froalaEditorValue
@@ -17,14 +18,13 @@ import { datePicker } from 'ilios-common';
 
 export default {
   scope: '[data-test-detail-learning-materials]',
+  search,
   createNew: clickable('.detail-learningmaterials-actions button'),
   pickNew: clickOnText('.detail-learningmaterials-actions ul li'),
   save: clickable('.actions button.bigadd'),
   cancel: clickable('.actions button.bigcancel'),
-  canSearch: isVisible('[data-test-search-box]'),
   canCreateNew: isVisible('.detail-learningmaterials-actions .action-menu'),
   canCollapse: isVisible('.detail-learningmaterials-actions .collapse-button'),
-  search: fillable('[data-test-search-box] input'),
   current: collection({
     scope: '.detail-learningmaterials-content table',
     itemScope: 'tbody tr',
@@ -38,23 +38,6 @@ export default {
       isNotePublic: isVisible('.fa-eye'),
       isTimedRelease: isVisible('.fa-clock'),
       details: clickable('.link', { at: 0 }),
-    },
-  }),
-  searchResults: collection({
-    scope: '.lm-search-results',
-    itemScope: '> li',
-    item: {
-      title: text('[data-test-title]'),
-      description: text('learning-material-description'),
-      hasFileIcon: isVisible('.fa-file'),
-      properties: collection({
-        scope: '.learning-material-properties',
-        itemScope: 'li',
-        item: {
-          value: text(),
-        },
-      }),
-      add: clickable(),
     },
   }),
   newLearningMaterial: {
@@ -118,6 +101,5 @@ export default {
     },
     hasEndDateValidationError: isVisible('[data-test-end-date-validation-error-message]'),
     hasTitleValidationError: isVisible('[data-test-title-validation-error-message]')
-
-  }
+  },
 };

--- a/addon-test-support/ilios-common/page-objects/components/learningmaterial-search.js
+++ b/addon-test-support/ilios-common/page-objects/components/learningmaterial-search.js
@@ -1,0 +1,25 @@
+import {
+  clickable,
+  collection,
+  create,
+  fillable,
+  isVisible,
+  text,
+} from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-learningmaterial-search]',
+  search: fillable('[data-test-search-box] input'),
+  searchResults: collection('.lm-search-results > li', {
+    title: text('[data-test-title]'),
+    description: text('learning-material-description'),
+    hasFileIcon: isVisible('.fa-file'),
+    properties: collection('.learning-material-properties li', {
+      value: text(),
+    }),
+    add: clickable(),
+  }),
+};
+
+export default definition;
+export const component = create(definition);

--- a/addon/components/learningmaterial-search.js
+++ b/addon/components/learningmaterial-search.js
@@ -1,5 +1,4 @@
 
-import $ from 'jquery';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { task } from 'ember-concurrency';
@@ -19,6 +18,7 @@ export default Component.extend({
   targetItemTitle: '',
   searching: false,
   searchReturned: false,
+  'data-test-learningmaterial-search': true,
 
   init(){
     this._super(...arguments);
@@ -26,7 +26,7 @@ export default Component.extend({
   },
   actions: {
     search(query){
-      if ($.trim(query) === '') {
+      if (query.trim() === '') {
         this.set('searchReturned', false);
         this.set('searching', false);
         this.set('searchPage', 1);

--- a/tests/acceptance/course/learningmaterials-test.js
+++ b/tests/acceptance/course/learningmaterials-test.js
@@ -158,10 +158,10 @@ module('Acceptance | Course - Learning Materials', function(hooks) {
 
       await page.visit({ courseId: 1, details: true });
       assert.equal(page.learningMaterials.current().count, 4);
-      assert.ok(page.learningMaterials.canSearch);
+      assert.ok(page.learningMaterials.search.isVisible);
       await page.learningMaterials.createNew();
       await page.learningMaterials.pickNew('Web Link');
-      assert.notOk(page.learningMaterials.canSearch, 'search box is hidden while new group are being added');
+      assert.notOk(page.learningMaterials.search.isVisible, 'search box is hidden while new group are being added');
 
       await page.learningMaterials.newLearningMaterial.name(testTitle);
       assert.equal(page.learningMaterials.newLearningMaterial.userName, '0 guy M. Mc0son');
@@ -185,10 +185,10 @@ module('Acceptance | Course - Learning Materials', function(hooks) {
 
       await page.visit({ courseId: 1, details: true });
       assert.equal(page.learningMaterials.current().count, 4);
-      assert.ok(page.learningMaterials.canSearch);
+      assert.ok(page.learningMaterials.search.isVisible);
       await page.learningMaterials.createNew();
       await page.learningMaterials.pickNew('Citation');
-      assert.notOk(page.learningMaterials.canSearch, 'search box is hidden while new group are being added');
+      assert.notOk(page.learningMaterials.search.isVisible, 'search box is hidden while new group are being added');
 
       await page.learningMaterials.newLearningMaterial.name(testTitle);
       assert.equal(page.learningMaterials.newLearningMaterial.userName, '0 guy M. Mc0son');
@@ -219,7 +219,7 @@ module('Acceptance | Course - Learning Materials', function(hooks) {
       this.user.update({ administeredSchools: [this.school] });
       await page.visit({ courseId: 1, details: true });
       assert.equal(page.learningMaterials.current().count, 4);
-      assert.ok(page.learningMaterials.canSearch);
+      assert.ok(page.learningMaterials.search.isVisible);
       await page.learningMaterials.createNew();
       await page.learningMaterials.pickNew('Citation');
       await page.learningMaterials.newLearningMaterial.cancel();
@@ -445,16 +445,16 @@ module('Acceptance | Course - Learning Materials', function(hooks) {
       this.user.update({ administeredSchools: [this.school] });
       await page.visit({ courseId: 1, details: true });
       assert.equal(page.learningMaterials.current().count, 4);
-      await page.learningMaterials.search('doc');
-      assert.equal(page.learningMaterials.searchResults().count, 1);
+      await page.learningMaterials.search.search('doc');
+      assert.equal(page.learningMaterials.search.searchResults.length, 1);
 
-      assert.equal(page.learningMaterials.searchResults(0).title, 'Letter to Doc Brown');
-      assert.ok(page.learningMaterials.searchResults(0).hasFileIcon);
-      assert.equal(page.learningMaterials.searchResults(0).properties().count, 3);
-      assert.equal(page.learningMaterials.searchResults(0).properties(0).value, 'Owner: 0 guy M. Mc0son');
-      assert.equal(page.learningMaterials.searchResults(0).properties(1).value, 'Content Author: ' + 'Marty McFly');
-      assert.equal(page.learningMaterials.searchResults(0).properties(2).value, 'Upload date: ' + moment('2016-03-03').format('M-D-YYYY'));
-      await page.learningMaterials.searchResults(0).add();
+      assert.equal(page.learningMaterials.search.searchResults[0].title, 'Letter to Doc Brown');
+      assert.ok(page.learningMaterials.search.searchResults[0].hasFileIcon);
+      assert.equal(page.learningMaterials.search.searchResults[0].properties.length, 3);
+      assert.equal(page.learningMaterials.search.searchResults[0].properties[0].value, 'Owner: 0 guy M. Mc0son');
+      assert.equal(page.learningMaterials.search.searchResults[0].properties[1].value, 'Content Author: ' + 'Marty McFly');
+      assert.equal(page.learningMaterials.search.searchResults[0].properties[2].value, 'Upload date: ' + moment('2016-03-03').format('M-D-YYYY'));
+      await page.learningMaterials.search.searchResults[0].add();
       assert.equal(page.learningMaterials.current().count, 5);
     });
 

--- a/tests/acceptance/course/session/learningmaterials-test.js
+++ b/tests/acceptance/course/session/learningmaterials-test.js
@@ -159,10 +159,10 @@ module('Acceptance | Session - Learning Materials', function(hooks) {
 
       await page.visit({ courseId: 1, sessionId: 1 });
       assert.equal(page.learningMaterials.current().count, 4);
-      assert.ok(page.learningMaterials.canSearch);
+      assert.ok(page.learningMaterials.search.isVisible);
       await page.learningMaterials.createNew();
       await page.learningMaterials.pickNew('Web Link');
-      assert.notOk(page.learningMaterials.canSearch, 'search box is hidden while new group are being added');
+      assert.notOk(page.learningMaterials.search.isVisible, 'search box is hidden while new group are being added');
 
       await page.learningMaterials.newLearningMaterial.name(testTitle);
       assert.equal(page.learningMaterials.newLearningMaterial.userName, '0 guy M. Mc0son');
@@ -186,10 +186,10 @@ module('Acceptance | Session - Learning Materials', function(hooks) {
 
       await page.visit({ courseId: 1, sessionId: 1 });
       assert.equal(page.learningMaterials.current().count, 4);
-      assert.ok(page.learningMaterials.canSearch);
+      assert.ok(page.learningMaterials.search.isVisible);
       await page.learningMaterials.createNew();
       await page.learningMaterials.pickNew('Citation');
-      assert.notOk(page.learningMaterials.canSearch, 'search box is hidden while new group are being added');
+      assert.notOk(page.learningMaterials.search.isVisible, 'search box is hidden while new group are being added');
 
       await page.learningMaterials.newLearningMaterial.name(testTitle);
       assert.equal(page.learningMaterials.newLearningMaterial.userName, '0 guy M. Mc0son');
@@ -221,7 +221,7 @@ module('Acceptance | Session - Learning Materials', function(hooks) {
 
       await page.visit({ courseId: 1, sessionId: 1 });
       assert.equal(page.learningMaterials.current().count, 4);
-      assert.ok(page.learningMaterials.canSearch);
+      assert.ok(page.learningMaterials.search.isVisible);
       await page.learningMaterials.createNew();
       await page.learningMaterials.pickNew('Citation');
       await page.learningMaterials.newLearningMaterial.cancel();
@@ -442,16 +442,16 @@ module('Acceptance | Session - Learning Materials', function(hooks) {
       this.user.update({ administeredSchools: [this.school] });
       await page.visit({ courseId: 1, sessionId: 1 });
       assert.equal(page.learningMaterials.current().count, 4);
-      await page.learningMaterials.search('doc');
-      assert.equal(page.learningMaterials.searchResults().count, 1);
+      await page.learningMaterials.search.search('doc');
+      assert.equal(page.learningMaterials.search.searchResults.length, 1);
 
-      assert.equal(page.learningMaterials.searchResults(0).title, 'Letter to Doc Brown');
-      assert.ok(page.learningMaterials.searchResults(0).hasFileIcon);
-      assert.equal(page.learningMaterials.searchResults(0).properties().count, 3);
-      assert.equal(page.learningMaterials.searchResults(0).properties(0).value, 'Owner: 0 guy M. Mc0son');
-      assert.equal(page.learningMaterials.searchResults(0).properties(1).value, 'Content Author: ' + 'Marty McFly');
-      assert.equal(page.learningMaterials.searchResults(0).properties(2).value, 'Upload date: ' + moment('2016-03-03').format('M-D-YYYY'));
-      await page.learningMaterials.searchResults(0).add();
+      assert.equal(page.learningMaterials.search.searchResults[0].title, 'Letter to Doc Brown');
+      assert.ok(page.learningMaterials.search.searchResults[0].hasFileIcon);
+      assert.equal(page.learningMaterials.search.searchResults[0].properties.length, 3);
+      assert.equal(page.learningMaterials.search.searchResults[0].properties[0].value, 'Owner: 0 guy M. Mc0son');
+      assert.equal(page.learningMaterials.search.searchResults[0].properties[1].value, 'Content Author: ' + 'Marty McFly');
+      assert.equal(page.learningMaterials.search.searchResults[0].properties[2].value, 'Upload date: ' + moment('2016-03-03').format('M-D-YYYY'));
+      await page.learningMaterials.search.searchResults[0].add();
       assert.equal(page.learningMaterials.current().count, 5);
     });
 

--- a/tests/integration/components/learningmaterial-search-test.js
+++ b/tests/integration/components/learningmaterial-search-test.js
@@ -3,15 +3,29 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { setupIntl } from 'ember-intl/test-support';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { component } from 'ilios-common/page-objects/components/learningmaterial-search';
 
 module('Integration | Component | learningmaterial search', function(hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks);
+  setupMirage(hooks);
 
-  test('it renders', async function(assert) {
+  test('search shows results', async function(assert) {
     assert.expect(1);
+    this.server.createList('learning-material', 2);
     await render(hbs`{{learningmaterial-search}}`);
+    await component.search('material');
+    assert.equal(component.searchResults.length, 2);
+  });
 
-    assert.dom(this.element).hasText('');
+  test('empty search clears results', async function(assert) {
+    assert.expect(2);
+    this.server.createList('learning-material', 2);
+    await render(hbs`{{learningmaterial-search}}`);
+    await component.search('    material    ');
+    assert.equal(component.searchResults.length, 2);
+    await component.search('        ');
+    assert.equal(component.searchResults.length, 0);
   });
 });


### PR DESCRIPTION
Adding a test for this change might have gotten a bit too involved :) I
moved the component into a page object and then also removed the legacy
collections from the page object component.