### PR TITLE
Refactor usage of hasOwnProperty from object prototype

### DIFF
--- a/addon/components/week-glance.js
+++ b/addon/components/week-glance.js
@@ -85,7 +85,7 @@ export default Component.extend({
     // grab ILMs only, and group them by session.
     const groups = {};
     preWork.filter(ev => ev.ilmSession).forEach(ilm => {
-      if (! groups.hasOwnProperty(ilm.session)) {
+      if (! Object.prototype.hasOwnProperty.call(groups, ilm.session)) {
         groups[ilm.session] = [];
       }
       groups[ilm.session].pushObject(ilm);

--- a/addon/helpers/lm-type.js
+++ b/addon/helpers/lm-type.js
@@ -2,13 +2,13 @@ import { helper } from '@ember/component/helper';
 
 export function lmType(params/*, hash*/) {
   const obj = params[0];
-  if (obj.hasOwnProperty('filename')) {
+  if (Object.prototype.hasOwnProperty.call(obj, 'filename')) {
     return 'file';
   }
-  if (obj.hasOwnProperty('citation')) {
+  if (Object.prototype.hasOwnProperty.call(obj, 'citation')) {
     return 'citation';
   }
-  if (obj.hasOwnProperty('link')) {
+  if (Object.prototype.hasOwnProperty.call(obj, 'link')) {
     return 'link';
   }
 }

--- a/addon/services/permission-matrix.js
+++ b/addon/services/permission-matrix.js
@@ -250,11 +250,11 @@ export default Service.extend({
   async hasPermission(school, capability, userRoles) {
     const matrix = await this.get('permissionMatrix');
     const schoolId = school.get('id');
-    if (!matrix.hasOwnProperty(schoolId)) {
+    if (!Object.prototype.hasOwnProperty.call(matrix, schoolId)) {
       return false;
     }
     const schoolMatrix = matrix[schoolId];
-    if (!schoolMatrix.hasOwnProperty(capability)) {
+    if (!Object.prototype.hasOwnProperty.call(schoolMatrix, capability)) {
       return false;
     }
 
@@ -265,11 +265,11 @@ export default Service.extend({
   async getPermittedRoles(school, capability) {
     const matrix = await this.get('permissionMatrix');
     const schoolId = school.get('id');
-    if (!matrix.hasOwnProperty(schoolId)) {
+    if (!Object.prototype.hasOwnProperty.call(matrix, schoolId)) {
       return [];
     }
     const schoolMatrix = matrix[schoolId];
-    if (!schoolMatrix.hasOwnProperty(capability)) {
+    if (!Object.prototype.hasOwnProperty.call(schoolMatrix, capability)) {
       return [];
     }
 

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports = {
     let isRegistered = false;
     for(let i = 0; i < registered.length; i++) {
       const plugin = registered[i];
-      if (plugin.hasOwnProperty('name') && 'v-get' === plugin.name) {
+      if (Object.prototype.hasOwnProperty.call(plugin, 'name') && 'v-get' === plugin.name) {
         isRegistered = true;
         break;
       }


### PR DESCRIPTION
This is now considered to be a bad idea and ESLint 6+ adds it to their
default rules. It's a bit more verbose, but the new syntax looks ok to
me and we can just go with the flow here.

Refs #736 