### PR TITLE
Get course from the event

### DIFF
--- a/addon/mixins/events.js
+++ b/addon/mixins/events.js
@@ -25,9 +25,8 @@ export default Mixin.create({
    * @param {Object} event
    * @return {Promise.<Object>}
    */
-  async getCourseForEvent(event){
-    const session = await this.getSessionForEvent(event);
-    return await session.get('course');
+  async getCourseForEvent(event) {
+    return await this.store.findRecord('course', event.course);
   },
 
   /**

--- a/tests/acceptance/dashboard/calendar-test.js
+++ b/tests/acceptance/dashboard/calendar-test.js
@@ -54,26 +54,26 @@ module('Acceptance | Dashboard Calendar', function(hooks) {
     this.server.create('sessionType', {
       school: this.school,
     });
-    const course1 = this.server.create('course', {
+    this.course1 = this.server.create('course', {
       school: this.school,
       year: 2015,
       cohorts: [cohort1],
     });
-    const course2 = this.server.create('course', {
+    this.course2 = this.server.create('course', {
       year: 2015,
       school: this.school,
       cohorts: [cohort2],
     });
     const session1 = this.server.create('session', {
-      course: course1,
+      course: this.course1,
       sessionType: sessionType1,
     });
     const session2 = this.server.create('session', {
-      course: course1,
+      course: this.course1,
       sessionType: sessionType2,
     });
     const session3 = this.server.create('session', {
-      course: course2,
+      course: this.course2,
       sessionType: sessionType2
     });
     this.server.create('academicYear', {
@@ -385,12 +385,14 @@ module('Acceptance | Dashboard Calendar', function(hooks) {
       startDate: today.format(),
       endDate: today.clone().add(1, 'hour').format(),
       offering: this.offering1.id,
+      course: this.course1.id,
     });
     this.server.create('userevent', {
       user: parseInt(this.user.id, 10),
       startDate: today.format(),
       endDate: today.clone().add(1, 'hour').format(),
       offering: this.offering2.id,
+      course: this.course1.id,
     });
     await visit('/dashboard?show=calendar');
     await showFilters();
@@ -416,12 +418,14 @@ module('Acceptance | Dashboard Calendar', function(hooks) {
       user: parseInt(this.user.id, 10),
       startDate: today.format(),
       endDate: today.clone().add(1, 'hour').format(),
+      course: this.course1.id,
       offering: this.offering1.id,
     });
     this.server.create('userevent', {
       user: parseInt(this.user.id, 10),
       startDate: today.format(),
       endDate: today.clone().add(1, 'hour').format(),
+      course: this.course1.id,
       offering: this.offering2.id,
     });
     await visit('/dashboard?show=calendar');
@@ -457,18 +461,21 @@ module('Acceptance | Dashboard Calendar', function(hooks) {
       user: parseInt(this.user.id, 10),
       startDate: today.format(),
       endDate: today.clone().add(1, 'hour').format(),
+      course: this.course1.id,
       offering: this.offering1.id,
     });
     this.server.create('userevent', {
       user: parseInt(this.user.id, 10),
       startDate: today.format(),
       endDate: today.clone().add(1, 'hour').format(),
+      course: this.course2.id,
       offering: this.offering3.id,
     });
     this.server.create('userevent', {
       user: parseInt(this.user.id, 10),
       startDate: today.format(),
       endDate: today.clone().add(1, 'hour').format(),
+      course: this.course1.id,
       offering: this.offering2.id,
     });
     await visit('/dashboard?show=calendar');
@@ -490,18 +497,21 @@ module('Acceptance | Dashboard Calendar', function(hooks) {
       user: parseInt(this.user.id, 10),
       startDate: today.format(),
       endDate: today.clone().add(1, 'hour').format(),
+      course: this.course1.id,
       offering: this.offering1.id,
     });
     this.server.create('userevent', {
       user: parseInt(this.user.id, 10),
       startDate: today.format(),
       endDate: today.clone().add(1, 'hour').format(),
+      course: this.course2.id,
       offering: this.offering3.id,
     });
     this.server.create('userevent', {
       user: parseInt(this.user.id, 10),
       startDate: today.format(),
       endDate: today.clone().add(1, 'hour').format(),
+      course: this.course1.id,
       offering: this.offering2.id,
     });
     await visit('/dashboard?show=calendar');

--- a/tests/unit/mixins/events-test.js
+++ b/tests/unit/mixins/events-test.js
@@ -65,6 +65,9 @@ module('Unit | Mixin | events', function(hooks) {
         if ([ 'offering', 'ilmSession' ].includes(what)) {
           return resolve(intermediary);
         }
+        if (what === 'course') {
+          return resolve(course);
+        }
         throw 'Unsupported model type requested.';
       },
     });
@@ -89,7 +92,7 @@ module('Unit | Mixin | events', function(hooks) {
   test('getCourseForEvent', async function(assert) {
     assert.expect(1);
     const subject = this.subject();
-    const event = { offering: 1 };
+    const event = { course: course.id };
     const courseForEvent = await subject.getCourseForEvent(event);
     assert.equal(courseForEvent, course);
 
@@ -117,7 +120,7 @@ module('Unit | Mixin | events', function(hooks) {
   test('getCourseLevelForEvent', async function(assert) {
     assert.expect(1);
     const subject = this.subject();
-    const event = { offering: 1 };
+    const event = { course: course.id };
     const courseLevel = await subject.getCourseLevelForEvent(event);
     assert.equal(courseLevel, 4);
   });
@@ -125,7 +128,7 @@ module('Unit | Mixin | events', function(hooks) {
   test('getCourseIdForEvent', async function(assert) {
     assert.expect(1);
     const subject = this.subject();
-    const event = { offering: 1 };
+    const event = { course: course.id };
     const courseId = await subject.getCourseIdForEvent(event);
     assert.equal(courseId, 22);
   });


### PR DESCRIPTION
The session is not available for students to access, but we have access
to the course ID here, we can just use that. This allows students to use
the course filtering options on the calendar.

Fixes #649