### PR TITLE
Provide API version as a service

### DIFF
--- a/addon/services/api-version.js
+++ b/addon/services/api-version.js
@@ -1,0 +1,19 @@
+import Service from '@ember/service';
+import { inject as service } from '@ember/service';
+import { computed } from '@ember/object';
+import { getOwner } from '@ember/application';
+
+export default Service.extend({
+  iliosConfig: service(),
+
+  version: computed(function () {
+    const { apiVersion } = getOwner(this).resolveRegistration('config:environment');
+
+    return apiVersion;
+  }),
+
+  isMismatched: computed('iliosConfig.apiVersion', 'version', async function () {
+    const serverApiVersion = await this.iliosConfig.apiVersion;
+    return serverApiVersion !== this.version;
+  }),
+});

--- a/app/services/api-version.js
+++ b/app/services/api-version.js
@@ -1,0 +1,1 @@
+export { default } from 'ilios-common/services/api-version';

--- a/config/api-version.js
+++ b/config/api-version.js
@@ -1,0 +1,3 @@
+/* eslint-env node */
+
+module.exports = 'v1.38';

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const API_VERSION = require('./api-version.js');
+
 module.exports = function(environment /*, appConfig */) {
   var ENV = {
     googleFonts: [
@@ -19,7 +21,8 @@ module.exports = function(environment /*, appConfig */) {
     },
     featureFlags: {
       'sessionLinkingAdminUi': true,
-    }
+    },
+    apiVersion: API_VERSION,
   };
 
   if ('development' === environment) {

--- a/tests/unit/services/api-version-test.js
+++ b/tests/unit/services/api-version-test.js
@@ -1,0 +1,43 @@
+import Service from '@ember/service';
+import { resolve } from 'rsvp';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Service | api-version', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let service = this.owner.lookup('service:api-version');
+    assert.ok(service);
+  });
+
+  test('returns false when versions match', async function (assert) {
+    const { apiVersion } = this.owner.resolveRegistration('config:environment');
+    assert.ok(apiVersion);
+    const iliosConfigMock = Service.extend({
+      apiVersion: resolve(apiVersion)
+    });
+    this.owner.register('service:iliosConfig', iliosConfigMock);
+    const service = this.owner.lookup('service:api-version');
+    const versionMismatch = await service.isMismatched;
+    assert.notOk(versionMismatch);
+  });
+
+  test('returns true on version mismatch', async function(assert) {
+    const iliosConfigMock = Service.extend({
+      apiVersion: resolve('1.0.0')
+    });
+    this.owner.register('service:iliosConfig', iliosConfigMock);
+    const service = this.owner.lookup('service:api-version');
+    const versionMismatch = await service.isMismatched;
+    assert.ok(versionMismatch);
+  });
+
+  test('returns the current version', async function (assert) {
+    const { apiVersion } = this.owner.resolveRegistration('config:environment');
+    assert.ok(apiVersion);
+    const service = this.owner.lookup('service:api-version');
+    assert.equal(apiVersion, await service.version);
+  });
+});


### PR DESCRIPTION
It makes sense to have this in common as that is where the models go
that actually bump the version. We also need this information in the
course manager API to prevent writes there when the version does not
match.