### PR TITLE
update All Weeks link title

### DIFF
--- a/addon/templates/components/dashboard-week.hbs
+++ b/addon/templates/components/dashboard-week.hbs
@@ -1,16 +1,13 @@
 <div class="weeklylink" data-test-weekly-link>
   {{t "general.view"}}:
-  {{#link-to
-    "weeklyevents"
-    (query-params expanded=expanded)
-  }}
-    {{t "general.lastNextAllWeeks"}}
+  {{#link-to "weeklyevents" (query-params expanded=expanded)}}
+    {{t "general.allWeeks"}}
   {{/link-to}}
 </div>
+
 {{week-glance
-  collapsible=false
   collapsed=false
+  collapsible=false
   showFullTitle=true
-  year=year
   week=week
-}}
+  year=year}}

--- a/tests/integration/components/dashboard-week-test.js
+++ b/tests/integration/components/dashboard-week-test.js
@@ -85,13 +85,10 @@ module('Integration | Component | dashboard week', function(hooks) {
     this.owner.register('service:user-events', this.userEventsMock);
 
     await render(hbs`{{dashboard-week}}`);
-
     const expectedTitle = getTitle();
-
-    assert.equal(component.weeklyLink, 'Last Week / Next Week / All Weeks');
+    assert.equal(component.weeklyLink, 'All Weeks');
     assert.equal(component.weekGlance.title, expectedTitle);
     assert.equal(component.weekGlance.offeringEvents.length, 2, 'Blank events are not shown');
-
     assert.equal(component.weekGlance.offeringEvents[0].title, 'Learn to Learn');
     assert.equal(component.weekGlance.offeringEvents[1].title, 'Finding the Point in Life');
   });
@@ -103,8 +100,7 @@ module('Integration | Component | dashboard week', function(hooks) {
 
     await render(hbs`{{dashboard-week}}`);
     const expectedTitle = getTitle();
-
-    assert.equal(component.weeklyLink, 'Last Week / Next Week / All Weeks');
+    assert.equal(component.weeklyLink, 'All Weeks');
     assert.equal(component.weekGlance.title, expectedTitle);
     assert.equal(component.weekGlance.offeringEvents.length, 0);
   });

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -122,7 +122,6 @@ general:
   instructorGroups: "Instructor Groups"
   instructors: Instructors
   instructorsManageTitle: "Manage Instructors"
-  lastNextAllWeeks: "Last Week / Next Week / All Weeks"
   learnerGroups: "Learner Groups"
   learnerGroupsManageTitle: "Manage Learner Groups"
   learners: Learners

--- a/translations/es.yaml
+++ b/translations/es.yaml
@@ -122,7 +122,6 @@ general:
   instructorGroups: "Grupos de Instructores"
   instructors: Instructores
   instructorsManageTitle: "Administrar Instructores"
-  lastNextAllWeeks: "La Semana Pasada / La Semana Próxima / Todas Las Semanas"
   learnerGroups: "Grupos de Aprendedores"
   learnerGroupsManageTitle: "Administrar Grupos de Aprendedores"
   learners: Aprendedores

--- a/translations/fr.yaml
+++ b/translations/fr.yaml
@@ -122,7 +122,6 @@ general:
   instructorGroups: "Groupes des Instructeurs"
   instructors: Instructeurs
   instructorsManageTitle: "Manager Instructeurs"
-  lastNextAllWeeks: "dernière semaine / la semaine prochaîne / toutes les semaine"
   learnerGroups: "Groupes d'Étudiants"
   learnerGroupsManageTitle: "Manager groupes d'apprenants"
   learners: "Étudiants"


### PR DESCRIPTION
**Summary:**
Updated `weeklyevents` link text from `Last Week / Next Week / All Weeks` to `All Weeks`.

**UI:**
<img width="894" alt="Screen Shot 2019-03-25 at 6 03 00 PM" src="https://user-images.githubusercontent.com/7553764/54957132-42d43380-4f28-11e9-9983-fcdb29158b3f.png">

Fixes https://github.com/ilios/frontend/issues/3980