### PR TITLE
Guard against empty type in icon

### DIFF
--- a/addon/components/lm-type-icon.js
+++ b/addon/components/lm-type-icon.js
@@ -32,5 +32,9 @@ export default Component.extend({
       }
     }
     return 'file';
+  }),
+  title: computed('type', function () {
+    const type = this.type ? this.type : 'file';
+    return `general.${type}`;
   })
 });

--- a/addon/templates/components/lm-type-icon.hbs
+++ b/addon/templates/components/lm-type-icon.hbs
@@ -1,1 +1,1 @@
-{{fa-icon icon listItem=listItem title=(t (concat "general." type))}}
+{{fa-icon icon listItem=listItem title=(t title)}}


### PR DESCRIPTION
Usually too fast for the eye to see, but this can render without a
correct type which shows up as errors in our tests. Making this a
computed property with a default prevents this.