### PR TITLE
scroll for missing items & unlinked objectives warnings

### DIFF
--- a/addon/components/course-publicationcheck.js
+++ b/addon/components/course-publicationcheck.js
@@ -1,8 +1,27 @@
 import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
+import { isEmpty } from '@ember/utils';
 import layout from '../templates/components/course-publicationcheck';
 
 export default Component.extend({
+  router: service(),
+
   layout,
+
   classNames: ['course-publicationcheck'],
-  course: null
+
+  course: null,
+
+  showUnlinkIcon: computed('course.objectives.[]', function() {
+    const objectives = this.course.objectives;
+    return objectives.any((objective) => isEmpty(objective.parents));
+  }),
+
+  actions: {
+    transitionToCourse() {
+      const queryParams = { courseObjectiveDetails: true, details: true };
+      this.router.transitionTo('course', this.course, { queryParams });
+    }
+  }
 });

--- a/addon/components/publish-menu.js
+++ b/addon/components/publish-menu.js
@@ -1,8 +1,13 @@
 import Component from '@ember/component';
+import { inject as service } from '@ember/service';
+import scrollTo from 'ilios-common/utils/scroll-to';
 import layout from '../templates/components/publish-menu';
 
 export default Component.extend({
+  router: service(),
+
   layout,
+
   classNameBindings: ['publicationStatus', ':publish-menu'],
   publicationStatus: 'notpublished',
   icon: 'cloud',
@@ -17,4 +22,19 @@ export default Component.extend({
   parentObject: null,
   publishTranslation: '',
   unpublishTranslation: '',
+
+  actions: {
+    scrollToCoursePublication() {
+      this.router.transitionTo(this.reviewRoute, this.reviewObject);
+      scrollTo('.course-publicationcheck');
+    },
+
+    scrollToSessionPublication() {
+      const reviewRoute = this.reviewRoute;
+      const parentObjectId = this.parentObject.id;
+      const reviewObject = this.reviewObject;
+      this.router.transitionTo(reviewRoute, parentObjectId, reviewObject);
+      scrollTo('.session-publicationcheck-content');
+    }
+  }
 });

--- a/addon/components/session-publicationcheck.js
+++ b/addon/components/session-publicationcheck.js
@@ -1,8 +1,27 @@
 import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
+import { isEmpty } from '@ember/utils';
 import layout from '../templates/components/session-publicationcheck';
 
 export default Component.extend({
+  router: service(),
+
   layout,
+
   classNames: ['session-publicationcheck'],
+
   session: null,
+
+  showUnlinkIcon: computed('session.objectives.[]', function() {
+    const objectives = this.session.objectives;
+    return objectives.any((objective) => isEmpty(objective.parents));
+  }),
+
+  actions: {
+    transitionToSession() {
+      const queryParams = { sessionObjectiveDetails: true };
+      this.router.transitionTo('session', this.session, { queryParams });
+    }
+  }
 });

--- a/addon/models/session.js
+++ b/addon/models/session.js
@@ -292,6 +292,11 @@ export default Model.extend(PublishableModel, CategorizableModel, SortableByPosi
     return !!this.belongsTo('postrequisite').id();
   }),
 
+  showUnlinkIcon: computed('objectives.[]', function() {
+    const objectives = this.objectives;
+    return objectives.any((objective) => isEmpty(objective.parents));
+  }),
+
   init() {
     this._super(...arguments);
     this.set('optionalPublicationLengthFields', ['terms', 'objectives', 'meshDescriptors']);

--- a/addon/templates/components/course-publicationcheck.hbs
+++ b/addon/templates/components/course-publicationcheck.hbs
@@ -1,6 +1,7 @@
 <div class="title">
   {{t "general.missingItems"}} ({{course.allPublicationIssuesLength}})
 </div>
+
 <div class="course-publicationcheck-content">
   <table>
     <thead>
@@ -12,6 +13,7 @@
         <th>{{t "general.meshTerms"}}</th>
       </tr>
     </thead>
+
     <tbody>
       <tr>
         <td>{{course.title}}</td>
@@ -25,8 +27,15 @@
         {{else}}
           <td class="no">{{t "general.no"}}</td>
         {{/if}}
-        {{#if course.objectives.length}}
-          <td class="yes">{{t "general.yes"}} ({{course.objectives.length}})</td>
+        {{#if @course.objectives.length}}
+          <td class="yes">
+            {{t "general.yes"}} ({{@course.objectives.length}})
+            {{#if this.showUnlinkIcon}}
+              {{fa-icon "unlink"
+                class="clickable"
+                click=(action "transitionToCourse")}}
+            {{/if}}
+          </td>
         {{else}}
           <td class="no">{{t "general.no"}}</td>
         {{/if}}

--- a/addon/templates/components/publish-all-sessions.hbs
+++ b/addon/templates/components/publish-all-sessions.hbs
@@ -14,6 +14,7 @@
   >
     {{t "general.incompleteSessions"}} ({{get (await unPublishableSessions) "length"}})
   </div>
+
   {{#unless unPublishableCollapsed}}
     <div class="content">
       <table>
@@ -26,6 +27,7 @@
             <th>{{t "general.meshTerms"}}</th>
           </tr>
         </thead>
+
         <tbody>
           {{#each (await unPublishableSessions) as |session|}}
             <tr>
@@ -41,7 +43,14 @@
                 <td class="no">{{t "general.no"}}</td>
               {{/if}}
               {{#if session.objectives.length}}
-                <td class="yes">{{t "general.yes"}} ({{session.objectives.length}})</td>
+                <td class="yes">
+                  {{t "general.yes"}} ({{session.objectives.length}})
+                  {{#if session.showUnlinkIcon}}
+                    {{fa-icon "unlink"
+                      class="clickable"
+                      click=(action "transitionToSession" session)}}
+                  {{/if}}
+                </td>
               {{else}}
                 <td class="no">{{t "general.no"}}</td>
               {{/if}}
@@ -66,6 +75,7 @@
   >
     {{t "general.completeSessions"}} ({{get (await publishableSessions) "length"}})
   </div>
+
   {{#unless publishableCollapsed}}
     <div class="content">
       <table>
@@ -78,6 +88,7 @@
             <th>{{t "general.meshTerms"}}</th>
           </tr>
         </thead>
+
         <tbody>
           {{#each (await publishableSessions) as |session|}}
             <tr>
@@ -93,7 +104,14 @@
                 <td class="no">{{t "general.no"}}</td>
               {{/if}}
               {{#if session.objectives.length}}
-                <td class="yes">{{t "general.yes"}} ({{session.objectives.length}})</td>
+                <td class="yes">
+                  {{t "general.yes"}} ({{session.objectives.length}})
+                  {{#if session.showUnlinkIcon}}
+                    {{fa-icon "unlink"
+                      class="clickable"
+                      click=(action "transitionToSession" session)}}
+                  {{/if}}
+                </td>
               {{else}}
                 <td class="no">{{t "general.no"}}</td>
               {{/if}}
@@ -114,6 +132,7 @@
   <div class="title">
     {{t "general.reviewSessions"}} ({{get (await overridableSessions) "length"}})
   </div>
+
   <div class="content">
     {{#if (get (await overridableSessions) "length")}}
       <button disabled={{await allSessionsAsIs}} {{action "publishAllAsIs"}}>
@@ -122,6 +141,7 @@
       <button disabled={{noSessionsAsIs}} {{action "publishNoneAsIs"}}>
         {{t "general.markAsScheduled"}}
       </button>
+
       <table>
         <thead>
           <tr>
@@ -133,6 +153,7 @@
             <th>{{t "general.meshTerms"}}</th>
           </tr>
         </thead>
+
         <tbody>
           {{#each (await overridableSessions) as |session|}}
             <tr>
@@ -180,7 +201,14 @@
                 <td class="no">{{t "general.no"}}</td>
               {{/if}}
               {{#if session.objectives.length}}
-                <td class="yes">{{t "general.yes"}} ({{session.objectives.length}})</td>
+                <td class="yes">
+                  {{t "general.yes"}} ({{session.objectives.length}})
+                  {{#if session.showUnlinkIcon}}
+                    {{fa-icon "unlink"
+                      class="clickable"
+                      click=(action "transitionToSession" session)}}
+                  {{/if}}
+                </td>
               {{else}}
                 <td class="no">{{t "general.no"}}</td>
               {{/if}}
@@ -198,6 +226,15 @@
 </section>
 
 <div class="publish-all-sessions-review">
+  {{#if (await this.showWarning)}}
+    <span class="unlinked-warning">{{t "general.unlinkedObjectives"}}</span>
+    {{fa-icon "unlink"
+      class="clickable"
+      click=(action "transitionToCourse")}}
+    {{fa-icon "chart-bar"
+      class="clickable"
+      click=(action "transitionToVisualizeObjectives")}}
+  {{/if}}
   <p>
     {{t
       "general.publishAllConfirmation"

--- a/addon/templates/components/publish-menu.hbs
+++ b/addon/templates/components/publish-menu.hbs
@@ -13,23 +13,15 @@
     {{/if}}
     {{#if (and showReview reviewRoute reviewObject)}}
       {{#if parentObject}}
-        {{#link-to reviewRoute parentObject reviewObject}}
-          <button class="good">
-            {{t
-              "general.reviewMissingItems"
-              count=(get reviewObject "allPublicationIssuesLength")
-            }}
-          </button>
-        {{/link-to}}
+        <button class="good" {{action "scrollToSessionPublication"}}>
+          {{t "general.reviewMissingItems"
+            count=(get this.reviewObject "allPublicationIssuesLength")}}
+        </button>
       {{else}}
-        {{#link-to reviewRoute reviewObject}}
-          <button class="good">
-            {{t
-              "general.reviewMissingItems"
-              count=(get reviewObject "allPublicationIssuesLength")
-            }}
-          </button>
-        {{/link-to}}
+        <button class="good" {{action "scrollToCoursePublication"}}>
+          {{t "general.reviewMissingItems"
+            count=(get this.reviewObject "allPublicationIssuesLength")}}
+        </button>
       {{/if}}
     {{/if}}
     {{#if showTbd}}

--- a/addon/templates/components/session-publicationcheck.hbs
+++ b/addon/templates/components/session-publicationcheck.hbs
@@ -14,6 +14,7 @@
   <div class="title">
     {{t "general.missingItems"}} ({{session.allPublicationIssuesLength}})
   </div>
+
   <div class="session-publicationcheck-content">
     <table>
       <thead>
@@ -25,6 +26,7 @@
           <th>{{t "general.meshTerms"}}</th>
         </tr>
       </thead>
+
       <tbody>
         <tr>
           <td>{{session.title}}</td>
@@ -38,8 +40,15 @@
           {{else}}
             <td class="no">{{t "general.no"}}</td>
           {{/if}}
-          {{#if session.objectives.length}}
-            <td class="yes">{{t "general.yes"}} ({{session.objectives.length}})</td>
+          {{#if @session.objectives.length}}
+            <td class="yes">
+              {{t "general.yes"}} ({{@session.objectives.length}})
+              {{#if this.showUnlinkIcon}}
+                {{fa-icon "unlink"
+                  class="clickable"
+                  click=(action "transitionToSession")}}
+              {{/if}}
+            </td>
           {{else}}
             <td class="no">{{t "general.no"}}</td>
           {{/if}}

--- a/app/styles/ilios-common/components/course-publicationcheck.scss
+++ b/app/styles/ilios-common/components/course-publicationcheck.scss
@@ -8,4 +8,9 @@
   .course-publicationcheck-content {
     @include detail-container-content;
   }
+
+  .fa-unlink {
+    color: $black;
+    font-size: .75rem;
+  }
 }

--- a/app/styles/ilios-common/components/publish-all-sessions.scss
+++ b/app/styles/ilios-common/components/publish-all-sessions.scss
@@ -35,6 +35,16 @@
     padding: 1rem;
     text-align: center;
 
+    .unlinked-warning {
+      color: $ilios-yellow;
+      font-size: 1rem;
+    }
+
+    .fa-chart-bar {
+      color: $ilios-blue;
+      font-size: .8rem;
+    }
+
     p {
       color: $ilios-green;
       font-weight: bold;
@@ -46,6 +56,10 @@
       background: $ilios-green;
       color: $white;
     }
+  }
 
+  .fa-unlink {
+    color: $black;
+    font-size: .75rem;
   }
 }

--- a/app/styles/ilios-common/components/session-publicationcheck.scss
+++ b/app/styles/ilios-common/components/session-publicationcheck.scss
@@ -23,4 +23,9 @@
       }
     }
   }
+
+  .fa-unlink {
+    color: $black;
+    font-size: .75rem;
+  }
 }

--- a/config/icons.js
+++ b/config/icons.js
@@ -68,6 +68,7 @@ module.exports = function() {
       'times',
       'trash',
       'undo',
+      'unlink',
       'user',
       'user-clock',
       'user-plus',

--- a/tests/acceptance/course/session/publish-test.js
+++ b/tests/acceptance/course/session/publish-test.js
@@ -131,10 +131,9 @@ module('Acceptance | Session - Publish', function(hooks) {
     const menu = '.session-header .publish-menu';
     const selector = `${menu} .rl-dropdown-toggle`;
     const choices = `${menu} .rl-dropdown button`;
-    const schedule = `${choices}:nth-of-type(2)`;
+    const schedule = `${choices}:nth-of-type(3)`;
     await click(selector);
     await click(schedule);
-
     assert.equal(await getElementText(selector), getText('Scheduled'));
   });
 
@@ -155,10 +154,9 @@ module('Acceptance | Session - Publish', function(hooks) {
     const menu = '.session-header .publish-menu';
     const selector = `${menu} .rl-dropdown-toggle`;
     const choices = `${menu} .rl-dropdown button`;
-    const unPublish = `${choices}:nth-of-type(2)`;
+    const unPublish = `${choices}:nth-of-type(3)`;
     await click(selector);
     await click(unPublish);
-
     assert.equal(await getElementText(selector), getText('Not Published'));
   });
 
@@ -167,10 +165,9 @@ module('Acceptance | Session - Publish', function(hooks) {
     const menu = '.session-header .publish-menu';
     const selector = `${menu} .rl-dropdown-toggle`;
     const choices = `${menu} .rl-dropdown > button`;
-    const schedule = `${choices}:nth-of-type(1)`;
+    const schedule = `${choices}:nth-of-type(2)`;
     await click(selector);
     await click(schedule);
-
     assert.equal(await getElementText(selector), getText('Scheduled'));
   });
 
@@ -179,10 +176,9 @@ module('Acceptance | Session - Publish', function(hooks) {
     const menu = '.session-header .publish-menu';
     const selector = `${menu} .rl-dropdown-toggle`;
     const choices = `${menu} .rl-dropdown button`;
-    const unPublish = `${choices}:nth-of-type(2)`;
+    const unPublish = `${choices}:nth-of-type(3)`;
     await click(selector);
     await click(unPublish);
-
     assert.equal(await getElementText(selector), getText('Not Published'));
   });
 
@@ -192,10 +188,9 @@ module('Acceptance | Session - Publish', function(hooks) {
     const selector = `${menu} .rl-dropdown-toggle`;
     const choices = `${menu} .rl-dropdown > button`;
     const firstChoice = `${choices}:nth-of-type(1)`;
-    const secondChoice = `${menu} a`;
-    const thirdChoice = `${choices}:nth-of-type(2)`;
+    const secondChoice = `${choices}:nth-of-type(2)`;
+    const thirdChoice = `${choices}:nth-of-type(3)`;
     await click(selector);
-
     assert.equal(await getElementText(firstChoice), getText('Publish As-is'));
     assert.equal(await getElementText(secondChoice), getText('Review 3 Missing Items'));
     assert.equal(await getElementText(thirdChoice), getText('Mark as Scheduled'));

--- a/tests/integration/components/publish-menu-test.js
+++ b/tests/integration/components/publish-menu-test.js
@@ -33,9 +33,9 @@ module('Integration | Component | publish menu', function(hooks) {
     const dropDownItems = '.rl-dropdown button';
     const asIs = `${dropDownItems}:nth-of-type(1)`;
     const publish = `${dropDownItems}:nth-of-type(2)`;
-    const review = 'a:nth-of-type(1)';
-    const schedule = `${dropDownItems}:nth-of-type(3)`;
-    const unpublish = `${dropDownItems}:nth-of-type(4)`;
+    const review = `${dropDownItems}:nth-of-type(3)`;
+    const schedule = `${dropDownItems}:nth-of-type(4)`;
+    const unpublish = `${dropDownItems}:nth-of-type(5)`;
 
     assert.dom(toggle).hasText('title');
     assert.dom(icon).hasClass('fa-cloud');
@@ -166,10 +166,9 @@ module('Integration | Component | publish menu', function(hooks) {
     const dropDownItems = '.rl-dropdown button';
     const asIs = `${dropDownItems}:nth-of-type(1)`;
     const publish = `${dropDownItems}:nth-of-type(2)`;
-    const review = 'a:nth-of-type(1)';
-    const schedule = `${dropDownItems}:nth-of-type(3)`;
-    const unpublish = `${dropDownItems}:nth-of-type(4)`;
-
+    const review = `${dropDownItems}:nth-of-type(3)`;
+    const schedule = `${dropDownItems}:nth-of-type(4)`;
+    const unpublish = `${dropDownItems}:nth-of-type(5)`;
 
     assert.dom(toggle).hasText('title');
     assert.dom(icon).hasClass('fa-cloud');

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -288,6 +288,7 @@ general:
   tuesday: Tuesday
   type: Type
   universalLocator: "Universal Locator"
+  unlinkedObjectives: "This course has unlinked objective(s)"
   unPublishCourse: "UnPublish Course"
   unPublishedSuccessfully: "UnPublished Successfully"
   unPublishSession: "UnPublish Session"

--- a/translations/es.yaml
+++ b/translations/es.yaml
@@ -288,6 +288,7 @@ general:
   tuesday: Martes
   type: Tipo
   universalLocator: "Localizador universal de"
+  unlinkedObjectives: "Este curso tiene objetivo(s) no vinculados"
   unPublishCourse: "No Publique El Curso"
   unPublishedSuccessfully: "No Publicado con Éxito"
   unPublishSession: "No Publique La Sesión"

--- a/translations/fr.yaml
+++ b/translations/fr.yaml
@@ -288,6 +288,7 @@ general:
   tuesday: Mardi
   type: Type
   universalLocator: "Localisateur universel"
+  unlinkedObjectives: "Ce cours comprend des objectifs non liés"
   unPublishCourse: "Faire à Dépublier Cours"
   unPublishedSuccessfully: "Faire à Dépublier réussi"
   unPublishSession: "Faire à Dépublier Session"


### PR DESCRIPTION
**Summary:**
- Added scroll functionality to be directed to course/session missing items review when users click on the `Review Missing Items` dropdown option.
- Course Missing Items Review - checks if any of the course objectives do not have parents. If so, unlink icon will show up and transition the user to `/courses/course_id?courseObjectiveDetails=true&details=true`.
- Session Missing Items Review - checks if any of the session objectives do not have parents. If so, unlink icon will show up and transition the user to `/courses/course_id/sessions/session_id?sessionObjectiveDetails=true`.
- Publish All Review Page
  - There is a warning (in yellow) if the any one of the course objectives do not have parents, along with an unlink icon and chart icon, which takes users to course objective visualization route.
  - Applied unlink icon, which checks if any session objectives do not have parents, to the three sections:
    - Sessions Incomplete: cannot publish
    - Sessions Complete: ready to publish
    - Sessions Requiring Review

**UI:**
_Course Level Missing Items Review_
<img width="985" alt="Screen Shot 2019-05-02 at 4 49 24 PM" src="https://user-images.githubusercontent.com/7553764/57109431-0e0f8500-6cfb-11e9-81c7-80e413775da9.png">

_Session Level Missing Items Review_
<img width="983" alt="Screen Shot 2019-05-02 at 4 50 20 PM" src="https://user-images.githubusercontent.com/7553764/57109432-0ea81b80-6cfb-11e9-872e-d7b460451aaa.png">

_Publish All Review Page_
<img width="1073" alt="Screen Shot 2019-05-02 at 4 48 10 PM" src="https://user-images.githubusercontent.com/7553764/57109429-0d76ee80-6cfb-11e9-81d8-16b096c0fea8.png">

Fixes https://github.com/ilios/frontend/issues/1188
Fixes https://github.com/ilios/frontend/issues/3933