### PR TITLE
fixed expand text bug

### DIFF
--- a/addon-test-support/ilios-common/page-objects/components/objectives.js
+++ b/addon-test-support/ilios-common/page-objects/components/objectives.js
@@ -28,7 +28,7 @@ export default {
   current: collection('table tbody tr', {
     description: {
       scope: 'td:eq(0)',
-      openEditor: clickable('.editable'),
+      openEditor: clickable('[data-test-edit]'),
       editorContents: froalaEditorValue('.fr-box'),
       edit: fillInFroalaEditor('.fr-box'),
       save: clickable('.done'),

--- a/addon-test-support/ilios-common/page-objects/course.js
+++ b/addon-test-support/ilios-common/page-objects/course.js
@@ -31,8 +31,8 @@ export default create({
 
   header: {
     scope: '[data-test-course-header]',
-    title: text('.editable'),
-    edit: clickable('.clickable'),
+    title: text('[data-test-edit]'),
+    edit: clickable('[data-test-edit]'),
     set: fillable('input'),
     save: clickable('.done')
   },
@@ -48,7 +48,7 @@ export default create({
     externalId: {
       scope: '.courseexternalid',
       value: text('span', { at: 0}),
-      edit: clickable('.clickable'),
+      edit: clickable('[data-test-edit]'),
       set: fillable('input'),
       save: clickable('.done'),
       hasError: isVisible('.validation-error-message')
@@ -56,7 +56,7 @@ export default create({
     startDate: {
       scope: '.coursestartdate',
       value: text('span', { at: 0}),
-      edit: clickable('.clickable'),
+      edit: clickable('[data-test-edit]'),
       set: datePicker('input'),
       save: clickable('.done'),
       hasError: isVisible('.validation-error-message')
@@ -64,7 +64,7 @@ export default create({
     endDate: {
       scope: '.courseenddate',
       value: text('span', { at: 0}),
-      edit: clickable('.clickable'),
+      edit: clickable('[data-test-edit]'),
       set: datePicker('input'),
       save: clickable('.done'),
       hasError: isVisible('.validation-error-message')
@@ -72,7 +72,7 @@ export default create({
     level: {
       scope: '.courselevel',
       value: text('span', { at: 0}),
-      edit: clickable('.clickable'),
+      edit: clickable('[data-test-edit]'),
       set: fillable('select'),
       save: clickable('.done'),
       hasError: isVisible('.validation-error-message')
@@ -81,7 +81,7 @@ export default create({
     clerkshipType: {
       scope: '.clerkshiptype',
       value: text('span', { at: 0}),
-      edit: clickable('.clickable'),
+      edit: clickable('[data-test-edit]'),
       set: fillable('select'),
       save: clickable('.done')
     },

--- a/addon-test-support/ilios-common/page-objects/session.js
+++ b/addon-test-support/ilios-common/page-objects/session.js
@@ -34,7 +34,7 @@ export default create({
     title: {
       scope: '.session-header',
       title: text('.editable'),
-      edit: clickable('.clickable'),
+      edit: clickable('[data-test-edit]'),
       set: fillable('input'),
       save: clickable('.done'),
       value: text('.title')
@@ -48,7 +48,7 @@ export default create({
     sessionType: {
       scope: '.sessiontype',
       value: text('span', { at: 0}),
-      edit: clickable('.clickable'),
+      edit: clickable('[data-test-edit]'),
       set: fillable('select'),
       save: clickable('.done'),
       hasError: isVisible('.validation-error-message')
@@ -56,7 +56,7 @@ export default create({
     sessionDescription: {
       scope: '.sessiondescription',
       value: text('span', { at: 0}),
-      edit: clickable('.editable'),
+      edit: clickable('[data-test-edit]'),
       set: fillInFroalaEditor('.fr-box'),
       save: clickable('.done'),
       cancel: clickable('.cancel'),
@@ -65,7 +65,7 @@ export default create({
     instructionalNotes: {
       scope: '[data-test-instructional-notes]',
       value: text('span', { at: 0}),
-      edit: clickable('.editable'),
+      edit: clickable('[data-test-edit]'),
       set: fillInFroalaEditor('.fr-box'),
       save: clickable('.done'),
       cancel: clickable('.cancel'),
@@ -74,7 +74,7 @@ export default create({
     ilmHours: {
       scope: '.sessionilmhours',
       value: text('span', { at: 0}),
-      edit: clickable('.clickable'),
+      edit: clickable('[data-test-edit]'),
       set: fillable('input'),
       save: clickable('.done'),
       hasError: isVisible('.validation-error-message'),
@@ -82,7 +82,7 @@ export default create({
     ilmDueDate: {
       scope: '.sessionilmduedate',
       value: text('span', { at: 0}),
-      edit: clickable('.clickable'),
+      edit: clickable('[data-test-edit]'),
       set: datePicker('input'),
       save: clickable('.done'),
       hasError: isVisible('.validation-error-message'),
@@ -114,7 +114,7 @@ export default create({
     postrequisite: {
       scope: '.postrequisite',
       value: text('span', { at: 0}),
-      edit: clickable('.clickable'),
+      edit: clickable('[data-test-edit]'),
       set: fillable('select'),
       save: clickable('.done'),
       hasError: isVisible('.validation-error-message')

--- a/addon/components/big-text.js
+++ b/addon/components/big-text.js
@@ -52,10 +52,5 @@ export default Component.extend({
 
     return new htmlSafe(text);
 
-  }),
-  actions: {
-    expand: function(){
-      this.set('expanded', true);
-    }
-  }
+  })
 });

--- a/addon/components/big-text.js
+++ b/addon/components/big-text.js
@@ -17,8 +17,12 @@ export default Component.extend({
   text: '',
   ellipsis: 'ellipsis-h',
   renderHtml: true,
+
+  onEdit() {},
+
   lengths: collect('length', 'slippage'),
   totalLength: sum('lengths'),
+
   showIcons: computed('displayText', 'text', 'renderHtml', function(){
     if(this.get('renderHtml')){
       return this.get('displayText').toString() !== this.get('text');

--- a/addon/components/editable-field.js
+++ b/addon/components/editable-field.js
@@ -1,7 +1,7 @@
 import Component from '@ember/component';
-import layout from '../templates/components/editable-field';
 import { computed } from '@ember/object';
 import { isEmpty } from '@ember/utils';
+import layout from '../templates/components/editable-field';
 import { timeout, task } from 'ember-concurrency';
 
 export default Component.extend({
@@ -39,12 +39,25 @@ export default Component.extend({
   }).drop(),
 
   edit: task(function * () {
+    if (this.shouldExpandText(event)) {
+      return;
+    }
+
     this.set('isEditing', true);
     yield timeout(10);
     const control = this.$('.editor').find('input,textarea,select,.fr-element').filter(':visible:first');
-
     control.focus();
   }).drop(),
+
+  // Checks to see if the event should be bubbled down to expand text instead
+  // of showing an editor. Hacky addition until component is fully refactored.
+  shouldExpandText({ path }) {
+    return path.any(({ className }) => {
+      return typeof className === 'string'
+        ? className.includes('expand-text')
+        : false;
+    });
+  },
 
   keyUp(event) {
     const keyCode = event.keyCode;

--- a/addon/components/editable-field.js
+++ b/addon/components/editable-field.js
@@ -39,25 +39,11 @@ export default Component.extend({
   }).drop(),
 
   edit: task(function * () {
-    if (this.shouldExpandText(event)) {
-      return;
-    }
-
     this.set('isEditing', true);
     yield timeout(10);
     const control = this.$('.editor').find('input,textarea,select,.fr-element').filter(':visible:first');
     control.focus();
   }).drop(),
-
-  // Checks to see if the event should be bubbled down to expand text instead
-  // of showing an editor. Hacky addition until component is fully refactored.
-  shouldExpandText({ path }) {
-    return path.any(({ className }) => {
-      return typeof className === 'string'
-        ? className.includes('expand-text')
-        : false;
-    });
-  },
 
   keyUp(event) {
     const keyCode = event.keyCode;

--- a/addon/templates/components/big-text.hbs
+++ b/addon/templates/components/big-text.hbs
@@ -2,7 +2,10 @@
   {{displayText}}
 </span>
 {{#if showIcons}}
-  <span {{action "expand"}} class="clickable" role="button">
+  <span
+    class="clickable expand-text"
+    role="button"
+    {{action (mut expanded) true}}>
     {{fa-icon ellipsis classNames="text-bottom"}} {{fa-icon expandIcon}}
   </span>
 {{/if}}

--- a/addon/templates/components/big-text.hbs
+++ b/addon/templates/components/big-text.hbs
@@ -1,9 +1,12 @@
-<span class={{if renderHtml "list-reset"}}>
+<span
+  class={{if renderHtml "list-reset"}}
+  role="button"
+  onclick={{action onEdit}}>
   {{displayText}}
 </span>
 {{#if showIcons}}
   <span
-    class="clickable expand-text"
+    class="clickable"
     role="button"
     {{action (mut expanded) true}}>
     {{fa-icon ellipsis classNames="text-bottom"}} {{fa-icon expandIcon}}

--- a/addon/templates/components/big-text.hbs
+++ b/addon/templates/components/big-text.hbs
@@ -1,5 +1,6 @@
 <span
-  class={{if renderHtml "list-reset"}}
+  class="clickable {{if renderHtml "list-reset"}}"
+  data-test-edit
   role="button"
   onclick={{action onEdit}}>
   {{displayText}}
@@ -7,6 +8,7 @@
 {{#if showIcons}}
   <span
     class="clickable"
+    data-test-edit
     role="button"
     {{action (mut expanded) true}}>
     {{fa-icon ellipsis classNames="text-bottom"}} {{fa-icon expandIcon}}

--- a/addon/templates/components/editable-field.hbs
+++ b/addon/templates/components/editable-field.hbs
@@ -1,9 +1,12 @@
 <span class="content">
   {{#unless isEditing}}
-    <span class="clickable editable">
+    <span>
       {{#if value}}
         {{#if looksEmpty}}
-          {{fa-icon "edit" class="enabled" click=(perform edit)}}
+          {{fa-icon "edit"
+            class="enabled"
+            data-test-edit=""
+            click=(perform edit)}}
         {{else}}
           {{big-text
             renderHtml=renderHtml
@@ -11,7 +14,13 @@
             onEdit=(perform edit)}}
         {{/if}}
       {{else}}
-        {{clickPrompt}}
+        <span
+          class="clickable"
+          data-test-edit
+          role="button"
+          {{action (perform edit)}}>
+          {{clickPrompt}}
+        </span>
       {{/if}}
     </span>
   {{else}}

--- a/addon/templates/components/editable-field.hbs
+++ b/addon/templates/components/editable-field.hbs
@@ -1,11 +1,14 @@
 <span class="content">
   {{#unless isEditing}}
-    <span onclick={{perform edit}} class="clickable editable">
+    <span class="clickable editable">
       {{#if value}}
         {{#if looksEmpty}}
-          {{fa-icon "edit" class="enabled"}}
+          {{fa-icon "edit" class="enabled" click=(perform edit)}}
         {{else}}
-          {{big-text text=value renderHtml=renderHtml}}
+          {{big-text
+            renderHtml=renderHtml
+            text=value
+            onEdit=(perform edit)}}
         {{/if}}
       {{else}}
         {{clickPrompt}}

--- a/tests/integration/components/course-objective-list-item-test.js
+++ b/tests/integration/components/course-objective-list-item-test.js
@@ -67,7 +67,7 @@ module('Integration | Component | course objective list item', function(hooks) {
       manageDescriptors=(action nothing)
     }}`);
 
-    await click('td:nth-of-type(1) .editable');
+    await click('td:nth-of-type(1) [data-test-edit]');
     await fillInFroalaEditor('td:nth-of-type(1) .froala-editor-container', 'new title');
     await click('td:nth-of-type(1) .done');
   });

--- a/tests/integration/components/course-overview-test.js
+++ b/tests/integration/components/course-overview-test.js
@@ -37,7 +37,7 @@ module('Integration | Component | course overview', function(hooks) {
 
     const item = '.courseexternalid';
     const error = `${item} .validation-error-message`;
-    const button = `${item} .clickable`;
+    const button = `${item} [data-test-edit]`;
     const save = `${item} .actions .done`;
     const input = `${item} input`;
     await click(button);
@@ -56,7 +56,7 @@ module('Integration | Component | course overview', function(hooks) {
 
     const item = '.courseexternalid';
     const error = `${item} .validation-error-message`;
-    const button = `${item} .clickable`;
+    const button = `${item} [data-test-edit]`;
     const save = `${item} .actions .done`;
     const input = `${item} input`;
     await click(button);
@@ -86,7 +86,7 @@ module('Integration | Component | course overview', function(hooks) {
 
     const item = '.courseexternalid';
     const error = `${item} .validation-error-message`;
-    const button = `${item} .clickable`;
+    const button = `${item} [data-test-edit]`;
     const save = `${item} .actions .done`;
     const input = `${item} input`;
     await click(button);
@@ -116,7 +116,7 @@ module('Integration | Component | course overview', function(hooks) {
 
     const item = '.courseexternalid';
     const error = `${item} .validation-error-message`;
-    const button = `${item} .clickable`;
+    const button = `${item} [data-test-edit]`;
     const save = `${item} .actions .done`;
     const input = `${item} input`;
     await click(button);

--- a/tests/integration/components/editable-field-test.js
+++ b/tests/integration/components/editable-field-test.js
@@ -30,10 +30,8 @@ module('Integration | Component | editable field', function(hooks) {
    `);
 
     assert.dom(this.element).hasText('text');
-    await click('.editable');
+    await click('[data-test-edit]');
     assert.dom(this.element).hasText('template block text');
-
-
   });
 
   test('it renders an edit icon when it looks empty', async function(assert) {
@@ -54,7 +52,7 @@ module('Integration | Component | editable field', function(hooks) {
     await render(
       hbs`{{#editable-field save=(action save) saveOnEnter=true value=value}}<input value={{value}} oninput={{action (mut value) value="target.value"}}>{{/editable-field}}`
     );
-    await click('.editable');
+    await click('[data-test-edit]');
     await triggerKeyEvent('.editinplace input', 'keyup', 13);
   });
 
@@ -67,7 +65,7 @@ module('Integration | Component | editable field', function(hooks) {
     await render(
       hbs`{{#editable-field close=(action revert) closeOnEscape=true value=value}}<input value={{value}} oninput={{action (mut value) value="target.value"}}>{{/editable-field}}`
     );
-    await click('.editable');
+    await click('[data-test-edit]');
     await triggerKeyEvent('.editinplace input', 'keyup', 27);
   });
 });

--- a/tests/integration/components/session-objective-list-item-test.js
+++ b/tests/integration/components/session-objective-list-item-test.js
@@ -67,7 +67,7 @@ module('Integration | Component | session objective list item', function(hooks) 
       manageDescriptors=(action nothing)
     }}`);
 
-    await click('td:nth-of-type(1) .editable');
+    await click('td:nth-of-type(1) [data-test-edit]');
     await fillInFroalaEditor('td:nth-of-type(1) .froala-editor-container', 'new title');
     await click('td:nth-of-type(1) .done');
   });


### PR DESCRIPTION
**Summary:**
The ellipses icon which normally expands the display text doesn't work because it's embedded in a element which also has a click event trigger and the `edit` task function gets hit first before bubbling the action down to the ellipses icon. The parent click event trigger is removed and moved to `big-text` component.

Fixes https://github.com/ilios/frontend/issues/2519