### PR TITLE
Add more descriptive information to links

### DIFF
--- a/addon/templates/components/week-glance-event.hbs
+++ b/addon/templates/components/week-glance-event.hbs
@@ -1,11 +1,15 @@
 <div class="event" data-test-week-glance-event>
   <h4 id={{concat "event" @event.slug}}>
-    <span class="title" data-test-event-title>
-      {{#link-to "events" @event.slug}}
+    <span id={{concat "event" @event.slug "title"}} class="title" data-test-event-title>
+      <LinkTo
+        @route="events"
+        @model={{@event.slug}}
+        aria-labelledby="{{concat "event" @event.slug "title"}} {{concat "event" @event.slug "date"}}"
+      >
         {{@event.name}}
-      {{/link-to}}
+      </LinkTo>
     </span>
-    <span class="date" data-test-date>
+    <span id={{concat "event" @event.slug "date"}} class="date" data-test-date>
       {{#if @event.ilmSession}}
         <span class="ilm-due">{{t "general.dueBy"}}</span>
       {{/if}}
@@ -79,8 +83,8 @@
     </p>
   {{/if}}
   <ul class="learning-materials" data-test-learning-materials>
-    {{#each (filter-by "sessionLearningMaterial" @event.learningMaterials) as |lm|}}
-      <li class="learning-material"  data-test-learning-material>
+    {{#each (filter-by "sessionLearningMaterial" @event.learningMaterials) as |lm index|}}
+      <li class="learning-material" data-test-learning-material>
         {{#if lm.isBlanked}}
           <span class="lm-type-icon" data-test-type-icon>{{fa-icon icon="clock" title=(t "general.timedRelease")}}</span>
           <span data-test-material-title>{{lm.title}}</span>
@@ -88,15 +92,26 @@
           {{lm-type-icon type=(lm-type lm) mimetype=lm.mimetype}}
           {{#if lm.absoluteFileUri}}
             {{#if (eq lm.mimetype "application/pdf")}}
-              <a href="{{lm.absoluteFileUri}}?inline" data-test-material-title>
+              <a
+                id={{concat "event" @event.slug "lm" index}}
+                href="{{lm.absoluteFileUri}}?inline"
+                aria-labelledby="{{concat "event" @event.slug "lm" index}} {{concat "event" @event.slug "title"}}"
+                data-test-material-title>
                 {{lm.title}}
               </a>
-              <a href={{lm.absoluteFileUri}} target="_blank" rel="noopener">
+              <a
+                id={{concat "event" @event.slug "lmdownload" index}}
+                href={{lm.absoluteFileUri}}
+                aria-labelledby="{{concat "event" @event.slug "lmdownload" index}} {{concat "event" @event.slug "lm" index}} {{concat "event" @event.slug "title"}}"
+                target="_blank" rel="noopener"
+              >
                 {{fa-icon icon="download" title=(t "general.download")}}
               </a>
             {{else}}
               <a
+                id={{concat "event" @event.slug "lm" index}}
                 href={{lm.absoluteFileUri}}
+                aria-labelledby="{{concat "event" @event.slug "lm" index}} {{concat "event" @event.slug "title"}}"
                 target="_blank"
                 rel="noopener"
                 data-test-material-title
@@ -105,7 +120,16 @@
               </a>
             {{/if}}
           {{else if lm.link}}
-            <a href={{lm.link}} target="_blank" rel="noopener" data-test-material-title>{{lm.title}}</a>
+            <a
+              id={{concat "event" @event.slug "lm" index}}
+              href={{lm.link}}
+              aria-labelledby="{{concat "event" @event.slug "lm" index}} {{concat "event" @event.slug "title"}}"
+              target="_blank"
+              rel="noopener"
+              data-test-material-title
+            >
+              {{lm.title}}
+            </a>
           {{else}}
             <span data-test-material-title>{{lm.title}}</span>
             <ul data-test-citation>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2658,6 +2658,12 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
+    "axe-core": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.3.2.tgz",
+      "integrity": "sha512-lRdxsRt7yNhqpcXQk1ao1BL73OZDzmFCWOG0mC4tGR/r14ohH2payjHwCMQjHGbBKm924eDlmG7utAGHiX/A6g==",
+      "dev": true
+    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -6296,6 +6302,64 @@
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.0"
+      }
+    },
+    "ember-a11y-testing": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ember-a11y-testing/-/ember-a11y-testing-1.1.0.tgz",
+      "integrity": "sha512-OuXJQa0IJLHiOO+EtXu0Gh0e/gTPa+E7KozSp7DOelzTSG/HMm/x39bbrfnEdKDGRvA2a7dlokMAbmQ2DKqrpQ==",
+      "dev": true,
+      "requires": {
+        "axe-core": "^3.3.2",
+        "broccoli-funnel": "^2.0.2",
+        "ember-cli-babel": "^6.8.2",
+        "ember-cli-version-checker": "^3.1.3",
+        "ember-get-config": "^0.2.4"
+      },
+      "dependencies": {
+        "ember-cli-babel": {
+          "version": "6.18.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
+          "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
+          "dev": true,
+          "requires": {
+            "amd-name-resolver": "1.2.0",
+            "babel-plugin-debug-macros": "^0.2.0-beta.6",
+            "babel-plugin-ember-modules-api-polyfill": "^2.6.0",
+            "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
+            "babel-polyfill": "^6.26.0",
+            "babel-preset-env": "^1.7.0",
+            "broccoli-babel-transpiler": "^6.5.0",
+            "broccoli-debug": "^0.6.4",
+            "broccoli-funnel": "^2.0.0",
+            "broccoli-source": "^1.1.0",
+            "clone": "^2.0.0",
+            "ember-cli-version-checker": "^2.1.2",
+            "semver": "^5.5.0"
+          },
+          "dependencies": {
+            "ember-cli-version-checker": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
+              "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
+              "dev": true,
+              "requires": {
+                "resolve": "^1.3.3",
+                "semver": "^5.3.0"
+              }
+            }
+          }
+        },
+        "ember-cli-version-checker": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-3.1.3.tgz",
+          "integrity": "sha512-PZNSvpzwWgv68hcXxyjREpj3WWb81A7rtYNQq1lLEgrWIchF8ApKJjWP3NBpHjaatwILkZAV8klair5WFlXAKg==",
+          "dev": true,
+          "requires": {
+            "resolve-package-path": "^1.2.6",
+            "semver": "^5.6.0"
+          }
+        }
       }
     },
     "ember-ajax": {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@ilios/eslint-config-ember-addon": "^2.0.1",
     "broccoli-asset-rev": "^3.0.0",
     "dotenv": "^8.0.0",
+    "ember-a11y-testing": "^1.1.0",
     "ember-ajax": "^5.0.0",
     "ember-cli": "~3.11.0",
     "ember-cli-dependency-checker": "^3.1.0",

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -37,6 +37,12 @@ module.exports = function(environment) {
       enableExperimentalBuildTimeTransform: false,
       defaultPrefix: 'fas',
     },
+    'ember-a11y-testing': {
+      componentOptions: {
+        turnAuditOff: process.env.SKIP_A11Y || false,
+        visualNoiseLevel: 1,
+      },
+    },
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build


### PR DESCRIPTION
Many learning materials and events have identical titles. For example 'slides'. When these all appear on the same page it is difficult for those using assistive technologies to figure out which one is correct. aria labels allow us to add more context to each link.

This also adds the `a11y-testing` library so we can start automating these tests, but there is a lot left to do on WAAG so I have not added those tests here.