### PR TITLE
Add Improved API Version Notice Component

### DIFF
--- a/addon-test-support/ilios-common/page-objects/components/api-version-notice.js
+++ b/addon-test-support/ilios-common/page-objects/components/api-version-notice.js
@@ -1,0 +1,16 @@
+import {
+  create,
+  hasClass,
+  notHasClass,
+  property,
+} from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-api-version-notice]',
+  notMismatched: notHasClass('mismatch'),
+  mismatched: hasClass('mismatch'),
+  htmlHidden: property('hidden'),
+};
+
+export default definition;
+export const component = create(definition);

--- a/addon/components/api-version-notice.js
+++ b/addon/components/api-version-notice.js
@@ -1,0 +1,61 @@
+import Component from '@ember/component';
+import layout from '../templates/components/api-version-notice';
+import { inject as service } from '@ember/service';
+import { task, timeout } from 'ember-concurrency';
+import { set } from '@ember/object';
+
+export default Component.extend({
+  apiVersion: service(),
+  layout,
+  tagName: '',
+
+  mismatched: false,
+  updateAvailable: false,
+  countdownToUpdate: null,
+  showReloadButton: false,
+
+  check: task(function* () {
+    const mismatched = yield this.apiVersion.isMismatched;
+    if (mismatched && 'serviceWorker' in navigator) {
+      yield (2000); //wait to let the new service worker get fetched if it is available
+      const reg = yield navigator.serviceWorker.getRegistration();
+      if (reg) {
+        if (reg.waiting) {
+          this.update.perform();
+        } else {
+          reg.onupdatefound = () => {
+            this.countdown.perform();
+          };
+        }
+      } else {
+        set(this, 'showReloadButton', true);
+      }
+    }
+    this.set('mismatched', mismatched);
+    return true; //always return true to update data-test-load-finished property
+  }).drop().on('didInsertElement'),
+
+  actions: {
+    reload() {
+      window.location.reload();
+    }
+  },
+
+  countdown: task(function* () {
+    this.set('updateAvailable', true);
+    for (let i = 5; i > 0; i--) {
+      this.set('countdownToUpdate', i);
+      yield timeout(1000);
+    }
+    yield this.update.perform();
+  }).drop(),
+  update: task(function* () {
+    if ('serviceWorker' in navigator) {
+      const reg = yield navigator.serviceWorker.getRegistration();
+      if (reg && reg.waiting) {
+        reg.waiting.postMessage('skipWaiting');
+      }
+    }
+    yield timeout(3000);
+  }).drop(),
+});

--- a/addon/templates/components/api-version-notice.hbs
+++ b/addon/templates/components/api-version-notice.hbs
@@ -1,0 +1,33 @@
+<div
+  class="api-version-notice {{if mismatched "mismatch"}}"
+  hidden={{not mismatched}}
+  aria-role={{if mismatched "alert" false}}
+  data-test-load-finished={{check.lastSuccessful.value}}
+  data-test-api-version-notice
+>
+  <h2>
+    {{fa-icon "exclamation-circle"}}
+    {{t "general.apiVersionMismatch"}}
+  </h2>
+  <div class="details">
+    <p>{{t "general.apiVersionMismatchDetails"}}</p>
+    {{#if updateAvailable}}
+      <p>
+        {{t "general.autoUpdatingSeconds" count=countdownToUpdate}}
+        <button {{action (perform update)}}>
+          {{t "general.updateNow"}}
+        </button>
+      </p>
+    {{/if}}
+    {{#if update.isRunning}}
+      <p>{{t "general.updatePending"}}</p>
+    {{/if}}
+    {{#if showReloadButton}}
+      <p>
+        <button {{action "reload"}}>
+          {{t "general.updateNow"}}
+        </button>
+      </p>
+    {{/if}}
+  </div>
+</div>

--- a/app/components/api-version-notice.js
+++ b/app/components/api-version-notice.js
@@ -1,0 +1,1 @@
+export { default } from 'ilios-common/components/api-version-notice';

--- a/app/styles/ilios-common/components.scss
+++ b/app/styles/ilios-common/components.scss
@@ -1,4 +1,5 @@
 @import 'components/action-menu';
+@import 'components/api-version-notice';
 @import 'components/back-link';
 @import 'components/big-text';
 @import 'components/body';

--- a/app/styles/ilios-common/components/api-version-notice.scss
+++ b/app/styles/ilios-common/components/api-version-notice.scss
@@ -1,0 +1,23 @@
+.api-version-notice {
+  @include critical-notice($warning-color, $text-grey, 1rem);
+
+  display: none;
+  padding: .25rem 1rem;
+
+  &.mismatch {
+    display: block;
+  }
+
+  .details {
+    line-height: 1em;
+    button {
+      background-color: $text-grey;
+      border: 0;
+      color: $white;
+      display: inline-block;
+      height: 100%;
+    }
+  }
+
+
+}

--- a/app/styles/ilios-common/mixins.scss
+++ b/app/styles/ilios-common/mixins.scss
@@ -1,5 +1,6 @@
 @import 'mixins/media';
 @import 'mixins/collapsed-container';
+@import 'mixins/critical-notice';
 @import 'mixins/detail-container';
 @import 'mixins/icon';
 @import 'mixins/ilios-button';

--- a/app/styles/ilios-common/mixins/critical-notice.scss
+++ b/app/styles/ilios-common/mixins/critical-notice.scss
@@ -1,0 +1,11 @@
+@mixin critical-notice ($background-color, $color, $height) {
+  background-color: $background-color;
+  color: $color;
+  display: block;
+  line-height: $height;
+  margin: 0;
+  min-height: $height;
+  padding: 0;
+  text-align: center;
+  width: 100%;
+}

--- a/tests/integration/components/api-version-notice-test.js
+++ b/tests/integration/components/api-version-notice-test.js
@@ -1,0 +1,34 @@
+import Service from '@ember/service';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, waitFor } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { component } from 'ilios-common/page-objects/components/api-version-notice';
+
+module('Integration | Component | api-version-notice', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('hidden when version match', async function (assert) {
+    const apiVersionMock = Service.extend({
+      isMismatched: false,
+    });
+    this.owner.register('service:apiVersion', apiVersionMock);
+    await render(hbs`<ApiVersionNotice />`);
+    await waitFor('[data-test-load-finished]');
+    assert.ok(component.isHidden);
+    assert.ok(component.notMismatched);
+    assert.ok(component.htmlHidden);
+  });
+
+  test('visible when versions do not match', async function (assert) {
+    const apiVersionMock = Service.extend({
+      isMismatched: true,
+    });
+    this.owner.register('service:apiVersion', apiVersionMock);
+    await render(hbs`<ApiVersionNotice />`);
+    await waitFor('[data-test-load-finished]');
+    assert.ok(component.isVisible);
+    assert.ok(component.mismatched);
+    assert.notOk(component.htmlHidden);
+  });
+});

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -11,12 +11,15 @@ general:
   allCourses: "All Courses"
   allEvents: "All Events"
   allWeeks: "All Weeks"
+  apiVersionMismatch: "API Version Mismatch"
+  apiVersionMismatchDetails: "This is usually a temporary error in your browser; Ilios is in read-only mode until it resolved. If updating does not help, please notify an administrator or technical owner of the system regarding this error. You may also wish to try a different browser."
   assignedTerms: "Assigned Terms"
   associatedGroups: "Associated Groups"
   attendanceIs_Required_: "Attendance is <strong><em>required</em></strong>"
   attendanceIsRequired: "Attendance is required"
   attendanceRequired: "Attendance Required"
   author: Author
+  autoUpdatingSeconds: "{count, plural, =1 {Auto updating in 1 second...} other {Auto updating in # seconds...}}"
   availableLearnerGroups: "Available Learner Groups"
   back: Back
   backToCourse: "Back to Course"
@@ -298,6 +301,7 @@ general:
   unusedObjectives: "Unused Objectives"
   upcomingActivities: "My Activities for the next {days} days"
   upcomingMaterials: "My Learning Materials for the next {days} days"
+  updateNow: "Update Now"
   uploadDate: "Upload date"
   url: URL
   userRole: "User Role"

--- a/translations/es.yaml
+++ b/translations/es.yaml
@@ -11,12 +11,15 @@ general:
   allCourses: "Todos Los Cursos"
   allEvents: "Todos los Eventos"
   allWeeks: "Todas las Semanas"
+  apiVersionMismatch: "Incompatibilidad de versión de API"
+  apiVersionMismatchDetails: "Este interfaz de usuario no corresponde a la versión del API con el cual se comunica. Por favor notifique a un administrador o el dueño técnico del sistema con respecto a este error <em>inmediatamente</em>, no puede trabajar con Ilios hasta que esto ha sido resuelto"
   assignedTerms: "Términos asignados"
   associatedGroups: "Grupos Associados"
   attendanceIs_Required_: "Se <strong><em>require</em></strong> asistencia"
   attendanceIsRequired: "Se require asistencia"
   attendanceRequired: "Asistencia Requerida"
   author: Autor
+  autoUpdatingSeconds: "{count, plural, =1 {Actualización automática en 1 segundo...} other {Actualización automática en # segundos...}}"
   availableLearnerGroups: "Grupos de Aprendedores Disponibles"
   back: Volver
   backToCourse: "Volver al Curso"
@@ -298,6 +301,7 @@ general:
   unusedObjectives: "Objetivos no Utilizados"
   upcomingActivities: "Mis Actividades para los próximos {days} días"
   upcomingMaterials: "Mis Materiales de Aprendizaje para los próximos {days} días"
+  updateNow: "Actualizar Ahora "
   uploadDate: "Fecha de carga"
   url: URL
   userRole: "Función de Usuario"

--- a/translations/fr.yaml
+++ b/translations/fr.yaml
@@ -11,12 +11,15 @@ general:
   allCourses: "Tous les Cours"
   allEvents: "Tous les Événements"
   allWeeks: "Toutes les Semaines"
+  apiVersionMismatch: "API  conflit de version"
+  apiVersionMismatchDetails: "Il s'agit généralement d'une erreur temporaire dans votre navigateur; Ilios est en mode lecture seule jusqu'à ce qu'il soit résolu. Si la mise à jour ne vous aide pas, veuillez aviser un administrateur ou le propriétaire de la technologie du système de cette erreur. Vous pouvez également essayer un autre navigateur."
   assignedTerms: "Termes assignées"
   associatedGroups: "Groupes Associés"
   attendanceIs_Required_: "Présence <strong><em>requise</em></strong>"
   attendanceIsRequired: "Présence requise"
   attendanceRequired: "Participation Requise"
   author: Auteur
+  autoUpdatingSeconds: "{count, plural, =1 { Mise à jour automatique en 1 seconde...} other { Mise à jour automatique en # secondes...}}"
   availableLearnerGroups: "Groupes d'apprenants disponsibles"
   back: Retour
   backToCourse: "Retour au Cours"
@@ -298,6 +301,7 @@ general:
   unusedObjectives: "Objectifs non Utilisés"
   upcomingActivities: "Mes Activités pendant les {days} prochains jours"
   upcomingMaterials: "Mes Matériels d'Étude pendant les {days} prochains jours"
+  updateNow: "Actualiser affichage"
   uploadDate: "Date de dépôt"
   url: URL
   userRole: "Rôle d'utilisateur"


### PR DESCRIPTION
When the API version here doesn't match the one on the API the app goes
into read-only mode. This notice should appear at the top to let users
know what is going on.

WIP:
- [ ] Validate Message
- [x] Needs updated Spanish translation

Example:

![Screen Shot 2019-07-08 at 10 27 42 AM](https://user-images.githubusercontent.com/349624/60830041-2c668680-a16b-11e9-888e-da41b382856b.png)
