### PR TITLE
Fix text buttons

### DIFF
--- a/app/styles/ilios-common/mixins/ilios-form.scss
+++ b/app/styles/ilios-common/mixins/ilios-form.scss
@@ -75,12 +75,11 @@
       color: $text-grey;
 
       &:enabled {
-        &:hover {
-          background-color: $ilios-green;
-        }
+        &:hover,
         &:active,
         &.active {
-          background-color: darken($ilios-green, 10);
+          background-color: $ilios-green;
+          color: $white;
         }
       }
     }


### PR DESCRIPTION
New dark green color can make active buttons difficult to read, they
probably always should have had this style applied, but it's critical
now.