### PR TITLE
Add missing lock icon

### DIFF
--- a/config/icons.js
+++ b/config/icons.js
@@ -45,6 +45,7 @@ module.exports = function() {
       'list',
       'list-ol',
       'list-ul',
+      'lock',
       'minus',
       'minus-square',
       'paragraph',


### PR DESCRIPTION
This is needed on the course header, but wasn't included.