### PR TITLE
added query params for all 5 additional checkbox-filters

### DIFF
--- a/addon/components/common-dashboard.js
+++ b/addon/components/common-dashboard.js
@@ -21,6 +21,10 @@ export default Component.extend({
   selectedCourses: null,
   selectedSessionTypes: null,
   selectedTerms: null,
-  onResetParams() {},
-  onUpdateParam() {}
+  onClearFilters() {},
+  onUpdateCohorts() {},
+  onUpdateCourseLevels() {},
+  onUpdateCourses() {},
+  onUpdateSessionTypes() {},
+  onUpdateTerms() {}
 });

--- a/addon/components/common-dashboard.js
+++ b/addon/components/common-dashboard.js
@@ -3,8 +3,10 @@ import layout from '../templates/components/common-dashboard';
 
 export default Component.extend({
   layout,
+
   classNames: ['common-dashboard'],
   tagName: 'section',
+
   show: 'week',
   selectedDate: null,
   selectedView: 'week',
@@ -13,4 +15,12 @@ export default Component.extend({
   selectedAcademicYear: null,
   selectedSchool: null,
   courseFilters: null,
+
+  selectedCohorts: null,
+  selectedCourseLevels: null,
+  selectedCourses: null,
+  selectedSessionTypes: null,
+  selectedTerms: null,
+  onResetParams() {},
+  onUpdateParam() {}
 });

--- a/addon/components/dashboard-calendar.js
+++ b/addon/components/dashboard-calendar.js
@@ -16,24 +16,29 @@ export default Component.extend({
   store: service(),
   intl: service(),
   iliosConfig: service(),
+
   layout,
   classNames: ['dashboard-calendar'],
+
   selectedSchool: null,
   selectedDate: null,
   selectedView: null,
+  selectedAcademicYear: null,
+
   selectedCohorts: null,
   selectedCourseLevels: null,
   selectedCourses: null,
   selectedSessionTypes: null,
-  selectedAcademicYear: null,
   selectedTerms: null,
+  onResetParams() {},
+  onUpdateParam() {},
 
   /**
    * @property courseLevels
    * @type {Array}
    * @public
    */
-  courseLevels: null,
+  courseLevels: Object.freeze([1, 2, 3, 4, 5]),
 
   calendarDate: momentFormat('selectedDate', 'YYYY-MM-DD'),
 
@@ -264,15 +269,20 @@ export default Component.extend({
    * @type {Ember.computed}
    * @public
    */
-  activeFilters: computed('selectedCourses.[]', 'selectedSessionTypes.[]', 'selectedCourseLevels.[]', 'selectedCohorts.[]', 'selectedTerms.[]', function () {
-    const a = this.get('selectedSessionTypes');
-    const b = this.get('selectedCourseLevels');
-    const c = this.get('selectedCohorts');
-    const d = this.get('selectedCourses');
-    const e = this.get('selectedTerms');
-
-    return [].concat(a, b, c, d, e);
-  }),
+  activeFilters: computed(
+    'selectedCohorts.[]',
+    'selectedCourseLevels.[]',
+    'selectedCourses.[]',
+    'selectedSessionTypes.[]',
+    'selectedTerms.[]', async function () {
+      const a = await this.selectedSessionTypes;
+      const b = this.selectedCourseLevels;
+      const c = await this.selectedCohorts;
+      const d = await this.selectedCourses;
+      const e = await this.selectedTerms;
+      return [].concat(a, b, c, d, e);
+    }
+  ),
 
   /**
    * @property ourEvents
@@ -292,10 +302,11 @@ export default Component.extend({
    * @type {Ember.computed}
    * @protected
    */
-  eventsWithSelectedSessionTypes: computed('ourEvents.[]', 'selectedSessionTypes.[]', async function(){
-    const events = await this.get('ourEvents');
-    const selectedSessionTypes = this.get('selectedSessionTypes').mapBy('id');
-    if(isEmpty(selectedSessionTypes)) {
+  eventsWithSelectedSessionTypes: computed('ourEvents.[]', 'selectedSessionTypes.[]', async function() {
+    const events = await this.ourEvents;
+    const selectedSessionTypes = (await this.selectedSessionTypes).mapBy('id');
+
+    if (isEmpty(selectedSessionTypes)) {
       return events;
     }
     const matchingEvents = await map(events, async event => {
@@ -319,8 +330,8 @@ export default Component.extend({
    * @protected
    */
   eventsWithSelectedCourseLevels: computed('ourEvents.[]', 'selectedCourseLevels.[]', async function(){
-    const events = await this.get('ourEvents');
-    const selectedCourseLevels = this.get('selectedCourseLevels');
+    const events = await this.ourEvents;
+    const selectedCourseLevels = this.selectedCourseLevels;
     if(isEmpty(selectedCourseLevels)) {
       return events;
     }
@@ -345,8 +356,8 @@ export default Component.extend({
    * @protected
    */
   eventsWithSelectedCohorts: computed('ourEvents.[]', 'selectedCohorts.[]', async function(){
-    const events = await this.get('ourEvents');
-    const selectedCohorts = this.get('selectedCohorts').mapBy('id');
+    const events = await this.ourEvents;
+    const selectedCohorts = (await this.selectedCohorts).mapBy('id');
     if(isEmpty(selectedCohorts)) {
       return events;
     }
@@ -373,8 +384,8 @@ export default Component.extend({
    * @protected
    */
   eventsWithSelectedCourses: computed('ourEvents.[]', 'selectedCourses.[]', async function(){
-    const events = await this.get('ourEvents');
-    const selectedCourses = this.get('selectedCourses').mapBy('id');
+    const events = await this.ourEvents;
+    const selectedCourses = (await this.selectedCourses).mapBy('id');
     if(isEmpty(selectedCourses)) {
       return events;
     }
@@ -400,8 +411,8 @@ export default Component.extend({
    * @protected
    */
   eventsWithSelectedTerms: computed('ourEvents.[]', 'selectedTerms.[]', async function(){
-    const events = await this.get('ourEvents');
-    const selectedTerms = this.get('selectedTerms').mapBy('id');
+    const events = await this.ourEvents;
+    const selectedTerms = (await this.selectedTerms).mapBy('id');
     if(isEmpty(selectedTerms)) {
       return events;
     }
@@ -458,82 +469,45 @@ export default Component.extend({
     return server + '/ics/' + icsFeedKey;
   }),
 
-  init() {
-    this._super(...arguments);
-    //do these on setup otherwise tests were failing because
-    //the old filter value hung around
-    this.set('selectedSessionTypes', []);
-    this.set('selectedCourseLevels', []);
-    this.set('selectedCohorts', []);
-    this.set('selectedCourses', []);
-    this.set('selectedTerms', []);
-    this.set('courseLevels', [1, 2, 3, 4, 5]);
-  },
   actions: {
-    toggleSessionType(sessionType){
-      if(this.get('selectedSessionTypes').includes(sessionType)){
-        this.get('selectedSessionTypes').removeObject(sessionType);
-      } else {
-        this.get('selectedSessionTypes').pushObject(sessionType);
-      }
-    },
-    toggleCourseLevel(level){
-      if(this.get('selectedCourseLevels').includes(level)){
-        this.get('selectedCourseLevels').removeObject(level);
-      } else {
-        this.get('selectedCourseLevels').pushObject(level);
-      }
-    },
-    toggleCohort(cohort){
-      if(this.get('selectedCohorts').includes(cohort)){
-        this.get('selectedCohorts').removeObject(cohort);
-      } else {
-        this.get('selectedCohorts').pushObject(cohort);
-      }
-    },
-    toggleCourse(course){
-      if(this.get('selectedCourses').includes(course)){
-        this.get('selectedCourses').removeObject(course);
-      } else {
-        this.get('selectedCourses').pushObject(course);
-      }
-    },
-    toggleTerm(term){
-      if(this.get('selectedTerms').includes(term)){
-        this.get('selectedTerms').removeObject(term);
-      } else {
-        this.get('selectedTerms').pushObject(term);
-      }
+    toggleCohort(cohortId) {
+      this.onUpdateParam(cohortId, 'cohorts');
     },
 
-    clearFilters() {
-      const selectedCourses = [];
-      const selectedSessionTypes = [];
-      const selectedCourseLevels = [];
-      const selectedCohorts = [];
-      const selectedTerms = [];
+    toggleCourse(courseId){
+      this.onUpdateParam(courseId, 'courses');
+    },
 
-      this.setProperties({ selectedCourses, selectedSessionTypes, selectedCourseLevels, selectedCohorts, selectedTerms });
+    toggleCourseLevel(level) {
+      this.onUpdateParam(level, 'courseLevels');
+    },
+
+    toggleSessionType(sessionTypeId) {
+      this.onUpdateParam(sessionTypeId, 'sessionTypes');
+    },
+
+    toggleTerm(term) {
+      this.onUpdateParam(term.id, 'terms');
     },
 
     removeFilter(filter) {
       if (typeof filter === 'number') {
-        this.send('toggleCourseLevel', filter);
+        this.onUpdateParam(filter, 'courseLevels');
       } else {
-        let model = filter.get('constructor.modelName');
-
+        const model = filter.constructor.modelName;
+        const id = filter.id;
         switch (model) {
         case 'session-type':
-          this.send('toggleSessionType', filter);
+          this.onUpdateParam(id, 'sessionTypes');
           break;
         case 'cohort':
-          this.send('toggleCohort', filter);
+          this.onUpdateParam(id, 'cohorts');
           break;
         case 'course':
-          this.send('toggleCourse', filter);
+          this.onUpdateParam(id, 'courses');
           break;
         case 'term':
-          this.send('toggleTerm', filter);
+          this.onUpdateParam(id, 'terms');
           break;
         }
       }

--- a/addon/components/dashboard-calendar.js
+++ b/addon/components/dashboard-calendar.js
@@ -30,8 +30,12 @@ export default Component.extend({
   selectedCourses: null,
   selectedSessionTypes: null,
   selectedTerms: null,
-  onResetParams() {},
-  onUpdateParam() {},
+  onClearFilters() {},
+  onUpdateCohorts() {},
+  onUpdateCourseLevels() {},
+  onUpdateCourses() {},
+  onUpdateSessionTypes() {},
+  onUpdateTerms() {},
 
   /**
    * @property courseLevels
@@ -470,44 +474,24 @@ export default Component.extend({
   }),
 
   actions: {
-    toggleCohort(cohortId) {
-      this.onUpdateParam(cohortId, 'cohorts');
-    },
-
-    toggleCourse(courseId){
-      this.onUpdateParam(courseId, 'courses');
-    },
-
-    toggleCourseLevel(level) {
-      this.onUpdateParam(level, 'courseLevels');
-    },
-
-    toggleSessionType(sessionTypeId) {
-      this.onUpdateParam(sessionTypeId, 'sessionTypes');
-    },
-
-    toggleTerm(term) {
-      this.onUpdateParam(term.id, 'terms');
-    },
-
     removeFilter(filter) {
       if (typeof filter === 'number') {
-        this.onUpdateParam(filter, 'courseLevels');
+        this.onUpdateCourseLevels(filter);
       } else {
         const model = filter.constructor.modelName;
         const id = filter.id;
         switch (model) {
         case 'session-type':
-          this.onUpdateParam(id, 'sessionTypes');
+          this.onUpdateSessionTypes(id);
           break;
         case 'cohort':
-          this.onUpdateParam(id, 'cohorts');
+          this.onUpdateCohorts(id);
           break;
         case 'course':
-          this.onUpdateParam(id, 'courses');
+          this.onUpdateCourses(id);
           break;
         case 'term':
-          this.onUpdateParam(id, 'terms');
+          this.onUpdateTerms(filter);
           break;
         }
       }

--- a/addon/mixins/dashboard-controller.js
+++ b/addon/mixins/dashboard-controller.js
@@ -134,25 +134,94 @@ export default Mixin.create({
       }
     },
 
-    updateParam(modelId, property) {
-      const id = modelId.toString();
-      const queryParam = this.get(property);
+    updateCohorts(cohortId) {
+      const cohortIds = this.cohorts;
 
-      if (queryParam) {
-        const idArray = queryParam.split(',');
+      if (cohortIds) {
+        const idArray = cohortIds.split(',');
 
-        if (idArray.includes(id)) {
-          idArray.removeObject(id);
-          this.set(property, idArray.join(','));
+        if (idArray.includes(cohortId)) {
+          idArray.removeObject(cohortId);
+          this.set('cohorts', idArray.join(','));
         } else {
-          this.set(property, queryParam + `,${id}`);
+          this.set('cohorts', cohortIds + `,${cohortId}`);
         }
       } else {
-        this.set(property, id);
+        this.set('cohorts', cohortId);
       }
     },
 
-    resetParams() {
+    updateCourseLevels(level) {
+      const id = level.toString();
+      const levels = this.courseLevels;
+
+      if (levels) {
+        const idArray = levels.split(',');
+
+        if (idArray.includes(id)) {
+          idArray.removeObject(id);
+          this.set('courseLevels', idArray.join(','));
+        } else {
+          this.set('courseLevels', levels + `,${id}`);
+        }
+      } else {
+        this.set('courseLevels', id);
+      }
+    },
+
+    updateCourses(courseId) {
+      const courseIds = this.courses;
+
+      if (courseIds) {
+        const idArray = courseIds.split(',');
+
+        if (idArray.includes(courseId)) {
+          idArray.removeObject(courseId);
+          this.set('courses', idArray.join(','));
+        } else {
+          this.set('courses', courseIds + `,${courseId}`);
+        }
+      } else {
+        this.set('courses', courseId);
+      }
+    },
+
+    updateSessionTypes(sessionTypeId) {
+      const sessionTypeIds = this.sessionTypes;
+
+      if (sessionTypeIds) {
+        const idArray = sessionTypeIds.split(',');
+
+        if (idArray.includes(sessionTypeId)) {
+          idArray.removeObject(sessionTypeId);
+          this.set('sessionTypes', idArray.join(','));
+        } else {
+          this.set('sessionTypes', sessionTypeIds + `,${sessionTypeId}`);
+        }
+      } else {
+        this.set('sessionTypes', sessionTypeId);
+      }
+    },
+
+    updateTerms(term) {
+      const termId = term.id;
+      const termIds = this.terms;
+
+      if (termIds) {
+        const idArray = termIds.split(',');
+
+        if (idArray.includes(termId)) {
+          idArray.removeObject(termId);
+          this.set('terms', idArray.join(','));
+        } else {
+          this.set('terms', termIds + `,${termId}`);
+        }
+      } else {
+        this.set('terms', termId);
+      }
+    },
+
+    clearFilters() {
       this.setProperties({
         cohorts: '', courseLevels: '', courses: '', sessionTypes: '', terms: ''
       });

--- a/addon/templates/components/common-dashboard.hbs
+++ b/addon/templates/components/common-dashboard.hbs
@@ -24,8 +24,12 @@
     selectedCourses=@selectedCourses
     selectedSessionTypes=@selectedSessionTypes
     selectedTerms=@selectedTerms
-    onResetParams=(action @onResetParams)
-    onUpdateParam=(action @onUpdateParam)}}
+    onClearFilters=@onClearFilters
+    onUpdateCohorts=@onUpdateCohorts
+    onUpdateCourseLevels=@onUpdateCourseLevels
+    onUpdateCourses=@onUpdateCourses
+    onUpdateSessionTypes=@onUpdateSessionTypes
+    onUpdateTerms=@onUpdateTerms}}
 {{else if (eq show "materials")}}
   {{dashboard-materials}}
 {{else if (eq show "agenda")}}

--- a/addon/templates/components/common-dashboard.hbs
+++ b/addon/templates/components/common-dashboard.hbs
@@ -19,7 +19,13 @@
     changeSchool=changeSchool
     courseFilters=courseFilters
     toggleCourseFilters=toggleCourseFilters
-  }}
+    selectedCohorts=@selectedCohorts
+    selectedCourseLevels=@selectedCourseLevels
+    selectedCourses=@selectedCourses
+    selectedSessionTypes=@selectedSessionTypes
+    selectedTerms=@selectedTerms
+    onResetParams=(action @onResetParams)
+    onUpdateParam=(action @onUpdateParam)}}
 {{else if (eq show "materials")}}
   {{dashboard-materials}}
 {{else if (eq show "agenda")}}

--- a/addon/templates/components/dashboard-calendar.hbs
+++ b/addon/templates/components/dashboard-calendar.hbs
@@ -32,8 +32,7 @@
         id="calendar-clear-filters"
         class="calendar-clear-filters"
         role="button"
-        {{action "clearFilters"}}
-      >
+        {{action @onResetParams}}>
         {{t "general.clearFilters"}}
       </span>
     {{/if}}
@@ -81,8 +80,7 @@
       {{#liquid-if courseFilters class="crossFade"}}
         <div
           id="calendar-coursefilter"
-          class="calendar-filter-list large-filter-list coursefilter"
-        >
+          class="calendar-filter-list large-filter-list coursefilter">
           <h5>{{get (await bestSelectedAcademicYear) "academicYearTitle"}} {{t "general.courses"}}</h5>
           {{#if (is-fulfilled courses)}}
             <ul>
@@ -91,10 +89,9 @@
                   <input
                     class="checkbox"
                     type="checkbox"
-                    checked={{is-in selectedCourses course}}
-                    {{action "toggleCourse" course on="change"}}
-                  >
-                  <span {{action "toggleCourse" course}} class="list-indentation" role="button">
+                    checked={{is-in (await @selectedCourses) course}}
+                    {{action "toggleCourse" course.id on="change"}}>
+                  <span {{action "toggleCourse" course.id}} class="list-indentation" role="button">
                     {{course.title}}
                     {{#if course.externalId}}
                       ({{course.externalId}})
@@ -110,24 +107,21 @@
 
         <div
           id="calendar-sessiontypefilter"
-          class="calendar-filter-list sessiontypefilter"
-        >
+          class="calendar-filter-list sessiontypefilter">
           <h5>{{t "general.sessionTypes"}}</h5>
           {{#if (is-fulfilled sessionTypes)}}
             <ul>
               {{#each (await sessionTypes) as |type|}}
                 <li class="clickable">
                   <input
+                    checked={{is-in (await @selectedSessionTypes) type}}
                     class="checkbox"
                     type="checkbox"
-                    checked={{is-in selectedSessionTypes type}}
-                    {{action "toggleSessionType" type on="change"}}
-                  >
+                    {{action "toggleSessionType" type.id on="change"}}>
                   <span
                     class="list-indentation"
                     role="button"
-                    {{action "toggleSessionType" type}}
-                  >
+                    {{action "toggleSessionType" type.id}}>
                     {{type.title}}
                   </span>
                 </li>
@@ -146,7 +140,7 @@
                 <h6>{{vocabulary.title}}</h6>
                 {{selected-term-tree
                   terms=(await vocabulary.topLevelTerms)
-                  selectedTerms=selectedTerms
+                  selectedTerms=(await @selectedTerms)
                   toggle=(action "toggleTerm")
                 }}
               {{/each}}
@@ -158,8 +152,7 @@
       {{else}}
         <div
           id="calendar-sessiontypefilter"
-          class="calendar-filter-list sessiontypefilter"
-        >
+          class="calendar-filter-list sessiontypefilter">
           <h5>{{t "general.sessionTypes"}}</h5>
           {{#if (is-fulfilled sessionTypes)}}
             <ul>
@@ -168,14 +161,12 @@
                   <input
                     class="checkbox"
                     type="checkbox"
-                    checked={{is-in selectedSessionTypes type}}
-                    {{action "toggleSessionType" type on="change"}}
-                  >
+                    checked={{is-in (await @selectedSessionTypes) type}}
+                    {{action "toggleSessionType" type.id on="change"}}>
                   <span
                     class="list-indentation"
                     role="button"
-                    {{action "toggleSessionType" type}}
-                  >
+                    {{action "toggleSessionType" type.id}}>
                     {{type.title}}
                   </span>
                 </li>
@@ -187,8 +178,7 @@
         </div>
         <div
           id="calendar-courselevelfilter"
-          class="calendar-filter-list small-filter-list courselevelfilter"
-        >
+          class="calendar-filter-list small-filter-list courselevelfilter">
           <h5>{{t "general.courseLevels"}}</h5>
           <ul>
             {{#each courseLevels as |level|}}
@@ -196,14 +186,12 @@
                 <input
                   class="checkbox"
                   type="checkbox"
-                  checked={{contains level selectedCourseLevels}}
-                  {{action "toggleCourseLevel" level on="change"}}
-                >
+                  checked={{contains level @selectedCourseLevels}}
+                  {{action "toggleCourseLevel" level on="change"}}>
                 <span
                   class="list-indentation"
                   role="button"
-                  {{action "toggleCourseLevel" level}}
-                >
+                  {{action "toggleCourseLevel" level}}>
                   {{level}}
                 </span>
               </li>
@@ -222,10 +210,9 @@
                   <input
                     class="checkbox"
                     type="checkbox"
-                    checked={{is-in selectedCohorts cohort}}
-                    {{action "toggleCohort" cohort on="change"}}
-                  >
-                  <span {{action "toggleCohort" cohort}} class="list-indentation" role="button">
+                    checked={{is-in (await @selectedCohorts) cohort}}
+                    {{action "toggleCohort" cohort.id on="change"}}>
+                  <span {{action "toggleCohort" cohort.id}} class="list-indentation" role="button">
                     {{#if cohort.title}}
                       {{cohort.title}}
                     {{else}}
@@ -245,7 +232,7 @@
   </div>
 </section>
 
-{{#if (gt activeFilters.length 0)}}
+{{#if (gt (get (await activeFilters) "length") 0)}}
   <section class="filters-list">
     <header class="filters-header">{{t "general.activeFilters"}}:</header>
     <div class="filter-tags">
@@ -253,8 +240,7 @@
         <span
           class="filter-tag {{tag.class}}"
           role="button"
-          {{action "removeFilter" tag.filter}}
-        >
+          {{action "removeFilter" tag.filter}}>
           {{tag.name}} {{fa-icon "times"}}
         </span>
       {{/each}}
@@ -262,8 +248,7 @@
         id="calendar-clear-filters"
         class="filters-clear-filters"
         role="button"
-        {{action "clearFilters"}}
-      >
+        {{action @onResetParams}}>
         {{t "general.clearFilters"}}
       </span>
     </div>

--- a/addon/templates/components/dashboard-calendar.hbs
+++ b/addon/templates/components/dashboard-calendar.hbs
@@ -32,7 +32,7 @@
         id="calendar-clear-filters"
         class="calendar-clear-filters"
         role="button"
-        {{action @onResetParams}}>
+        {{action @onClearFilters}}>
         {{t "general.clearFilters"}}
       </span>
     {{/if}}
@@ -90,8 +90,8 @@
                     class="checkbox"
                     type="checkbox"
                     checked={{is-in (await @selectedCourses) course}}
-                    {{action "toggleCourse" course.id on="change"}}>
-                  <span {{action "toggleCourse" course.id}} class="list-indentation" role="button">
+                    {{action @onUpdateCourses course.id on="change"}}>
+                  <span {{action @onUpdateCourses course.id}} class="list-indentation" role="button">
                     {{course.title}}
                     {{#if course.externalId}}
                       ({{course.externalId}})
@@ -117,11 +117,11 @@
                     checked={{is-in (await @selectedSessionTypes) type}}
                     class="checkbox"
                     type="checkbox"
-                    {{action "toggleSessionType" type.id on="change"}}>
+                    {{action @onUpdateSessionTypes type.id on="change"}}>
                   <span
                     class="list-indentation"
                     role="button"
-                    {{action "toggleSessionType" type.id}}>
+                    {{action @onUpdateSessionTypes type.id}}>
                     {{type.title}}
                   </span>
                 </li>
@@ -139,10 +139,9 @@
               {{#each (await vocabularies) as |vocabulary|}}
                 <h6>{{vocabulary.title}}</h6>
                 {{selected-term-tree
-                  terms=(await vocabulary.topLevelTerms)
                   selectedTerms=(await @selectedTerms)
-                  toggle=(action "toggleTerm")
-                }}
+                  terms=(await vocabulary.topLevelTerms)
+                  toggle=(action @onUpdateTerms)}}
               {{/each}}
             </ul>
           {{else}}
@@ -162,11 +161,11 @@
                     class="checkbox"
                     type="checkbox"
                     checked={{is-in (await @selectedSessionTypes) type}}
-                    {{action "toggleSessionType" type.id on="change"}}>
+                    {{action @onUpdateSessionTypes type.id on="change"}}>
                   <span
                     class="list-indentation"
                     role="button"
-                    {{action "toggleSessionType" type.id}}>
+                    {{action @onUpdateSessionTypes type.id}}>
                     {{type.title}}
                   </span>
                 </li>
@@ -187,11 +186,11 @@
                   class="checkbox"
                   type="checkbox"
                   checked={{contains level @selectedCourseLevels}}
-                  {{action "toggleCourseLevel" level on="change"}}>
+                  {{action @onUpdateCourseLevels level on="change"}}>
                 <span
                   class="list-indentation"
                   role="button"
-                  {{action "toggleCourseLevel" level}}>
+                  {{action @onUpdateCourseLevels level}}>
                   {{level}}
                 </span>
               </li>
@@ -211,8 +210,8 @@
                     class="checkbox"
                     type="checkbox"
                     checked={{is-in (await @selectedCohorts) cohort}}
-                    {{action "toggleCohort" cohort.id on="change"}}>
-                  <span {{action "toggleCohort" cohort.id}} class="list-indentation" role="button">
+                    {{action @onUpdateCohorts cohort.id on="change"}}>
+                  <span {{action @onUpdateCohorts cohort.id}} class="list-indentation" role="button">
                     {{#if cohort.title}}
                       {{cohort.title}}
                     {{else}}
@@ -248,7 +247,7 @@
         id="calendar-clear-filters"
         class="filters-clear-filters"
         role="button"
-        {{action @onResetParams}}>
+        {{action @onClearFilters}}>
         {{t "general.clearFilters"}}
       </span>
     </div>

--- a/tests/acceptance/dashboard/calendar-test.js
+++ b/tests/acceptance/dashboard/calendar-test.js
@@ -709,10 +709,10 @@ module('Acceptance | Dashboard Calendar', function(hooks) {
     await click(calendarPicker);
     assert.equal(currentURL(), '/dashboard?show=calendar');
 
-    await click(find(schoolEvents));
+    await click(schoolEvents);
     assert.equal(currentURL(), '/dashboard?mySchedule=false&show=calendar');
 
-    await click(find(showFiltersButton));
+    await click(showFiltersButton);
     assert.equal(currentURL(), '/dashboard?mySchedule=false&show=calendar&showFilters=true');
 
     await chooseDetailFilter();
@@ -721,8 +721,58 @@ module('Acceptance | Dashboard Calendar', function(hooks) {
     await fillIn(academicYearDropdown, '2015');
     assert.equal(currentURL(), '/dashboard?academicYear=2015&courseFilters=false&mySchedule=false&show=calendar&showFilters=true');
 
-    await click(find(hideFiltersButton));
+    await click(hideFiltersButton);
     assert.equal(currentURL(), '/dashboard?mySchedule=false&show=calendar');
+
+    await click(showFiltersButton);
+    await click('.coursefilter ul li:nth-child(1) input');
+    assert.equal(currentURL(), '/dashboard?courses=1&mySchedule=false&show=calendar&showFilters=true');
+
+    await click('.coursefilter ul li:nth-child(2) input');
+    assert.equal(currentURL(), '/dashboard?courses=1%2C2&mySchedule=false&show=calendar&showFilters=true');
+
+    await click('.coursefilter ul li:nth-child(2) input');
+    assert.equal(currentURL(), '/dashboard?courses=1&mySchedule=false&show=calendar&showFilters=true');
+
+    await click('.coursefilter ul li:nth-child(1) input');
+    assert.equal(currentURL(), '/dashboard?mySchedule=false&show=calendar&showFilters=true');
+
+    await click('.sessiontypefilter ul li:nth-child(1) input');
+    assert.equal(currentURL(), '/dashboard?mySchedule=false&sessionTypes=1&show=calendar&showFilters=true');
+
+    await click('.sessiontypefilter ul li:nth-child(2) input');
+    assert.equal(currentURL(), '/dashboard?mySchedule=false&sessionTypes=1%2C2&show=calendar&showFilters=true');
+
+    await click('.sessiontypefilter ul li:nth-child(2) input');
+    assert.equal(currentURL(), '/dashboard?mySchedule=false&sessionTypes=1&show=calendar&showFilters=true');
+
+    await click('.sessiontypefilter ul li:nth-child(1) input');
+    assert.equal(currentURL(), '/dashboard?mySchedule=false&show=calendar&showFilters=true');
+
+    await click('.togglecoursefilters label:nth-of-type(2)');
+    await click('.courselevelfilter ul li:nth-child(1) input');
+    assert.equal(currentURL(), '/dashboard?courseFilters=false&courseLevels=1&mySchedule=false&show=calendar&showFilters=true');
+
+    await click('.courselevelfilter ul li:nth-child(2) input');
+    assert.equal(currentURL(), '/dashboard?courseFilters=false&courseLevels=1%2C2&mySchedule=false&show=calendar&showFilters=true');
+
+    await click('.courselevelfilter ul li:nth-child(2) input');
+    assert.equal(currentURL(), '/dashboard?courseFilters=false&courseLevels=1&mySchedule=false&show=calendar&showFilters=true');
+
+    await click('.courselevelfilter ul li:nth-child(1) input');
+    assert.equal(currentURL(), '/dashboard?courseFilters=false&mySchedule=false&show=calendar&showFilters=true');
+
+    await click('.cohortfilter ul li:nth-child(1) input');
+    assert.equal(currentURL(), '/dashboard?cohorts=1&courseFilters=false&mySchedule=false&show=calendar&showFilters=true');
+
+    await click('.cohortfilter ul li:nth-child(2) input');
+    assert.equal(currentURL(), '/dashboard?cohorts=1%2C2&courseFilters=false&mySchedule=false&show=calendar&showFilters=true');
+
+    await click('.cohortfilter ul li:nth-child(2) input');
+    assert.equal(currentURL(), '/dashboard?cohorts=1&courseFilters=false&mySchedule=false&show=calendar&showFilters=true');
+
+    await click('.cohortfilter ul li:nth-child(1) input');
+    assert.equal(currentURL(), '/dashboard?courseFilters=false&mySchedule=false&show=calendar&showFilters=true');
   });
 
   test('week summary displays the whole week', async function(assert) {

--- a/tests/dummy/app/templates/dashboard.hbs
+++ b/tests/dummy/app/templates/dashboard.hbs
@@ -16,4 +16,10 @@
   changeSchool=(action (mut school))
   courseFilters=courseFilters
   toggleCourseFilters=(action (toggle "courseFilters" this))
-}}
+  selectedCohorts=selectedCohorts
+  selectedCourseLevels=selectedCourseLevels
+  selectedCourses=selectedCourses
+  selectedSessionTypes=selectedSessionTypes
+  selectedTerms=selectedTerms
+  onResetParams=(action "resetParams")
+  onUpdateParam=(action "updateParam")}}

--- a/tests/dummy/app/templates/dashboard.hbs
+++ b/tests/dummy/app/templates/dashboard.hbs
@@ -21,5 +21,9 @@
   selectedCourses=selectedCourses
   selectedSessionTypes=selectedSessionTypes
   selectedTerms=selectedTerms
-  onResetParams=(action "resetParams")
-  onUpdateParam=(action "updateParam")}}
+  onClearFilters=(action "clearFilters")
+  onUpdateCohorts=(action "updateCohorts")
+  onUpdateCourseLevels=(action "updateCourseLevels")
+  onUpdateCourses=(action "updateCourses")
+  onUpdateSessionTypes=(action "updateSessionTypes")
+  onUpdateTerms=(action "updateTerms")}}


### PR DESCRIPTION
**Summary:**
Enabled query params on five checkbox filters for the calendar.
- Courses: `?courses=1%2C2`
- Session Types: `?sessionTypes=1%2C2`
- Terms: `?terms=1%2C2`
- Course Levels: `?courseLevels=1%2C2`
- Program/Cohort: `?cohorts=1%2C2`

**UI:**
_Course / Type_
<img width="1052" alt="Screen Shot 2019-04-18 at 1 01 07 PM" src="https://user-images.githubusercontent.com/7553764/56381312-1f746f80-61da-11e9-9109-e3296c8f0f07.png">

_Detail_
<img width="979" alt="Screen Shot 2019-04-18 at 1 01 21 PM" src="https://user-images.githubusercontent.com/7553764/56381313-1f746f80-61da-11e9-81f5-cb2e4e9c08c4.png">

Accompanies https://github.com/ilios/frontend/pull/4500
Fixes https://github.com/ilios/frontend/issues/3061