### PR TITLE
Replace computed props with plain functions

### DIFF
--- a/addon/components/new-learningmaterial.js
+++ b/addon/components/new-learningmaterial.js
@@ -6,7 +6,7 @@ import ValidationErrorDisplay from 'ilios-common/mixins/validation-error-display
 import { task } from 'ember-concurrency';
 import layout from '../templates/components/new-learningmaterial';
 
-const { equal, not, reads } = computed;
+const { equal, reads } = computed;
 
 const Validations = buildValidations({
   title: [
@@ -27,37 +27,45 @@ const Validations = buildValidations({
     validator('presence', {
       presence: true,
       dependentKeys: ['model.isFile'],
-      disabled: not('model.isFile')
+      disabled(model) {
+        return !model.get('isFile');
+      }
     }),
   ],
   filename: [
     validator('presence', {
       presence: true,
       dependentKeys: ['model.isFile'],
-      disabled: not('model.isFile')
+      disabled(model) {
+        return !model.get('isFile');
+      }
     }),
   ],
   link: [
     validator('presence', {
       presence: true,
       dependentKeys: ['model.isLink'],
-      disabled: not('model.isLink')
+      disabled(model) {
+        return !model.get('isLink');
+      }
     }),
   ],
   citation: [
     validator('presence', {
       presence: true,
       dependentKeys: ['model.isCitation'],
-      disabled: not('model.isCitation')
+      disabled(model) {
+        return !model.get('isCitation');
+      }
     }),
   ],
   copyrightRationale: [
     validator('presence', {
       presence: true,
-      dependentKeys: ['model.copyrightPermission'],
-      disabled: computed('model.isFile', 'model.copyrightPermission', function(){
-        return !this.get('model.isFile') || this.get('model.copyrightPermission');
-      })
+      dependentKeys: ['model.isFile', 'model.copyrightPermission'],
+      disabled(model) {
+        return !model.get('isFile') || model.get('copyrightPermission');
+      }
     }),
     validator('length', {
       min: 2,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1064,9 +1064,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.7.4",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.4.tgz",
-          "integrity": "sha512-W0+n1Y+gK/8G2P/piTkBBN38Qc5Q1ZSO6B5H3QmPCUewaiXOo2GCAWZ4ElZCcNhjJuBSUSLGFUJnmlCn5+nxOQ=="
+          "version": "12.7.5",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.5.tgz",
+          "integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w=="
         },
         "acorn": {
           "version": "7.0.0",
@@ -1979,9 +1979,9 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
     },
     "@types/node": {
-      "version": "9.6.51",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.51.tgz",
-      "integrity": "sha512-5lhC7QM2J3b/+epdwaNfRuG2peN4c9EX+mkd27+SqLKhJSdswHTZvc4aZLBZChi+Wo32+E1DeMZs0fSpu/uBXQ=="
+      "version": "9.6.52",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.52.tgz",
+      "integrity": "sha512-d6UdHtc8HKe3NTruj9mHk2B8EiHZyuG/00aYbUedHvy9sBhtLAX1gaxSNgvcheOvIZavvmpJYlwfHjjxlU/Few=="
     },
     "@types/resolve": {
       "version": "0.0.8",
@@ -2227,9 +2227,9 @@
       }
     },
     "acorn-globals": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.3.tgz",
-      "integrity": "sha512-vkR40VwS2SYO98AIeFvzWWh+xyc2qi9s7OoXSFEGIP/rOJKzjnhykaZJNnHdoq4BL2gGxI5EZOU16z896EYnOQ==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
+      "integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
       "requires": {
         "acorn": "^6.0.1",
         "acorn-walk": "^6.0.1"
@@ -6341,9 +6341,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.253",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.253.tgz",
-      "integrity": "sha512-LAwFRWViiiCSxQ2Lj3mnyEP8atkpAoHSPUnkFoy4mNabbnPHxtfseWvPCGGhewjHQI+ky/V4LdlTyyI0d3YPXA=="
+      "version": "1.3.255",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.255.tgz",
+      "integrity": "sha512-SZ6NlaNw3h4WR5kA1BK8XltdJCax02P+lW+z78RYoLDqmpyYuDQ5bS+/O6MCJ/j761qoZIFox2qYYt+UwqGA5w=="
     },
     "elemental-calendar": {
       "version": "0.2.0",
@@ -9354,9 +9354,9 @@
       }
     },
     "ember-pikaday": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/ember-pikaday/-/ember-pikaday-2.4.0.tgz",
-      "integrity": "sha512-ZWgbrJKoYmt5X8HHAJNAIsOcDl/qxhixpvr/6f9ZNubxtyiPQ54dDsX6z50qDrIYKjYFfhSw9iJLoLebnL0OZg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/ember-pikaday/-/ember-pikaday-2.4.1.tgz",
+      "integrity": "sha512-y9wCIXNkVpDL0yrchtu6YMTd4YXML/K3okVyMlMZn4jGLdKEUZ7gMoMY0Sejlx2Iaj7EqPke+CSbJoEt/w1tYw==",
       "requires": {
         "ember-cli-babel": "^6.16.0",
         "ember-cli-htmlbars": "^3.0.0",
@@ -14198,9 +14198,9 @@
       }
     },
     "minipass": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.5.0.tgz",
-      "integrity": "sha512-9FwMVYhn6ERvMR8XFdOavRz4QK/VJV8elU1x50vYexf9lslDcWe/f4HBRxCPd185ekRSjU6CfYyJCECa/CQy7Q==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.5.1.tgz",
+      "integrity": "sha512-dmpSnLJtNQioZFI5HfQ55Ad0DzzsMAb+HfokwRTNXwEQjepbTkl5mtIlSVxGIkOkxlpX7wIn5ET/oAd9fZ/Y/Q==",
       "dev": true,
       "requires": {
         "safe-buffer": "^5.1.2",
@@ -17464,21 +17464,21 @@
       }
     },
     "string.prototype.trimleft": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.0.0.tgz",
-      "integrity": "sha1-aLaqjhYsaoDnbjqKDC50cYbicf8=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+      "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.0.2"
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
       }
     },
     "string.prototype.trimright": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.0.0.tgz",
-      "integrity": "sha1-q0pW2AKgH75yk+EehPJNyBZGYd0=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+      "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.0.2"
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
       }
     },
     "string_decoder": {


### PR DESCRIPTION
Adding a computed property onto a validator breaks starting with ember
3.13.