### PR TITLE
Temporarily allow failures on ember-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ branches:
 jobs:
   fail_fast: true
   allow_failures:
+    - env: EMBER_TRY_SCENARIO=ember-release
     - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
 


### PR DESCRIPTION
As with beta before it we're waiting for a release of
ember-cp-validations that is compatible with Ember 3.13 until then we
don't need to hold up merging other things.