### PR TITLE
Remove unnecessary calls to translationMacro

### DIFF
--- a/addon/components/detail-cohort-manager.js
+++ b/addon/components/detail-cohort-manager.js
@@ -5,8 +5,6 @@ import Component from '@ember/component';
 import { map, filter } from 'rsvp';
 import { computed } from '@ember/object';
 
-import { translationMacro as t } from "ember-intl";
-
 export default Component.extend({
   intl: service(),
   store: service(),
@@ -18,7 +16,6 @@ export default Component.extend({
   school: null,
   selectedCohorts: null,
 
-  placeholder: t('general.filterPlaceholder'),
   allCohorts: computed('school', async function () {
     const store = this.get('store');
     const permissionChecker = this.get('permissionChecker');

--- a/addon/components/detail-mesh.js
+++ b/addon/components/detail-mesh.js
@@ -3,7 +3,6 @@ import layout from '../templates/components/detail-mesh';
 import { all } from 'rsvp';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
-import { translationMacro as t } from "ember-intl";
 
 export default Component.extend({
   store: service(),
@@ -19,7 +18,6 @@ export default Component.extend({
   editable: true,
   bufferTerms: null,
   'data-test-detail-mesh': true,
-  placeholder: t('general.meshSearchPlaceholder'),
   terms: oneWay('subject.meshDescriptors'),
   sortedTerms: sort('terms', 'sortTerms'),
   init() {

--- a/addon/components/instructor-selection-manager.js
+++ b/addon/components/instructor-selection-manager.js
@@ -1,6 +1,5 @@
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
-import { translationMacro as t } from "ember-intl";
 import layout from '../templates/components/instructor-selection-manager';
 
 export default Component.extend({
@@ -13,7 +12,6 @@ export default Component.extend({
   instructorGroups: null,
   'data-test-instructor-selection-manager': true,
 
-  userSearchPlaceholder: t('general.findInstructorOrGroup'),
   actions: {
     addInstructor(user){
       this.addInstructor(user);

--- a/addon/components/session-offerings.js
+++ b/addon/components/session-offerings.js
@@ -2,7 +2,6 @@ import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import layout from '../templates/components/session-offerings';
-import { translationMacro as t } from "ember-intl";
 
 const { alias, oneWay } = computed;
 
@@ -16,8 +15,6 @@ export default Component.extend({
   session: null,
   offeringEditorOn: false,
   'data-test-session-offerings': true,
-  placeholderValue: t('general.sessionTitleFilterPlaceholder'),
   offerings: oneWay('session.offerings'),
-  newButtonTitle: t('general.add'),
   cohorts: alias('session.course.cohorts'),
 });

--- a/addon/templates/components/instructor-selection-manager.hbs
+++ b/addon/templates/components/instructor-selection-manager.hbs
@@ -23,7 +23,7 @@
   addUser=(action "addInstructor")
   addInstructorGroup=(action "addInstructorGroup")
   currentlyActiveUsers=instructors
-  placeholder=userSearchPlaceholder
+  placeholder=(t "general.findInstructorOrGroup")
   availableInstructorGroups=(await availableInstructorGroups)
   currentlyActiveInstructorGroups=instructorGroups
 }}


### PR DESCRIPTION
This import is deprecated, but it turns out every usage of it was a
vestige of old code and this is done in templates now.