### PR TITLE
rm double-indent, correct color overrides.

### DIFF
--- a/addon/templates/components/leadership-search.hbs
+++ b/addon/templates/components/leadership-search.hbs
@@ -26,7 +26,7 @@
       {{/if}}
       {{#if (eq result.type "user")}}
         <li {{action (perform clickUser) result.user}}
-          class="user {{unless (contains result.user.id existingUserIds) "clickable"}}"
+          class="user {{unless (contains result.user.id existingUserIds) "clickable" "inactive" }}"
           role="button"
           data-test-result-index={{index}}
           data-test-result

--- a/app/styles/ilios-common/mixins/user-search.scss
+++ b/app/styles/ilios-common/mixins/user-search.scss
@@ -18,7 +18,10 @@
 
   li {
     border-bottom: 1px solid $base-border-color;
-    padding-left: 1rem;
+    color: $ilios-blue;
+    display: block;
+    padding: .1rem;
+    width: 100%;
 
     &.inactive {
       color: darken($header-grey, 20);
@@ -31,10 +34,6 @@
 
     a,
     &.clickable {
-      display: block;
-      padding: .1rem;
-      width: 100%;
-
       &:hover {
         background-color: lighten($base-link-color, 50);
       }
@@ -42,7 +41,6 @@
 
     .name,
     .email {
-      color: $ilios-blue;
       display: block;
       width: 100%;
 

--- a/tests/integration/components/leadership-search-test.js
+++ b/tests/integration/components/leadership-search-test.js
@@ -99,7 +99,7 @@ module('Integration | Component | leadership search', function(hooks) {
   });
 
   test('can not add users twice', async function(assert) {
-    assert.expect(6);
+    assert.expect(7);
     this.server.create('user', {
       firstName: 'test',
       lastName: 'person',
@@ -128,6 +128,7 @@ module('Integration | Component | leadership search', function(hooks) {
     assert.dom(resultsCount).hasText('2 results');
     assert.equal(find(firstResult).textContent.replace(/[\t\n\s]+/g, ""), 'testM.persontestemail');
     assert.dom(firstResult).hasNoClass('clickable');
+    assert.dom(firstResult).hasClass('inactive');
     assert.equal(find(secondResult).textContent.replace(/[\t\n\s]+/g, ""), 'testM.person2testemail2');
     assert.dom(secondResult).hasClass('clickable');
     await click(firstResult);


### PR DESCRIPTION
fixes #635

![Selection_452](https://user-images.githubusercontent.com/1410427/56448204-33939c00-62c2-11e9-807d-4c4840f27194.png)

affects leadership search in courses, sessions, programs, schools, and curriculum inventory.
