### PR TITLE
Prevent adding `u` underline using keyboard shortcut

### DIFF
--- a/addon/components/html-editor.js
+++ b/addon/components/html-editor.js
@@ -43,6 +43,7 @@ export default Component.extend({
       pluginsEnabled: ['lists', 'code_view', 'link'],
       iconsTemplate: 'font_awesome_5',
       listAdvancedTypes: false,
+      shortcutsEnabled: ['bold', 'italic', 'strikeThrough', 'undo', 'redo', 'createLink'],
     };
   }),
 

--- a/addon/templates/components/html-editor.hbs
+++ b/addon/templates/components/html-editor.hbs
@@ -1,2 +1,1 @@
 <FroalaEditor @content={{content}} @update={{update}} @options={{options}} />
-


### PR DESCRIPTION
We removed this button, but it was still possible to underline using the
keyboard. This shouldn't be allowed as the `u` element is not
accessible.

Refs: https://github.com/ilios/ilios/pull/2658
