### PR TITLE
Allow tests to fail against ember-beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ branches:
 jobs:
   fail_fast: true
   allow_failures:
+    - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
 
   include:


### PR DESCRIPTION
We're going to merge in this case so we should just officially allow it.