### PR TITLE
higher level learner group list header is bold

### DIFF
--- a/app/styles/ilios-common/components/learnergroup-selection-manager.scss
+++ b/app/styles/ilios-common/components/learnergroup-selection-manager.scss
@@ -1,5 +1,4 @@
 .learnergroup-selection-manager {
-
   .available-learner-groups {
     display: grid;
 
@@ -26,6 +25,10 @@
     h5 {
       margin-bottom: .5rem;
       padding: .5rem;
+    }
+
+    .tree-groups-list > li > span {
+      font-weight: bold;
     }
 
     & > ul {


### PR DESCRIPTION
**Summary:**
Top level learner groups in the list should be bold.

**UI:**
<img width="524" alt="Screen Shot 2019-05-08 at 1 11 34 PM" src="https://user-images.githubusercontent.com/7553764/57397765-00db1600-7193-11e9-85c0-6b594b9d9c59.png">

Fixes https://github.com/ilios/frontend/issues/4538