### PR TITLE
better course objective removal warning message

### DIFF
--- a/addon/templates/components/course-objective-list.hbs
+++ b/addon/templates/components/course-objective-list.hbs
@@ -34,10 +34,24 @@
               <tr class="confirm-removal">
                 <td colspan="8">
                   <div class="confirm-message">
-                    {{t "general.confirmObjectiveRemoval"}}<br>
+                    {{#if (gt objective.children.length 0)}}
+                      {{t "general.confirmObjectiveRemovalMultipleSessionObjectives"
+                        count=objective.children.length}}
+                    {{else}}
+                      {{t "general.confirmObjectiveRemoval"}}
+                    {{/if}}
+                    <br>
                     <div class="confirm-buttons">
-                      <button {{action "remove" objective}} class="remove text">{{t "general.yes"}}</button>
-                      <button {{action "cancelRemove" objective}} class="done text">{{t "general.cancel"}}</button>
+                      <button
+                        class="remove text"
+                        onclick={{action "remove" objective}}>
+                        {{t "general.yes"}}
+                      </button>
+                      <button
+                        class="done text"
+                        onclick={{action "cancelRemove" objective}}>
+                        {{t "general.cancel"}}
+                      </button>
                     </div>
                   </div>
                 </td>
@@ -48,7 +62,6 @@
       </table>
     {{/if}}
   {{/if}}
-
 {{else}}
   {{! template-lint-disable unused-block-params }}
   {{#each (repeat course.objectives.length) as |empty|}}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -39,6 +39,7 @@ general:
   competencies: Competencies
   completeSessions: "Sessions Complete: ready to publish"
   confirmObjectiveRemoval: "Are you sure you want to delete this objective?"
+  confirmObjectiveRemovalMultipleSessionObjectives: "You are about to delete this course objective, which is linked to {count} session objectives. This will delete those relationships as well. Are you sure you want to continue?"
   confirmRemoval: "Are you sure you want to remove this learning material?"
   confirmRemove: "Are you sure you want to delete this offering with {learnerGroupCount} learner groups? This action cannot be undone."
   confirmSessionRemoval: "Are you sure you want to delete this session?"

--- a/translations/es.yaml
+++ b/translations/es.yaml
@@ -39,6 +39,7 @@ general:
   competencies: Competencias
   completeSessions: "Sesiónes Completas: Listo a Publicar"
   confirmObjectiveRemoval: "¿Está seguro que desea eliminar este objetivo?"
+  confirmObjectiveRemovalMultipleSessionObjectives: "Está a punto de eliminar este objetivo de curso, que está vinculado a {count} objetivos de sesión. Esto eliminará también esas relaciones. ¿Está seguro que desea continuar?"
   confirmRemoval: "¿Está seguro que desea eliminar este material de aprendizaje?"
   confirmRemove: "¿Estás seguro que quieres borrar este ofrecimiento con {learnerGroupCount} grupos de aprendedores? Esta acción no se puede deshacer."
   confirmSessionRemoval: "¿Está seguro que desea eliminar este sessión?"

--- a/translations/fr.yaml
+++ b/translations/fr.yaml
@@ -39,6 +39,7 @@ general:
   competencies: "Compétences"
   completeSessions: "Séances complète: prêt à publier"
   confirmObjectiveRemoval: "Êtes vous sûr de vouloir supprimer cet objectif?"
+  confirmObjectiveRemovalMultipleSessionObjectives: "Vous êtes sur le point de supprimer cet objectif de cours, qui est lié à {count} objectifs de séance. Cela supprimera également ces liens. Êtes-vous certain de vouloir continuer?"
   confirmRemoval: "Êtes-vous sûr vous voulez supprimer cette matière d’étude?"
   confirmRemove: "Êtes-vous sûr vous voulez supprimer cette offre avec {learnerGroupCount} groupes d'apprenants?  Ça action ne peut pas être défait."
   confirmSessionRemoval: "Êtes vous sûr de vouloir supprimer cette séance?"


### PR DESCRIPTION
**Summary:**
If the course objective is associated as parent to any session objectives, users will receive a better warning removal message.

**UI:**
<img width="1076" alt="Screen Shot 2019-04-24 at 2 07 34 PM" src="https://user-images.githubusercontent.com/7553764/56686890-a7ef8600-669a-11e9-97dd-a9829d461a97.png">

Fixes https://github.com/ilios/frontend/issues/2125