### PR TITLE
Activate Octane Edition

### DIFF
--- a/.ember-cli.js
+++ b/.ember-cli.js
@@ -1,4 +1,10 @@
-{
+'use strict';
+
+const { setEdition } = require('@ember/edition-utils');
+
+setEdition('octane');
+
+module.exports = {
   /**
     Ember CLI sends analytics information by default. The data is completely
     anonymous, but there are times when you might want to disable this behavior.
@@ -6,4 +12,4 @@
     Setting `disableAnalytics` to true will prevent any data from being sent.
   */
   "disableAnalytics": false
-}
+};

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "striptags": "^3.1.1"
   },
   "devDependencies": {
+    "@ember/edition-utils": "^1.1.1",
     "@ember/jquery": "^0.6.0",
     "@ember/optional-features": "^1.0.0",
     "@ilios/ember-template-lint-plugin": "^1.0.1",

--- a/tests/dummy/config/optional-features.json
+++ b/tests/dummy/config/optional-features.json
@@ -1,3 +1,5 @@
 {
-  "jquery-integration": true
+  "jquery-integration": true,
+  "template-only-glimmer-components": true,
+  "application-template-wrapper": false
 }


### PR DESCRIPTION
This really only matters for the dummy app. With this edition activated
it can consume other Octane addons and use Octane features and
blueprints.