### PR TITLE
Remove jQuery from auth flow

### DIFF
--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -21,6 +21,7 @@ module.exports = function(environment) {
       serverTokenEndpoint: '/auth/login',
       serverTokenRefreshEndpoint: '/auth/token',
       tokenPropertyName: 'jwt',
+      refreshTokenPropertyName: 'jwt',
       authorizationHeaderName: 'X-JWT-Authorization',
       authorizationPrefix: 'Token ',
       refreshLeeway: 300


### PR DESCRIPTION
Using commonAjax brings in ember-ajax which is jQuery based, but
injecting the config here we can read the hostname information we needed
and then go back to using more of what is provided upstream.