### PR TITLE
smoother comprehensive transition when adding new MeSH terms

### DIFF
--- a/addon/components/detail-objectives.js
+++ b/addon/components/detail-objectives.js
@@ -64,7 +64,7 @@ export default Component.extend({
     },
     manageDescriptors(objective) {
       objective.get('meshDescriptors').then((meshDescriptors) => {
-        scrollTo(".detail-objectives");
+        scrollTo('.detail-objectives', 1000);
         this.set('initialStateForManageMeshObjective', meshDescriptors.toArray());
         this.set('manageDescriptorsObjective', objective);
       });

--- a/addon/templates/components/detail-objectives.hbs
+++ b/addon/templates/components/detail-objectives.hbs
@@ -52,7 +52,8 @@
       cancel=(action "toggleNewObjectiveEditor")
     }}
   {{/if}}
-  {{#unless isManaging class="horizontal"}}
+
+  {{#liquid-unless isManaging class="horizontal"}}
     {{#if isCourse}}
       {{course-objective-list
         subject=subject
@@ -92,12 +93,11 @@
     {{/if}}
     {{#if isManagingDescriptors}}
       {{objective-manage-descriptors
-        objective=manageDescriptorsObjective
         editable=editable
-      }}
+        objective=manageDescriptorsObjective}}
     {{/if}}
     {{#if isManagingCompetency}}
       {{objective-manage-competency objective=manageCompetencyObjective}}
     {{/if}}
-  {{/unless}}
+  {{/liquid-unless}}
 </div>

--- a/addon/templates/components/objective-manage-descriptors.hbs
+++ b/addon/templates/components/objective-manage-descriptors.hbs
@@ -1,3 +1,5 @@
+<span>{{objective.textTitle}}</span>
+
 {{mesh-manager
   add=(action "add")
   remove=(action "remove")

--- a/app/styles/ilios-common/components/detail-objectives.scss
+++ b/app/styles/ilios-common/components/detail-objectives.scss
@@ -15,6 +15,7 @@
 
   .detail-objectives-content {
     @include detail-container-content;
+    margin: 0;
   }
 
   .new-objective {


### PR DESCRIPTION
**Summary:**
This PR improves two areas when adding new Mesh terms.
- Smooth slower transition to let users know that the UI is changing
- Shows objective description when users add new terms 

**GIF:**
![2551](https://user-images.githubusercontent.com/7553764/56542314-bc653e80-6533-11e9-9da9-b5054700e1f4.gif)

Fixes https://github.com/ilios/frontend/issues/2551
Fixes https://github.com/ilios/frontend/issues/4512