### PR TITLE
Remove gpu flag for chrome

### DIFF
--- a/testem.js
+++ b/testem.js
@@ -15,7 +15,6 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
-        '--disable-gpu',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
         '--mute-audio',


### PR DESCRIPTION
This is no longer needed or recommended by ember-cli.