### PR TITLE
Use fetch API in place of ember-ajax

### DIFF
--- a/addon/components/course-rollover.js
+++ b/addon/components/course-rollover.js
@@ -24,7 +24,7 @@ const Validations = buildValidations({
 });
 
 export default Component.extend(ValidationErrorDisplay, Validations, {
-  commonAjax: service(),
+  fetch: service(),
   store: service(),
   flashMessages: service(),
   iliosConfig: service(),
@@ -100,7 +100,6 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
       this.set('isSaving', false);
       return;
     }
-    const commonAjax = this.get('commonAjax');
     const courseId = this.get('course.id');
     const year = this.get('selectedYear');
     const newCourseTitle = this.get('title');
@@ -118,17 +117,12 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
     if (skipOfferings) {
       data.skipOfferings = true;
     }
-    if (selectedCohortIds) {
+    if (selectedCohortIds && selectedCohortIds.length) {
       data.newCohorts = selectedCohortIds;
     }
-    const host = this.get('host') ? this.get('host') : '';
-    const namespace = this.get('namespace');
 
-    let url = host + '/' + namespace + `/courses/${courseId}/rollover`;
-    const newCoursesObj = yield commonAjax.request(url, {
-      method: 'POST',
-      data
-    });
+    let url = `${this.namespace}/courses/${courseId}/rollover`;
+    const newCoursesObj = yield this.fetch.postToApiHost(url, data);
 
     const flashMessages = this.get('flashMessages');
     const store = this.get('store');

--- a/addon/components/dashboard-materials.js
+++ b/addon/components/dashboard-materials.js
@@ -8,7 +8,7 @@ const { reads } = computed;
 
 export default Component.extend({
   currentUser: service(),
-  commonAjax: service(),
+  fetch: service(),
   iliosConfig: service(),
   layout,
   daysInAdvance: 60,
@@ -20,13 +20,12 @@ export default Component.extend({
   materials: computed('currentUser.currentUserId', async function() {
     const from = moment().hour(0).minute(0).unix();
     const to = moment().hour(23).minute(59).add(this.daysInAdvance, 'days').unix();
-    const commonAjax = this.get('commonAjax');
     const currentUser = this.get('currentUser');
     const namespace = this.get('namespace');
 
     const userId = currentUser.get('currentUserId');
     let url = `${namespace}/usermaterials/${userId}?before=${to}&after=${from}`;
-    const data = await commonAjax.request(url);
+    const data = await this.fetch.getJsonFromApiHost(url);
     return data.userMaterials;
   }),
   actions: {

--- a/addon/components/offering-calendar.js
+++ b/addon/components/offering-calendar.js
@@ -8,7 +8,6 @@ const { reads } = computed;
 const { map } = RSVP;
 
 export default Component.extend({
-  commonAjax: service(),
   iliosConfig: service(),
   layout,
   classNames: ['offering-calendar'],

--- a/addon/routes/mymaterials.js
+++ b/addon/routes/mymaterials.js
@@ -1,27 +1,20 @@
 import Route from '@ember/routing/route';
-import { reads } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
 export default Route.extend(AuthenticatedRouteMixin, {
-  commonAjax: service(),
+  fetch: service(),
   currentUser: service(),
   iliosConfig: service(),
-
-  host: reads('iliosConfig.apiHost'),
-  namespace: reads('iliosConfig.apiNameSpace'),
 
   model() {
     return { materials: this.fetchModelData() };
   },
 
   async fetchModelData() {
-    const commonAjax = this.commonAjax;
-    const host = this.host;
-    const namespace = this.namespace;
     const user = await this.currentUser.model;
-    const url = `${host}/${namespace}/usermaterials/${user.id}`;
-    const data = await commonAjax.request(url);
+    const url = `${this.iliosConfig.apiNameSpace}/usermaterials/${user.id}`;
+    const data = await this.fetch.getJsonFromApiHost(url);
     return data.userMaterials;
   }
 });

--- a/addon/services/fetch.js
+++ b/addon/services/fetch.js
@@ -1,6 +1,7 @@
 import Service from '@ember/service';
 import { inject as service } from '@ember/service';
 import fetch from 'fetch';
+import queryString from 'query-string';
 
 export default class Fetch extends Service {
   @service session;
@@ -31,6 +32,21 @@ export default class Fetch extends Service {
     const url = this.apiHostUrlFromPath(relativePath);
     const response = await fetch(url, {
       headers: this.authHeaders
+    });
+    return response.json();
+  }
+
+  async postToApiHost(relativePath, data) {
+    const url = this.apiHostUrlFromPath(relativePath);
+    let headers = this.authHeaders;
+    headers['Content-Type'] = 'application/x-www-form-urlencoded';
+    const body = queryString.stringify(data, {
+      arrayFormat: 'bracket',
+    });
+    const response = await fetch(url, {
+      method: 'POST',
+      headers,
+      body
     });
     return response.json();
   }

--- a/addon/services/fetch.js
+++ b/addon/services/fetch.js
@@ -1,0 +1,37 @@
+import Service from '@ember/service';
+import { inject as service } from '@ember/service';
+import fetch from 'fetch';
+
+export default class Fetch extends Service {
+  @service session;
+  @service iliosConfig;
+
+  get authHeaders() {
+    let headers = {};
+    if (this.session && this.session.isAuthenticated) {
+      const { jwt } = this.session.data.authenticated;
+      if (jwt) {
+        headers['X-JWT-Authorization'] = `Token ${jwt}`;
+      }
+    }
+
+    return headers;
+  }
+
+  get host() {
+    return this.iliosConfig.apiHost ? this.iliosConfig.apiHost : window.location.protocol + '//' + window.location.host;
+  }
+
+  apiHostUrlFromPath(relativePath) {
+    const trimmedPath = relativePath.replace(/^\//, "");
+    return `${this.host}/${trimmedPath}`;
+  }
+
+  async getJsonFromApiHost(relativePath) {
+    const url = this.apiHostUrlFromPath(relativePath);
+    const response = await fetch(url, {
+      headers: this.authHeaders
+    });
+    return response.json();
+  }
+}

--- a/addon/services/ilios-config.js
+++ b/addon/services/ilios-config.js
@@ -3,14 +3,11 @@ import { computed } from '@ember/object';
 import { isPresent } from '@ember/utils';
 
 export default Service.extend({
-  commonAjax: service(),
+  fetch: service(),
   serverVariables: service(),
 
   config: computed('apiHost', function(){
-    const apiHost = this.get('apiHost');
-    const url = apiHost + '/application/config';
-    const commonAjax = this.get('commonAjax');
-    return commonAjax.request(url);
+    return this.fetch.getJsonFromApiHost('/application/config');
   }),
 
   itemFromConfig(key){

--- a/addon/services/school-events.js
+++ b/addon/services/school-events.js
@@ -6,7 +6,7 @@ import moment from 'moment';
 export default Service.extend(EventMixin, {
   store: service(),
   currentUser: service(),
-  commonAjax: service(),
+  fetch: service(),
   iliosConfig:service(),
 
   namespace: reads('iliosConfig.apiNameSpace'),
@@ -28,8 +28,7 @@ export default Service.extend(EventMixin, {
     }
     url += '/schoolevents/' + schoolId + '?from=' + from + '&to=' + to;
 
-    const commonAjax = this.get('commonAjax');
-    const data = await commonAjax.request(url);
+    const data = await this.fetch.getJsonFromApiHost(url);
 
     return data.events.map(obj => this.createEventFromData(obj, false)).sortBy('startDate', 'name');
   },

--- a/addon/services/user-events.js
+++ b/addon/services/user-events.js
@@ -8,7 +8,7 @@ export default Service.extend(EventMixin, {
   store: service(),
   currentUser: service(),
   session: service(),
-  commonAjax: service(),
+  fetch: service(),
   iliosConfig: service(),
   namespace: reads('iliosConfig.apiNameSpace'),
 
@@ -32,8 +32,7 @@ export default Service.extend(EventMixin, {
     }
     url += '/userevents/' + user.get('id') + '?from=' + from + '&to=' + to;
 
-    const commonAjax = this.get('commonAjax');
-    const data = await commonAjax.request(url);
+    const data = await this.fetch.getJsonFromApiHost(url);
 
     return data.userEvents.map(obj => this.createEventFromData(obj, true)).sortBy('startDate', 'name');
   },

--- a/app/services/fetch.js
+++ b/app/services/fetch.js
@@ -1,0 +1,1 @@
+export { default } from 'ilios-common/services/fetch';

--- a/package-lock.json
+++ b/package-lock.json
@@ -15281,6 +15281,25 @@
         "prepend-http": "^2.0.0",
         "query-string": "^5.0.1",
         "sort-keys": "^2.0.0"
+      },
+      "dependencies": {
+        "query-string": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+          "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+          "dev": true,
+          "requires": {
+            "decode-uri-component": "^0.2.0",
+            "object-assign": "^4.1.0",
+            "strict-uri-encode": "^1.0.0"
+          }
+        },
+        "strict-uri-encode": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+          "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+          "dev": true
+        }
       }
     },
     "npm-git-info": {
@@ -16474,14 +16493,13 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "query-string": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
-      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
-      "dev": true,
+      "version": "6.8.3",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.8.3.tgz",
+      "integrity": "sha512-llcxWccnyaWlODe7A9hRjkvdCKamEKTh+wH8ITdTc3OhchaqUZteiSCX/2ablWHVrkVIe04dntnaZJ7BdyW0lQ==",
       "requires": {
         "decode-uri-component": "^0.2.0",
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
       }
     },
     "querystring": {
@@ -17877,6 +17895,11 @@
       "integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==",
       "dev": true
     },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -18063,10 +18086,9 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
     },
     "strict-uri-encode": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string-template": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "ember-test-selectors": "^2.0.0",
     "ember-truth-helpers": "^2.0.0",
     "liquid-fire": "^0.31.0",
+    "query-string": "^6.8.3",
     "scroll-into-view": "^1.9.3",
     "striptags": "^3.1.1"
   },

--- a/tests/integration/components/dashboard-materials-test.js
+++ b/tests/integration/components/dashboard-materials-test.js
@@ -1,11 +1,11 @@
 import Service from '@ember/service';
 import EmberObject from '@ember/object';
-import { resolve } from 'rsvp';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import moment from 'moment';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 let lm1, lm2, lm3, lm4, lm5, userMaterials;
 let today = moment();
@@ -13,6 +13,7 @@ let tomorrow = moment().add(1, 'day');
 
 module('Integration | Component | dashboard materials', function(hooks) {
   setupRenderingTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function() {
     lm1 = EmberObject.create({
@@ -70,7 +71,7 @@ module('Integration | Component | dashboard materials', function(hooks) {
 
 
   test('it renders with materials', async function(assert) {
-    assert.expect(39);
+    assert.expect(41);
     const currentUserMock = Service.extend({
       currentUserId: 11
     });
@@ -80,23 +81,21 @@ module('Integration | Component | dashboard materials', function(hooks) {
     });
     this.owner.register('service:iliosConfig', iliosConfigMock);
 
-    const ajaxMock = Service.extend({
-      request(url){
-        let exp = new RegExp(/(\/api\/usermaterials\/11)\?before=(\d+)&after=(\d+)/);
-        let matches = url.match(exp);
-        assert.equal(matches.length, 4);
-        assert.equal(matches[1], '/api/usermaterials/11');
-        let before = moment(matches[2], 'X');
-        let after = moment(matches[3], 'X');
-        assert.ok(before.isSame(today.clone().add(60, 'days'), 'day'));
-        assert.ok(after.isSame(today, 'day'));
+    this.server.get(`/api/usermaterials/:id`, (scheme, { params, queryParams }) => {
+      assert.ok('id' in params);
+      assert.equal(params.id, 11);
+      assert.ok('before' in queryParams);
+      assert.ok('after' in queryParams);
+      let before = moment(queryParams.before, 'X');
+      let after = moment(queryParams.after, 'X');
+      assert.ok(before.isSame(today.clone().add(60, 'days'), 'day'));
+      assert.ok(after.isSame(today, 'day'));
 
-        return resolve({
-          userMaterials
-        });
-      }
+      return {
+        userMaterials
+      };
     });
-    this.owner.register('service:commonAjax', ajaxMock);
+
     await render(hbs`<DashboardMaterials />`);
 
     const title = 'h3';
@@ -186,7 +185,7 @@ module('Integration | Component | dashboard materials', function(hooks) {
   });
 
   test('it renders blank', async function(assert) {
-    assert.expect(6);
+    assert.expect(8);
     const currentUserMock = Service.extend({
       currentUserId: 11
     });
@@ -196,23 +195,20 @@ module('Integration | Component | dashboard materials', function(hooks) {
     });
     this.owner.register('service:iliosConfig', iliosConfigMock);
 
-    const ajaxMock = Service.extend({
-      request(url){
-        let exp = new RegExp(/(\/api\/usermaterials\/11)\?before=(\d+)&after=(\d+)/);
-        let matches = url.match(exp);
-        assert.equal(matches.length, 4);
-        assert.equal(matches[1], '/api/usermaterials/11');
-        let before = moment(matches[2], 'X');
-        let after = moment(matches[3], 'X');
-        assert.ok(before.isSame(today.clone().add(60, 'days'), 'day'));
-        assert.ok(after.isSame(today, 'day'));
+    this.server.get(`/api/usermaterials/:id`, (scheme, { params, queryParams }) => {
+      assert.ok('id' in params);
+      assert.equal(params.id, 11);
+      assert.ok('before' in queryParams);
+      assert.ok('after' in queryParams);
+      let before = moment(queryParams.before, 'X');
+      let after = moment(queryParams.after, 'X');
+      assert.ok(before.isSame(today.clone().add(60, 'days'), 'day'));
+      assert.ok(after.isSame(today, 'day'));
 
-        return resolve({
-          userMaterials: []
-        });
-      }
+      return {
+        userMaterials: []
+      };
     });
-    this.owner.register('service:commonAjax', ajaxMock);
     const title = 'h3';
     const body = 'p';
 

--- a/tests/unit/services/fetch-test.js
+++ b/tests/unit/services/fetch-test.js
@@ -1,0 +1,57 @@
+import Service from '@ember/service';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+
+module('Unit | Service | fetch', function(hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    const iliosConfigMock = Service.extend({
+      apiHost: ''
+    });
+    this.owner.register('service:iliosConfig', iliosConfigMock);
+  });
+
+  test('getJsonFromApiHost works', async function (assert) {
+    this.server.get('/ourPath', (schema, { requestHeaders }) => {
+      assert.notOk('x-jwt-authorization' in requestHeaders);
+      return {
+        a: 11
+      };
+    });
+    let service = this.owner.lookup('service:fetch');
+    const data = await service.getJsonFromApiHost('ourPath');
+    assert.deepEqual(data, { a: 11 });
+  });
+
+  test('getJsonFromApiHost sends authentication headers', async function (assert) {
+    await authenticateSession({
+      jwt: 'aAbBcC'
+    });
+    this.server.get('/ourPath', (schema, { requestHeaders }) => {
+      assert.ok('x-jwt-authorization' in requestHeaders);
+      assert.equal(requestHeaders['x-jwt-authorization'], 'Token aAbBcC');
+      return {
+        a: 11
+      };
+    });
+    let service = this.owner.lookup('service:fetch');
+    const data = await service.getJsonFromApiHost('ourPath');
+    assert.deepEqual(data, { a: 11 });
+  });
+
+  test('getJsonFromApiHost removes extra slash if needed', async function (assert) {
+    this.server.get('/ourPath', (schema, { requestHeaders }) => {
+      assert.notOk('x-jwt-authorization' in requestHeaders);
+      return {
+        a: 11
+      };
+    });
+    let service = this.owner.lookup('service:fetch');
+    const data = await service.getJsonFromApiHost('/ourPath');
+    assert.deepEqual(data, { a: 11 });
+  });
+});


### PR DESCRIPTION
`ember-ajax` is jQuery based so this moves our network requests over to use `fetch` instead. I've moved us to a more explicit API for this so it's easier to inject the needed headers and return good data.