### PR TITLE
fixed buggy time inputs

### DIFF
--- a/addon/components/offering-form.js
+++ b/addon/components/offering-form.js
@@ -1,13 +1,14 @@
-import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';
+import { not } from '@ember/object/computed';
+import { inject as service } from '@ember/service';
+import { isEmpty, isPresent } from '@ember/utils';
 import {
   Promise as RSVPPromise,
-  map,
   filter,
-  hash
+  hash,
+  map
 } from 'rsvp';
-import { isEmpty, isPresent } from '@ember/utils';
 import moment from 'moment';
 import { validator, buildValidations } from 'ember-cp-validations';
 import ValidationErrorDisplay from 'ilios-common/mixins/validation-error-display';

--- a/addon/components/offering-form.js
+++ b/addon/components/offering-form.js
@@ -14,7 +14,7 @@ import ValidationErrorDisplay from 'ilios-common/mixins/validation-error-display
 import { task, timeout } from 'ember-concurrency';
 import layout from '../templates/components/offering-form';
 
-const { not } = computed;
+const DEBOUNCE_DELAY = 750;
 
 const Validations = buildValidations({
   room: [
@@ -39,14 +39,14 @@ const Validations = buildValidations({
       }),
     ]
   },
-  durationHours: [
+  hourBuffer: [
     validator('number', {
       allowString: true,
       integer: true,
       gte: 0
     })
   ],
-  durationMinutes: [
+  minuteBuffer: [
     validator('number', {
       allowString: true,
       integer: true,
@@ -63,14 +63,16 @@ const Validations = buildValidations({
         messageKey: 'general.smallGroupMessage'
       })
     ]
-  },
-
+  }
 });
 
 export default Component.extend(ValidationErrorDisplay, Validations, {
   currentUser: service(),
+
   layout,
+
   classNames: ['offering-form'],
+
   startDate: null,
   endDate: null,
   room: 'TBD',
@@ -93,6 +95,9 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
   recurringDayOptions: null,
   loaded: false,
   'data-test-offering-form': true,
+  hourBuffer: null,
+  minuteBuffer: null,
+
   associatedSchools: computed('cohorts.[]', function(){
     return new RSVPPromise(resolve => {
       const cohorts = this.get('cohorts');
@@ -402,6 +407,7 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
 
     this.setProperties({startDate, endDate, room, learnerGroups, recurringDays, instructors, instructorGroups, loaded});
   }).drop(),
+
   saveOffering: task(function * () {
     this.set('offeringsToSave', 0);
     this.set('savedOfferings', 0);
@@ -427,8 +433,8 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
     }
     this.send('clearErrorDisplay');
     this.get('close')();
-
   }),
+
   validateThenSaveOffering: task(function * () {
     this.send('addErrorDisplaysFor', ['room', 'numberOfWeeks', 'durationHours', 'durationMinutes', 'learnerGroups']);
     let {validations} = yield this.validate();
@@ -439,28 +445,40 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
 
     yield this.get('saveOffering').perform();
   }),
-  updateDurationMinutes: task(function * (minutes) {
-    let {validations} = yield this.validate();
-    this.send('addErrorDisplayFor', 'durationMinutes');
 
-    if (validations.get('durationMinutes.isInvalid')) {
-      return;
-    }
-    const hours = this.get('durationHours');
-    const startDate = moment(this.get('startDate'));
-    let endDate = startDate.clone().add(hours, 'hours').add(minutes, 'minutes').toDate();
-    this.set('endDate', endDate);
-  }).restartable(),
   updateDurationHours: task(function * (hours) {
-    let {validations} = yield this.validate();
+    yield timeout(DEBOUNCE_DELAY);
+    this.set('hourBuffer', hours);
+    const { validations } = yield this.validate();
+    const hourValidation = validations.toArray()[2];
     this.send('addErrorDisplayFor', 'durationHours');
-
-    if (validations.get('durationHours.isInvalid')) {
+    if (hourValidation.isInvalid) {
       return;
     }
-    const minutes = this.get('durationMinutes');
-    const startDate = moment(this.get('startDate'));
-    let endDate = startDate.clone().add(hours, 'hours').add(minutes, 'minutes').toDate();
+    const minutes = this.durationMinutes;
+    const endDate = moment(this.startDate)
+      .clone()
+      .add(hours, 'hours')
+      .add(minutes, 'minutes')
+      .toDate();
     this.set('endDate', endDate);
   }).restartable(),
+
+  updateDurationMinutes: task(function * (minutes) {
+    yield timeout(DEBOUNCE_DELAY);
+    this.set('minuteBuffer', minutes);
+    const { validations } = yield this.validate();
+    const minValidation = validations.toArray()[3];
+    this.send('addErrorDisplayFor', 'durationMinutes');
+    if (minValidation.isInvalid) {
+      return;
+    }
+    const hours = this.durationHours;
+    const endDate = moment(this.startDate)
+      .clone()
+      .add(hours, 'hours')
+      .add(minutes, 'minutes')
+      .toDate();
+    this.set('endDate', endDate);
+  }).restartable()
 });

--- a/addon/components/offering-form.js
+++ b/addon/components/offering-form.js
@@ -40,6 +40,21 @@ const Validations = buildValidations({
       }),
     ]
   },
+  durationHours: [
+    validator('number', {
+      allowString: true,
+      integer: true,
+      gte: 0
+    })
+  ],
+  durationMinutes: [
+    validator('number', {
+      allowString: true,
+      integer: true,
+      gte: 0,
+      lte: 59
+    })
+  ],
   learnerGroups: {
     dependentKeys: ['model.smallGroupMode'],
     disabled: not('model.smallGroupMode'),
@@ -432,6 +447,7 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
 
   updateDurationHours: task(function * (hours) {
     yield timeout(DEBOUNCE_DELAY);
+    this.send('addErrorDisplayFor', 'durationHours');
     const minutes = this.durationMinutes;
     const endDate = moment(this.startDate)
       .clone()
@@ -443,6 +459,7 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
 
   updateDurationMinutes: task(function * (minutes) {
     yield timeout(DEBOUNCE_DELAY);
+    this.send('addErrorDisplayFor', 'durationMinutes');
     const hours = this.durationHours;
     const endDate = moment(this.startDate)
       .clone()

--- a/addon/components/offering-form.js
+++ b/addon/components/offering-form.js
@@ -15,7 +15,7 @@ import ValidationErrorDisplay from 'ilios-common/mixins/validation-error-display
 import { task, timeout } from 'ember-concurrency';
 import layout from '../templates/components/offering-form';
 
-const DEBOUNCE_DELAY = 750;
+const DEBOUNCE_DELAY = 600;
 
 const Validations = buildValidations({
   room: [
@@ -40,21 +40,6 @@ const Validations = buildValidations({
       }),
     ]
   },
-  hourBuffer: [
-    validator('number', {
-      allowString: true,
-      integer: true,
-      gte: 0
-    })
-  ],
-  minuteBuffer: [
-    validator('number', {
-      allowString: true,
-      integer: true,
-      gte: 0,
-      lte: 59
-    })
-  ],
   learnerGroups: {
     dependentKeys: ['model.smallGroupMode'],
     disabled: not('model.smallGroupMode'),
@@ -96,8 +81,6 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
   recurringDayOptions: null,
   loaded: false,
   'data-test-offering-form': true,
-  hourBuffer: null,
-  minuteBuffer: null,
 
   associatedSchools: computed('cohorts.[]', function(){
     return new RSVPPromise(resolve => {
@@ -449,13 +432,6 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
 
   updateDurationHours: task(function * (hours) {
     yield timeout(DEBOUNCE_DELAY);
-    this.set('hourBuffer', hours);
-    const { validations } = yield this.validate();
-    const hourValidation = validations.toArray()[2];
-    this.send('addErrorDisplayFor', 'durationHours');
-    if (hourValidation.isInvalid) {
-      return;
-    }
     const minutes = this.durationMinutes;
     const endDate = moment(this.startDate)
       .clone()
@@ -467,13 +443,6 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
 
   updateDurationMinutes: task(function * (minutes) {
     yield timeout(DEBOUNCE_DELAY);
-    this.set('minuteBuffer', minutes);
-    const { validations } = yield this.validate();
-    const minValidation = validations.toArray()[3];
-    this.send('addErrorDisplayFor', 'durationMinutes');
-    if (minValidation.isInvalid) {
-      return;
-    }
     const hours = this.durationHours;
     const endDate = moment(this.startDate)
       .clone()

--- a/addon/templates/components/offering-form.hbs
+++ b/addon/templates/components/offering-form.hbs
@@ -1,33 +1,33 @@
 {{#if loaded}}
   <div class="toggle-offering-calendar">
     {{toggle-buttons
-      firstOptionSelected=(not showOfferingCalendar)
       firstLabel=(t "general.hideCalendar")
+      firstOptionSelected=(not showOfferingCalendar)
       secondLabel=(t "general.showCalendar")
-      toggle=(toggle "showOfferingCalendar" this)
-    }}
+      toggle=(toggle "showOfferingCalendar" this)}}
   </div>
+
   {{#if showOfferingCalendar}}
     {{offering-calendar
-      startDate=startDate
       endDate=endDate
       learnerGroups=learnerGroups
-      session=session
-    }}
+      startDate=startDate
+      session=session}}
   {{/if}}
 
   <div class="form">
     <div class="item start-date">
       <label>{{t "general.startDate"}}:</label>
       {{pikaday-input
-        value=startDate
-        onSelection=(action "updateStartDate")
         format="M/D/YYYY"
-      }}
+        value=startDate
+        onSelection=(action "updateStartDate")}}
     </div>
 
     <div class="item start-time">
-      <label>{{t "general.startTime"}}: <span class="timezone">({{browser-timezone}})</span></label>
+      <label>
+        {{t "general.startTime"}}: <span class="timezone">({{browser-timezone}})</span>
+      </label>
       {{time-picker date=startDate action=(action "updateStartTime")}}
     </div>
 
@@ -87,7 +87,9 @@
     {{#if showMakeRecurring}}
       <div class="item make-recurring">
         <label>{{t "general.makeRecurring"}}</label>
-        {{toggle-yesno yes=makeRecurring toggle=(toggle-action "makeRecurring" this)}}
+        {{toggle-yesno
+          yes=makeRecurring
+          toggle=(toggle-action "makeRecurring" this)}}
         {{#if makeRecurring}}
           <div class="make-recurring-options">
             <div class="make-recurring-days">

--- a/addon/templates/components/offering-form.hbs
+++ b/addon/templates/components/offering-form.hbs
@@ -35,44 +35,22 @@
       <label>{{t "general.duration"}}:</label>
       <div class="duration-inputs">
         <div class="hours">
-          <div class="hours__container">
-            <input
-              class={{if (and
-                (v-get this "hourBuffer" "isInvalid")
-                (is-in this.showErrorsFor "hourBuffer")) "has-error"}}
-              min="0"
-              type="number"
-              value={{durationHours}}
-              oninput={{perform this.updateDurationHours value="target.value"}}
-              onkeyup={{action "addErrorDisplayFor" "hourBuffer"}}>
-            <label>{{t "general.hours"}}</label>
-            {{#if (and (v-get this "hourBuffer" "isInvalid") (is-in showErrorsFor "hourBuffer"))}}
-              <span class="validation-error-message">
-                {{v-get this "hourBuffer" "message"}}
-              </span>
-            {{/if}}
-          </div>
+          <input
+            min="0"
+            type="number"
+            value={{durationHours}}
+            oninput={{perform this.updateDurationHours value="target.value"}}>
+          <label>{{t "general.hours"}}</label>
         </div>
 
         <div class="minutes">
-          <div class="minutes__container">
-            <input
-              class={{if (and
-                (v-get this "durationMinutes" "isInvalid")
-                (is-in this.showErrorsFor "durationMinutes")) "has-error"}}
-              max="59"
-              min="0"
-              type="number"
-              value={{durationMinutes}}
-              oninput={{perform this.updateDurationMinutes value="target.value"}}
-              onkeyup={{action "addErrorDisplayFor" "minuteBuffer"}}>
-            <label>{{t "general.minutes"}}</label>
-            {{#if (and (v-get this "minuteBuffer" "isInvalid") (is-in showErrorsFor "minuteBuffer"))}}
-              <span class="validation-error-message">
-                {{v-get this "minuteBuffer" "message"}}
-              </span>
-            {{/if}}
-          </div>
+          <input
+            max="59"
+            min="0"
+            type="number"
+            value={{durationMinutes}}
+            oninput={{perform this.updateDurationMinutes value="target.value"}}>
+          <label>{{t "general.minutes"}}</label>
         </div>
       </div>
     </div>

--- a/addon/templates/components/offering-form.hbs
+++ b/addon/templates/components/offering-form.hbs
@@ -35,40 +35,44 @@
       <label>{{t "general.duration"}}:</label>
       <div class="duration-inputs">
         <div class="hours">
-          <input
-            type="text"
-            value={{durationHours}}
-            oninput={{action (perform updateDurationHours) value="target.value"}}
-            onkeyup={{action "addErrorDisplayFor" "durationHours"}}
-            class={{if
-              (and (v-get this "durationHours" "isInvalid") (is-in showErrorsFor "durationHours"))
-              "has-error"
-            }}
-          >
-          {{#if
-            (and (v-get this "durationHours" "isInvalid") (is-in showErrorsFor "durationHours"))
-          }}
-            <span class="validation-error-message">{{v-get this "durationHours" "message"}}</span>
-          {{/if}}
-          <label>{{t "general.hours"}}</label>
+          <div class="hours__container">
+            <input
+              class={{if (and
+                (v-get this "hourBuffer" "isInvalid")
+                (is-in this.showErrorsFor "hourBuffer")) "has-error"}}
+              min="0"
+              type="number"
+              value={{durationHours}}
+              oninput={{perform this.updateDurationHours value="target.value"}}
+              onkeyup={{action "addErrorDisplayFor" "hourBuffer"}}>
+            <label>{{t "general.hours"}}</label>
+            {{#if (and (v-get this "hourBuffer" "isInvalid") (is-in showErrorsFor "hourBuffer"))}}
+              <span class="validation-error-message">
+                {{v-get this "hourBuffer" "message"}}
+              </span>
+            {{/if}}
+          </div>
         </div>
+
         <div class="minutes">
-          <input
-            type="text"
-            value={{durationMinutes}}
-            oninput={{action (perform updateDurationMinutes) value="target.value"}}
-            onkeyup={{action "addErrorDisplayFor" "durationMinutes"}}
-            class={{if
-              (and (v-get this "durationMinutes" "isInvalid") (is-in showErrorsFor "durationMinutes"))
-              "has-error"
-            }}
-          >
-          {{#if
-            (and (v-get this "durationMinutes" "isInvalid") (is-in showErrorsFor "durationMinutes"))
-          }}
-            <span class="validation-error-message">{{v-get this "durationMinutes" "message"}}</span>
-          {{/if}}
-          <label>{{t "general.minutes"}}</label>
+          <div class="minutes__container">
+            <input
+              class={{if (and
+                (v-get this "durationMinutes" "isInvalid")
+                (is-in this.showErrorsFor "durationMinutes")) "has-error"}}
+              max="59"
+              min="0"
+              type="number"
+              value={{durationMinutes}}
+              oninput={{perform this.updateDurationMinutes value="target.value"}}
+              onkeyup={{action "addErrorDisplayFor" "minuteBuffer"}}>
+            <label>{{t "general.minutes"}}</label>
+            {{#if (and (v-get this "minuteBuffer" "isInvalid") (is-in showErrorsFor "minuteBuffer"))}}
+              <span class="validation-error-message">
+                {{v-get this "minuteBuffer" "message"}}
+              </span>
+            {{/if}}
+          </div>
         </div>
       </div>
     </div>

--- a/addon/templates/components/offering-form.hbs
+++ b/addon/templates/components/offering-form.hbs
@@ -35,22 +35,46 @@
       <label>{{t "general.duration"}}:</label>
       <div class="duration-inputs">
         <div class="hours">
-          <input
-            min="0"
-            type="number"
-            value={{durationHours}}
-            oninput={{perform this.updateDurationHours value="target.value"}}>
-          <label>{{t "general.hours"}}</label>
+          <div class="hours-container">
+            <input
+              class={{if (and
+                (v-get this "durationHours" "isInvalid")
+                (is-in showErrorsFor "durationHours")) "has-error"}}
+              min="0"
+              type="number"
+              value={{durationHours}}
+              oninput={{perform this.updateDurationHours value="target.value"}}>
+            {{#if (and
+              (v-get this "durationHours" "isInvalid")
+              (is-in showErrorsFor "durationHours"))}}
+              <span class="validation-error-message">
+                {{v-get this "durationHours" "message"}}
+              </span>
+            {{/if}}
+            <label>{{t "general.hours"}}</label>
+          </div>
         </div>
 
         <div class="minutes">
-          <input
-            max="59"
-            min="0"
-            type="number"
-            value={{durationMinutes}}
-            oninput={{perform this.updateDurationMinutes value="target.value"}}>
-          <label>{{t "general.minutes"}}</label>
+          <div class="minutes-container">
+            <input
+              class={{if (and
+                (v-get this "durationMinutes" "isInvalid")
+                (is-in showErrorsFor "durationMinutes")) "has-error"}}
+              max="59"
+              min="0"
+              type="number"
+              value={{durationMinutes}}
+              oninput={{perform this.updateDurationMinutes value="target.value"}}>
+            {{#if (and
+              (v-get this "durationMinutes" "isInvalid")
+              (is-in showErrorsFor "durationMinutes"))}}
+              <span class="validation-error-message">
+                {{v-get this "durationMinutes" "message"}}
+              </span>
+            {{/if}}
+            <label>{{t "general.minutes"}}</label>
+          </div>
         </div>
       </div>
     </div>

--- a/app/styles/ilios-common/components/offering-form.scss
+++ b/app/styles/ilios-common/components/offering-form.scss
@@ -49,6 +49,10 @@
         min-width: 5rem;
         outline: none;
         width: 5rem;
+
+        &:invalid {
+          border: 1px $ilios-red solid;
+        }
       }
 
       label {
@@ -73,6 +77,26 @@
 
     .hours {
       margin-right: 40px;
+
+      .hours-container {
+        vertical-align: top;
+        width: 140px;
+      }
+    }
+
+    .minutes {
+      .minutes-container {
+        vertical-align: top;
+        width: 150px;
+      }
+    }
+
+    .validation-error-message {
+      color: $ilios-red;
+      display: block;
+      font-size: 12px;
+      font-style: italic;
+      margin-top: .75rem;
     }
 
     .instructors,

--- a/app/styles/ilios-common/components/offering-form.scss
+++ b/app/styles/ilios-common/components/offering-form.scss
@@ -47,7 +47,12 @@
       input {
         margin-right: .5rem;
         min-width: 5rem;
+        outline: none;
         width: 5rem;
+
+        &:invalid {
+          border: 1px $ilios-red solid;
+        }
       }
 
       label {
@@ -68,6 +73,30 @@
           width: auto;
         }
       }
+    }
+
+    .hours {
+      margin-right: 40px;
+
+      .hours__container {
+        vertical-align: top;
+        width: 140px;
+      }
+    }
+
+    .minutes {
+      .minutes__container {
+        vertical-align: top;
+        width: 150px;
+      }
+    }
+
+    .validation-error-message {
+      color: $ilios-red;
+      display: block;
+      font-size: 12px;
+      font-style: italic;
+      margin-top: 3px;
     }
 
     .instructors,

--- a/app/styles/ilios-common/components/offering-form.scss
+++ b/app/styles/ilios-common/components/offering-form.scss
@@ -49,10 +49,6 @@
         min-width: 5rem;
         outline: none;
         width: 5rem;
-
-        &:invalid {
-          border: 1px $ilios-red solid;
-        }
       }
 
       label {
@@ -77,26 +73,6 @@
 
     .hours {
       margin-right: 40px;
-
-      .hours__container {
-        vertical-align: top;
-        width: 140px;
-      }
-    }
-
-    .minutes {
-      .minutes__container {
-        vertical-align: top;
-        width: 150px;
-      }
-    }
-
-    .validation-error-message {
-      color: $ilios-red;
-      display: block;
-      font-size: 12px;
-      font-style: italic;
-      margin-top: 3px;
     }
 
     .instructors,


### PR DESCRIPTION
**Summary:**
Fixed buggy time inputs.
- Added `timeout` for better user experience; users would expect to be able to delete the 0
- `<input type="number>` is supported by all browsers (see [here](https://www.w3schools.com/tags/att_input_type_number.asp))
- All values entered are valid so no need for additional validations (non-number are automatically considered 0)

**GIF:**
![4402](https://user-images.githubusercontent.com/7553764/55120468-967f8200-50cc-11e9-90ec-fa680330a485.gif)

Fixes https://github.com/ilios/frontend/issues/2049