### PR TITLE
Update to new Octane Event API in templates

### DIFF
--- a/addon/components/detail-learnergroups-list.js
+++ b/addon/components/detail-learnergroups-list.js
@@ -60,5 +60,10 @@ export default Component.extend({
       const selectedChildren = children.filter((child) => ids.includes(child.id));
       return selectedChildren.length === 0;
     });
-  })
+  }),
+  remove(learnerGroup) {
+    if (this.isManaging) {
+      this.remove(learnerGroup);
+    }
+  },
 });

--- a/addon/components/detail-learnergroups.js
+++ b/addon/components/detail-learnergroups.js
@@ -51,6 +51,11 @@ export default Component.extend({
       this.set('learnerGroups', learnerGroups);
     }
   },
+  collapse() {
+    if (this.collapsible) {
+      this.collapse();
+    }
+  },
   loadLearnerGroups: task(function * (){
     const subject = this.get('subject');
     if (subject){

--- a/addon/components/learnergroup-tree.js
+++ b/addon/components/learnergroup-tree.js
@@ -62,4 +62,9 @@ export default Component.extend({
     this.set('isVisible', filterMatch && available);
     this.set('selectable', available);
   }).restartable(),
+  add(learnerGroup) {
+    if (this.selectable) {
+      this.add(learnerGroup);
+    }
+  }
 });

--- a/addon/templates/components/api-version-notice.hbs
+++ b/addon/templates/components/api-version-notice.hbs
@@ -16,7 +16,7 @@
     {{#if this.updateAvailable}}
       <p>
         {{t "general.autoUpdatingSeconds" count=this.countdownToUpdate}}
-        <button {{action (perform this.update)}}>
+        <button {{on "click" (perform this.update)}}>
           {{t "general.updateNow"}}
         </button>
       </p>
@@ -28,7 +28,7 @@
     {{/if}}
     {{#if this.showReloadButton}}
       <p>
-        <button {{action "reload"}}>
+        <button {{on "click" (action "reload")}}>
           {{t "general.updateNow"}}
         </button>
       </p>

--- a/addon/templates/components/big-text.hbs
+++ b/addon/templates/components/big-text.hbs
@@ -11,10 +11,9 @@
     class="clickable"
     data-test-edit
     role="button"
-    {{action (mut this.expanded) true}}
+    {{on "click" (fn (mut this.expanded) true)}}
   >
     <FaIcon @icon={{this.ellipsis}} @classNames="text-bottom" />
     <FaIcon @icon={{this.expandIcon}} />
   </span>
 {{/if}}
-

--- a/addon/templates/components/big-text.hbs
+++ b/addon/templates/components/big-text.hbs
@@ -2,7 +2,7 @@
   class="clickable {{if this.renderHtml "list-reset"}} editable"
   data-test-edit
   role="button"
-  onclick={{action this.onEdit}}
+  {{on "click" this.onEdit}}
 >
   {{this.displayText}}
 </span>

--- a/addon/templates/components/choose-material-type.hbs
+++ b/addon/templates/components/choose-material-type.hbs
@@ -7,7 +7,7 @@
     aria-expanded={{if this.isOpen "true" "false"}}
     data-level="toggle"
     data-test-toggle
-    {{action (toggle "isOpen" this)}}
+    {{on "click" (toggle "isOpen" this)}}
   >
     {{t "general.add"}}
   </button>
@@ -19,7 +19,7 @@
           tabindex="-1"
           data-level="item"
           data-test-item
-          {{action @choose type}}
+          {{on "click" (fn @choose type)}}
         >
           {{t (concat "general." type)}}
         </button>

--- a/addon/templates/components/click-choice-buttons.hbs
+++ b/addon/templates/components/click-choice-buttons.hbs
@@ -1,15 +1,14 @@
 <button
   class="first-button {{if this.firstChoicePicked "active"}}"
   data-test-first-button
-  {{action "clickFirstButton"}}
+  {{on "click" (action "clickFirstButton")}}
 >
   {{this.buttonContent1}}
 </button>
 <button
   class="second-button {{unless this.firstChoicePicked "active"}}"
   data-test-second-button
-  {{action "clickSecondButton"}}
+  {{on "click" (action "clickSecondButton")}}
 >
   {{this.buttonContent2}}
 </button>
-

--- a/addon/templates/components/collapsed-competencies.hbs
+++ b/addon/templates/components/collapsed-competencies.hbs
@@ -1,4 +1,4 @@
-<div class="title" role="button" {{action (action @expand)}}>
+<div class="title" role="button" {{on "click" @expand}}>
   {{t "general.competencies"}} ({{get (await @subject.competencies) "length"}})
 </div>
 {{#unless (is-fulfilled this.summary)}}

--- a/addon/templates/components/collapsed-learnergroups.hbs
+++ b/addon/templates/components/collapsed-learnergroups.hbs
@@ -1,4 +1,4 @@
-<div class="title clickable" onclick={{action @expand}} role="button">
+<div class="title clickable" role="button" {{on "click" @expand}}>
   {{t "general.learnerGroups"}} ({{get (await @subject.learnerGroups) "length"}})
 </div>
 <div class="collapsed-learnergroups-content">

--- a/addon/templates/components/collapsed-objectives.hbs
+++ b/addon/templates/components/collapsed-objectives.hbs
@@ -1,4 +1,4 @@
-<div class="title" role="button" {{action (action @expand)}}>
+<div class="title" role="button" {{on "click" @expand}}>
   {{t "general.objectives"}} ({{get (await this.objectives) "length"}})
 </div>
 {{#if

--- a/addon/templates/components/collapsed-taxonomies.hbs
+++ b/addon/templates/components/collapsed-taxonomies.hbs
@@ -1,4 +1,4 @@
-<div class="title" role="button" {{action @expand}}>
+<div class="title" role="button" {{on "click" @expand}}>
   {{t "general.terms"}} ({{@subject.terms.length}})
 </div>
 {{#if (is-pending @subject.associatedVocabularies)}}

--- a/addon/templates/components/course-header.hbs
+++ b/addon/templates/components/course-header.hbs
@@ -15,8 +15,8 @@
           type="text"
           value={{this.courseTitle}}
           disabled={{isSaving}}
-          oninput={{action (mut this.courseTitle) value="target.value"}}
-          onkeyup={{action "addErrorDisplayFor" "courseTitle"}}
+          {{on "input" (action (mut this.courseTitle) value="target.value")}}
+          {{on "keyup" (fn (action "addErrorDisplayFor") "courseTitle")}}
         >
         {{#if
           (and

--- a/addon/templates/components/course-leadership-expanded.hbs
+++ b/addon/templates/components/course-leadership-expanded.hbs
@@ -8,7 +8,7 @@
   </h3>
   <div class="actions">
     {{#if @isManaging}}
-      <button class="bigadd" onclick={{perform this.save}}>
+      <button class="bigadd" {{on "click" (perform this.save)}}>
         <FaIcon
           @icon={{if this.save.isRunning "spinner" "check"}}
           @spin={{if this.isSaving true false}}

--- a/addon/templates/components/course-leadership-expanded.hbs
+++ b/addon/templates/components/course-leadership-expanded.hbs
@@ -2,7 +2,7 @@
   <h3
     class="title {{if this.isCollapsible "collapsible clickable"}}"
     role="button"
-    {{action @collapse}}
+    {{on "click" @collapse}}
   >
     {{t "general.courseLeadership"}}
   </h3>
@@ -14,11 +14,11 @@
           @spin={{if this.isSaving true false}}
         />
       </button>
-      <button class="bigcancel" {{action @setIsManaging false}}>
+      <button class="bigcancel" {{on "click" (fn @setIsManaging false)}}>
         <FaIcon @icon="undo" />
       </button>
     {{else if @editable}}
-      <button {{action @setIsManaging true}}>
+      <button {{on "click" (fn @setIsManaging true)}}>
         {{t "general.manageLeadership"}}
       </button>
     {{/if}}

--- a/addon/templates/components/course-materials.hbs
+++ b/addon/templates/components/course-materials.hbs
@@ -6,7 +6,7 @@
     <input
       placeholder={{t "general.filterPlaceholder"}}
       value={{this.courseQuery}}
-      oninput={{perform this.setCourseQuery value="target.value"}}
+      {{on "input" (perform this.setCourseQuery value="target.value")}}
     >
   </span>
   <table data-test-course-table>
@@ -96,7 +96,7 @@
     <input
       placeholder={{t "general.filterPlaceholder"}}
       value={{this.sessionQuery}}
-      oninput={{perform this.setSessionQuery value="target.value"}}
+      {{on "input" (perform this.setSessionQuery value="target.value")}}
     >
   </span>
   <table data-test-session-table>

--- a/addon/templates/components/course-objective-list-item.hbs
+++ b/addon/templates/components/course-objective-list-item.hbs
@@ -44,7 +44,7 @@
           class="clickable link"
           data-test-parent
           role="button"
-          {{action @manageParents @objective}}
+          {{on "click" (fn @manageParents @objective)}}
         >
           {{parent.textTitle}}
         </span>
@@ -57,7 +57,7 @@
       <br>
     {{/each}}
   {{else if @editable}}
-    <button {{action @manageParents @objective}}>
+    <button {{on "click" (fn @manageParents @objective)}}>
       {{t "general.addNew"}}
     </button>
   {{else}}
@@ -72,7 +72,7 @@
           class="clickable link"
           role="button"
           data-test-term
-          {{action @manageDescriptors @objective}}
+          {{on "click" (fn @manageDescriptors @objective)}}
         >
           {{descriptor.name}}
         </li>
@@ -84,7 +84,7 @@
     {{else}}
       <li>
         {{#if @editable}}
-          <button {{action @manageDescriptors @objective}}>
+          <button {{on "click" (fn @manageDescriptors @objective)}}>
             {{t "general.addNew"}}
           </button>
         {{else}}
@@ -96,7 +96,7 @@
 </td>
 <td class="text-left text-top" colspan="1">
   {{#if @editable}}
-    <span class="clickable remove" role="button" {{action @remove @objective}}>
+    <span class="clickable remove" role="button" {{on "click" (fn @remove @objective)}}>
       <FaIcon @icon="trash" class="enabled" />
     </span>
   {{else}}

--- a/addon/templates/components/course-objective-list.hbs
+++ b/addon/templates/components/course-objective-list.hbs
@@ -56,16 +56,10 @@
                   {{/if}}
                   <br>
                   <div class="confirm-buttons">
-                    <button
-                      class="remove text"
-                      onclick={{action "remove" objective}}
-                    >
+                    <button class="remove text" {{on "click" (fn (action "remove") objective)}}>
                       {{t "general.yes"}}
                     </button>
-                    <button
-                      class="done text"
-                      onclick={{action "cancelRemove" objective}}
-                    >
+                    <button class="done text" {{on "click" (fn (action "cancelRemove") objective)}}>
                       {{t "general.cancel"}}
                     </button>
                   </div>

--- a/addon/templates/components/course-objective-list.hbs
+++ b/addon/templates/components/course-objective-list.hbs
@@ -7,7 +7,7 @@
     />
   {{else if (get (await @subject.objectives) "length")}}
     {{#if (and @editable (await this.hasMoreThanOneObjective))}}
-      <button class="sort-materials-btn" {{action (mut this.isSorting) true}}>
+      <button class="sort-materials-btn" {{on "click" (fn (mut this.isSorting) true)}}>
         {{t "general.sortObjectives"}}
       </button>
     {{/if}}

--- a/addon/templates/components/course-objective-manager.hbs
+++ b/addon/templates/components/course-objective-manager.hbs
@@ -49,12 +49,12 @@
                         "radio"
                       }}
                       checked="checked"
-                      {{action "removeParent" objective}}
+                      {{on "click" (fn (action "removeParent") objective)}}
                     >
                     <span
                       class="clickable"
                       role="button"
-                      {{action "removeParent" objective}}
+                      {{on "click" (fn (action "removeParent") objective)}}
                     >
                       {{objective.textTitle}}
                     </span>
@@ -69,12 +69,12 @@
                         "checkbox"
                         "radio"
                       }}
-                      {{action (perform this.addParent objective)}}
+                      {{on "click" (perform this.addParent objective)}}
                     >
                     <span
                       class="clickable"
                       role="button"
-                      {{action (perform this.addParent objective)}}
+                      {{on "click" (perform this.addParent objective)}}
                     >
                       {{objective.textTitle}}
                     </span>

--- a/addon/templates/components/course-overview.hbs
+++ b/addon/templates/components/course-overview.hbs
@@ -60,9 +60,9 @@
           <input
             type="text"
             value={{this.externalId}}
-            oninput={{action (mut this.externalId) value="target.value"}}
             disabled={{isSaving}}
-            onkeyup={{action "addErrorDisplayFor" "externalId"}}
+            {{on "input" (action (mut this.externalId) value="target.value")}}
+            {{on "keyup" (fn (action "addErrorDisplayFor") "externalId")}}
           >
           {{#if
             (and
@@ -89,9 +89,7 @@
           @save={{action "changeClerkshipType"}}
           @close={{action "revertClerkshipTypeChanges"}}
         >
-          <select
-            onchange={{action "setCourseClerkshipType" value="target.value"}}
-          >
+          <select {{on "change" (action "setCourseClerkshipType" value="target.value")}}>
             <option
               value="null"
               selected={{is-empty (await this.selectedClerkshipType)}}

--- a/addon/templates/components/course-overview.hbs
+++ b/addon/templates/components/course-overview.hbs
@@ -27,7 +27,7 @@
       <span
         class="clickable rollover"
         role="button"
-        {{action "transitionToRollover"}}
+        {{on "click" (action "transitionToRollover")}}
       >
         <FaIcon
           @icon="random"

--- a/addon/templates/components/course-rollover.hbs
+++ b/addon/templates/components/course-rollover.hbs
@@ -121,7 +121,7 @@
         true
       }}
       class="done text"
-      {{action (perform this.save)}}
+      {{on "click" (perform this.save)}}
     >
       {{#if this.isSaving}}
         <LoadingSpinner />

--- a/addon/templates/components/course-rollover.hbs
+++ b/addon/templates/components/course-rollover.hbs
@@ -15,13 +15,10 @@
     <input
       type="text"
       value={{this.title}}
-      oninput={{pipe
-        (action "changeTitle" value="target.value")
-        (action "addErrorDisplayFor" "title")
-      }}
       disabled={{this.isSaving}}
-      onkeyup={{action "addErrorDisplayFor" "title"}}
       placeholder={{t "general.courseTitlePlaceholder"}}
+      {{on "input" (pipe (action "changeTitle" value="target.value") (fn (action "addErrorDisplayFor") "title"))}}
+      {{on "keyup" (fn (action "addErrorDisplayFor") "title")}}
     >
     {{#if (and (v-get this "title" "isInvalid") (is-in this.showErrorsFor "title"))}}
       <span class="validation-error-message">
@@ -36,9 +33,7 @@
     {{#if this.loadUnavailableYears.isRunning}}
       <LoadingSpinner />
     {{else}}
-      <select
-        onchange={{action (perform this.changeSelectedYear) value="target.value"}}
-      >
+      <select {{on "change" (action (perform this.changeSelectedYear) value="target.value")}}>
         {{#each this.years as |year|}}
           <option
             disabled={{contains year this.loadUnavailableYears.lastSuccessful.value}}
@@ -90,8 +85,8 @@
         <input
           type="checkbox"
           checked={{not this.skipOfferings}}
-          onclick={{toggle "skipOfferings" this}}
           data-test-skip-offerings
+          {{on "click" (toggle "skipOfferings" this)}}
         >
         <span>
           {{t "general.offerings"}}

--- a/addon/templates/components/course-sessions.hbs
+++ b/addon/templates/components/course-sessions.hbs
@@ -42,9 +42,9 @@
 <div class="filter">
   <input
     value={{@filterByDebounced}}
-    oninput={{action (perform this.changeFilterBy) value="target.value"}}
     placeholder={{t "general.sessionTitleFilterPlaceholder"}}
     data-test-session-filter
+    {{on "input" (action (perform this.changeFilterBy) value="target.value")}}
   >
 </div>
 <section>

--- a/addon/templates/components/dashboard-calendar.hbs
+++ b/addon/templates/components/dashboard-calendar.hbs
@@ -29,7 +29,7 @@
         id="calendar-clear-filters"
         class="calendar-clear-filters"
         role="button"
-        {{action @onClearFilters}}
+        {{on "click" @onClearFilters}}
       >
         {{t "general.clearFilters"}}
       </span>
@@ -90,12 +90,12 @@
                     class="checkbox"
                     type="checkbox"
                     checked={{is-in (await @selectedCourses) course}}
-                    {{action @onUpdateCourses course.id on="change"}}
+                    {{on "change" (fn @onUpdateCourses course.id)}}
                   >
                   <span
                     class="list-indentation"
                     role="button"
-                    {{action @onUpdateCourses course.id}}
+                    {{on "click" (fn @onUpdateCourses course.id)}}
                   >
                     {{course.title}}
                     {{#if course.externalId}}
@@ -124,12 +124,12 @@
                     checked={{is-in (await @selectedSessionTypes) type}}
                     class="checkbox"
                     type="checkbox"
-                    {{action @onUpdateSessionTypes type.id on="change"}}
+                    {{on "change" (fn @onUpdateSessionTypes type.id)}}
                   >
                   <span
                     class="list-indentation"
                     role="button"
-                    {{action @onUpdateSessionTypes type.id}}
+                    {{on "click" (fn @onUpdateSessionTypes type.id)}}
                   >
                     {{type.title}}
                   </span>
@@ -177,12 +177,12 @@
                     class="checkbox"
                     type="checkbox"
                     checked={{is-in (await @selectedSessionTypes) type}}
-                    {{action @onUpdateSessionTypes type.id on="change"}}
+                    {{on "change" (fn @onUpdateSessionTypes type.id)}}
                   >
                   <span
                     class="list-indentation"
                     role="button"
-                    {{action @onUpdateSessionTypes type.id}}
+                    {{on "click" (fn @onUpdateSessionTypes type.id)}}
                   >
                     {{type.title}}
                   </span>
@@ -207,12 +207,12 @@
                   class="checkbox"
                   type="checkbox"
                   checked={{contains level @selectedCourseLevels}}
-                  {{action @onUpdateCourseLevels level on="change"}}
+                  {{on "change" (fn @onUpdateCourseLevels level)}}
                 >
                 <span
                   class="list-indentation"
                   role="button"
-                  {{action @onUpdateCourseLevels level}}
+                  {{on "click" (fn @onUpdateCourseLevels level)}}
                 >
                   {{level}}
                 </span>
@@ -236,12 +236,12 @@
                     class="checkbox"
                     type="checkbox"
                     checked={{is-in (await @selectedCohorts) cohort}}
-                    {{action @onUpdateCohorts cohort.id on="change"}}
+                    {{on "change" (fn @onUpdateCohorts cohort.id)}}
                   >
                   <span
                     class="list-indentation"
                     role="button"
-                    {{action @onUpdateCohorts cohort.id}}
+                    {{on "click" (fn @onUpdateCohorts cohort.id)}}
                   >
                     {{#if cohort.title}}
                       {{cohort.title}}
@@ -271,7 +271,7 @@
         <span
           class="filter-tag {{tag.class}}"
           role="button"
-          {{action "removeFilter" tag.filter}}
+          {{on "click" (fn (action "removeFilter") tag.filter)}}
         >
           {{tag.name}}
           <FaIcon @icon="times" />
@@ -281,7 +281,7 @@
         id="calendar-clear-filters"
         class="filters-clear-filters"
         role="button"
-        {{action @onClearFilters}}
+        {{on "click" @onClearFilters}}
       >
         {{t "general.clearFilters"}}
       </span>

--- a/addon/templates/components/dashboard-calendar.hbs
+++ b/addon/templates/components/dashboard-calendar.hbs
@@ -39,7 +39,7 @@
     <div class="calendar-options-control calendar-school-picker">
       <FaIcon @icon="university" />
       {{#if (await this.hasMoreThanOneSchool)}}
-        <select onchange={{action @changeSchool value="target.value"}}>
+        <select {{on "change" (action @changeSchool value="target.value")}}>
           {{#each (sort-by "title" (await this.allSchools)) as |school|}}
             <option
               value={{school.id}}
@@ -59,7 +59,7 @@
       id="calendar-year-picker"
       class="calendar-options-control calendar-year-picker"
     >
-      <select onchange={{action @changeAcademicYear value="target.value"}}>
+      <select {{on "change" (action @changeAcademicYear value="target.value")}}>
         {{#each (await this.academicYears) as |year|}}
           <option
             value={{year.title}}

--- a/addon/templates/components/dashboard-view-picker.hbs
+++ b/addon/templates/components/dashboard-view-picker.hbs
@@ -3,7 +3,7 @@
     <button
       class={{if (eq @show "week") "active"}}
       data-test-glance
-      {{action @change "week"}}
+      {{on "click" (fn @change "week")}}
     >
       {{t "general.weekAtAGlance"}}
     </button>
@@ -12,7 +12,7 @@
     <button
       class={{if (eq @show "agenda") "active"}}
       data-test-activities
-      {{action @change "agenda"}}
+      {{on "click" (fn @change "agenda")}}
     >
       {{t "general.activities"}}
     </button>
@@ -21,7 +21,7 @@
     <button
       class={{if (eq @show "materials") "active"}}
       data-test-materials
-      {{action @change "materials"}}
+      {{on "click" (fn @change "materials")}}
     >
       {{t "general.materials"}}
     </button>
@@ -30,7 +30,7 @@
     <button
       class={{if (eq @show "calendar") "active"}}
       data-test-calendar
-      {{action @change "calendar"}}
+      {{on "click" (fn @change "calendar")}}
     >
       {{t "general.calendar"}}
     </button>

--- a/addon/templates/components/detail-cohort-manager.hbs
+++ b/addon/templates/components/detail-cohort-manager.hbs
@@ -1,6 +1,6 @@
 <ul class="selected-cohorts">
   {{#each (sort-by "title" @selectedCohorts) as |cohort|}}
-    <li role="button" {{action "remove" cohort}}>
+    <li role="button" {{on "click" (fn (action "remove") cohort)}}>
       {{cohort.programYear.program.school.title}}
       |
       {{cohort.programYear.program.title}}
@@ -14,7 +14,7 @@
 <ul class="selectable-cohorts">
   {{#if (is-fulfilled this.sortedAvailableCohorts)}}
     {{#each (await this.sortedAvailableCohorts) as |cohort|}}
-      <li role="button" {{action "add" cohort}}>
+      <li role="button" {{on "click" (fn (action "add") cohort)}}>
         {{cohort.programYear.program.school.title}}
         |
         {{cohort.programYear.program.title}}

--- a/addon/templates/components/detail-cohorts.hbs
+++ b/addon/templates/components/detail-cohorts.hbs
@@ -10,17 +10,17 @@
   </div>
   <div class="actions">
     {{#if this.isManaging}}
-      <button class="bigadd" {{action "save"}}>
+      <button class="bigadd" {{on "click" (action "save")}}>
         <FaIcon
           @icon={{if this.isSaving "spinner" "check"}}
           @spin={{if this.isSaving true false}}
         />
       </button>
-      <button class="bigcancel" {{action "cancel"}}>
+      <button class="bigcancel" {{on "click" (action "cancel")}}>
         <FaIcon @icon="undo" />
       </button>
     {{else if @editable}}
-      <button {{action "manage"}}>
+      <button {{on "click" (action "manage")}}>
         {{t "general.cohortsManageTitle"}}
       </button>
     {{/if}}

--- a/addon/templates/components/detail-competencies.hbs
+++ b/addon/templates/components/detail-competencies.hbs
@@ -1,7 +1,7 @@
 <div
   class="title {{if (await this.showCollapsible) "clickable collapsible"}}"
   role="button"
-  {{action "collapse"}}
+  {{on "click" (action "collapse")}}
 >
   {{t "general.competencies"}} ({{get (await @course.competencies) "length"}})
 </div>

--- a/addon/templates/components/detail-instructors.hbs
+++ b/addon/templates/components/detail-instructors.hbs
@@ -11,14 +11,14 @@
   </div>
   <div class="actions">
     {{#if this.isManaging}}
-      <button class="bigadd" {{action "save"}}>
+      <button class="bigadd" {{on "click" (action "save")}}>
         <FaIcon @icon="check" />
       </button>
-      <button class="bigcancel" {{action "cancel"}}>
+      <button class="bigcancel" {{on "click" (action "cancel")}}>
         <FaIcon @icon="undo" />
       </button>
     {{else if @editable}}
-      <button {{action "manage"}}>
+      <button {{on "click" (action "manage")}}>
         {{t "general.instructorsManageTitle"}}
       </button>
     {{/if}}

--- a/addon/templates/components/detail-learnergroups-list.hbs
+++ b/addon/templates/components/detail-learnergroups-list.hbs
@@ -10,9 +10,9 @@
             <div class="remove-all-subgroups">
               <span
                 class="clickable remove"
-                onclick={{action @remove tree.topLevelGroup}}
                 data-test-remove-all
                 role="button"
+                {{on "click" (fn @remove tree.topLevelGroup)}}
               >
                 {{t "general.removeAll"}} (<FaIcon @icon="times" />)
               </span>
@@ -31,10 +31,9 @@
                     (contains learnerGroup (await this.lowestLeaves))
                     "lowest-leaf"
                   }}
-
                   {{if @isManaging "clickable"}}"
-                onclick={{if @isManaging (action @remove learnerGroup)}}
                 role={{if @isManaging "button"}}
+                {{on "click" (fn this.remove learnerGroup)}}
               >
                 {{learnerGroup.title}} ({{count-related learnerGroup "users"}})
                 {{#if @isManaging}}

--- a/addon/templates/components/detail-learnergroups.hbs
+++ b/addon/templates/components/detail-learnergroups.hbs
@@ -2,14 +2,14 @@
   {{! template-lint-disable no-invalid-interactive}}
   <div
     class="title {{if this.collapsible "collapsible clickable"}}"
-    onclick={{if this.collapsible (action @collapse)}}
     role={{if this.collapsible "button"}}
+    {{on "click" (fn this.collapse)}}
   >
     {{t "general.learnerGroups"}} ({{@subject.learnerGroups.length}})
   </div>
   <div class="actions">
     {{#if @isManaging}}
-      <button class="bigadd" onclick={{perform this.save}}>
+      <button class="bigadd" {{on "click" (perform this.save)}}>
         <FaIcon
           @icon={{if this.save.isRunning "spinner" "check"}}
           @spin={{this.save.isRunning}}

--- a/addon/templates/components/detail-learnergroups.hbs
+++ b/addon/templates/components/detail-learnergroups.hbs
@@ -15,11 +15,11 @@
           @spin={{this.save.isRunning}}
         />
       </button>
-      <button class="bigcancel" {{action "cancel"}}>
+      <button class="bigcancel" {{on "click" (action "cancel")}}>
         <FaIcon @icon="undo" />
       </button>
     {{else if @editable}}
-      <button {{action @setIsManaging true}}>
+      <button {{on "click" (fn @setIsManaging true)}}>
         {{t "general.learnerGroupsManageTitle"}}
       </button>
     {{/if}}

--- a/addon/templates/components/detail-learning-materials.hbs
+++ b/addon/templates/components/detail-learning-materials.hbs
@@ -16,7 +16,7 @@
   {{/if}}
   <div class="detail-learningmaterials-actions">
     {{#if this.displayAddNewForm}}
-      <button class="collapse-button" {{action (mut this.displayAddNewForm) false}}>
+      <button class="collapse-button" {{on "click" (fn (mut this.displayAddNewForm) false)}}>
         <FaIcon @icon="minus" />
       </button>
     {{else if (and @editable (not this.isSorting) (not this.isManaging))}}
@@ -52,7 +52,7 @@
     />
   {{else if (get (await @subject.learningMaterials) "length")}}
     {{#if (and @editable (await this.hasMoreThanOneLearningMaterial))}}
-      <button class="sort-materials-btn" {{action (mut this.isSorting) true}}>
+      <button class="sort-materials-btn" {{on "click" (fn (mut this.isSorting) true)}}>
         {{t "general.sortMaterials"}}
       </button>
     {{/if}}
@@ -89,7 +89,7 @@
               class="text-left clickable link"
               colspan="3"
               role="button"
-              {{action (mut this.managingMaterial) lmProxy.content}}
+              {{on "click" (fn (mut this.managingMaterial) lmProxy.content)}}
             >
               <LmTypeIcon
                 @type={{lmProxy.learningMaterial.type}}
@@ -158,7 +158,7 @@
                 <span
                   class="clickable remove"
                   role="button"
-                  {{action "confirmRemoval" lmProxy}}
+                  {{on "click" (fn (action "confirmRemoval") lmProxy)}}
                 >
                   <FaIcon @icon="trash" class="enabled" />
                 </span>
@@ -174,10 +174,10 @@
                   {{t "general.confirmRemoval"}}
                   <br>
                   <div class="confirm-buttons">
-                    <button class="remove text" {{action "remove" lmProxy}}>
+                    <button class="remove text" {{on "click" (fn (action "remove") lmProxy)}}>
                       {{t "general.yes"}}
                     </button>
-                    <button class="done text" {{action "cancelRemove" lmProxy}}>
+                    <button class="done text" {{on "click" (fn (action "cancelRemove") lmProxy)}}>
                       {{t "general.cancel"}}
                     </button>
                   </div>

--- a/addon/templates/components/detail-mesh.hbs
+++ b/addon/templates/components/detail-mesh.hbs
@@ -10,14 +10,14 @@
   </div>
   <div class="actions">
     {{#if this.isManaging}}
-      <button class="bigadd" {{action "save"}}>
+      <button class="bigadd" {{on "click" (action "save")}}>
         <FaIcon @icon="check" />
       </button>
-      <button class="bigcancel" {{action "cancel"}}>
+      <button class="bigcancel" {{on "click" (action "cancel")}}>
         <FaIcon @icon="undo" />
       </button>
     {{else if @editable}}
-      <button {{action "manage"}}>
+      <button {{on "click" (action "manage")}}>
         {{t "general.meshManageTitle"}}
       </button>
     {{/if}}

--- a/addon/templates/components/detail-objectives.hbs
+++ b/addon/templates/components/detail-objectives.hbs
@@ -21,17 +21,17 @@
     <div
       class="title {{if this.showCollapsible "clickable collapsible"}}"
       role="button"
-      {{action "collapse"}}
+      {{on "click" (action "collapse")}}
     >
       {{t "general.objectives"}} ({{@subject.objectives.length}})
     </div>
   {{/if}}
   <div class="detail-objectives-actions">
     {{#if this.isManaging class="horizontal"}}
-      <button class="bigadd" {{action "save"}}>
+      <button class="bigadd" {{on "click" (action "save")}}>
         <FaIcon @icon="check" />
       </button>
-      <button class="bigcancel" {{action "cancel"}}>
+      <button class="bigcancel" {{on "click" (action "cancel")}}>
         <FaIcon @icon="undo" />
       </button>
     {{else if @editable}}

--- a/addon/templates/components/detail-taxonomies.hbs
+++ b/addon/templates/components/detail-taxonomies.hbs
@@ -9,24 +9,24 @@
     <div
       class="title {{if this.showCollapsible "clickable collapsible"}}"
       role="button"
-      {{action "collapse"}}
+      {{on "click" (action "collapse")}}
     >
       {{t "general.terms"}} ({{@subject.terms.length}})
     </div>
   {{/if}}
   <div class="actions">
     {{#if this.isManaging}}
-      <button class="bigadd" {{action "save"}}>
+      <button class="bigadd" {{on "click" (action "save")}}>
         <FaIcon
           @icon={{if this.isSaving "spinner" "check"}}
           @spin={{if this.isSaving true false}}
         />
       </button>
-      <button class="bigcancel" {{action "cancel"}}>
+      <button class="bigcancel" {{on "click" (action "cancel")}}>
         <FaIcon @icon="undo" />
       </button>
     {{else if @editable}}
-      <button {{action "manage"}}>
+      <button {{on "click" (action "manage")}}>
         {{t "general.termsManageTitle"}}
       </button>
     {{/if}}

--- a/addon/templates/components/editable-field.hbs
+++ b/addon/templates/components/editable-field.hbs
@@ -21,7 +21,7 @@
           class="clickable editable"
           data-test-edit
           role="button"
-          {{action (perform this.edit)}}
+          {{on "click" (perform this.edit)}}
         >
           {{this.clickPrompt}}
         </span>
@@ -35,7 +35,7 @@
           disabled={{this.isSaveDisabled}}
           class="done"
           title={{t "general.save"}}
-          {{action (perform this.saveData)}}
+          {{on "click" (perform this.saveData)}}
         >
           <FaIcon
             @icon={{if this.saveData.isRunning "spinner" "check"}}
@@ -45,7 +45,7 @@
         <button
           class="cancel"
           title={{t "general.cancel"}}
-          {{action (perform this.closeEditor)}}
+          {{on "click" (perform this.closeEditor)}}
         >
           <FaIcon @icon="times" />
         </button>

--- a/addon/templates/components/expand-collapse-button.hbs
+++ b/addon/templates/components/expand-collapse-button.hbs
@@ -1,9 +1,9 @@
 {{#if @value}}
-  <button class="collapse-button" onclick={{@action}}>
+  <button class="collapse-button" {{on "click" @action}}>
     <FaIcon @icon="minus" />
   </button>
 {{else}}
-  <button class="expand-button" onclick={{@action}}>
+  <button class="expand-button" {{on "click" @action}}>
     <FaIcon @icon="plus" />
   </button>
 {{/if}}

--- a/addon/templates/components/ilios-calendar-month.hbs
+++ b/addon/templates/components/ilios-calendar-month.hbs
@@ -19,7 +19,7 @@
           <span
             class="clickable"
             role="button"
-            {{action "changeToDayView" day.date}}
+            {{on "click" (fn (action "changeToDayView") day.date)}}
           >
             {{moment-format day.date "D"}}
           </span>
@@ -41,7 +41,7 @@
               <span
                 class="clickable link month-more-events"
                 role="button"
-                {{action "changeToDayView" day.date}}
+                {{on "click" (fn (action "changeToDayView") day.date)}}
               >
                 <FaIcon @icon="ellipsis-h" />
                 {{this.showMore}}

--- a/addon/templates/components/ilios-calendar-multiday-event.hbs
+++ b/addon/templates/components/ilios-calendar-multiday-event.hbs
@@ -5,7 +5,7 @@
   class={{if (and this.clickable @isEventSelectable) "clickable"}}
   role="button"
   data-test-event-name
-  {{action "selectEvent" @event}}
+  {{on "click" (fn (action "selectEvent") @event)}}
 >
   {{@event.name}}
 </span>

--- a/addon/templates/components/ilios-calendar-week.hbs
+++ b/addon/templates/components/ilios-calendar-week.hbs
@@ -11,7 +11,7 @@
       <div
         class="cell title {{if this.areDaysSelectable "clickable"}}"
         role="button"
-        {{action "changeToDayView" day.date}}
+        {{on "click" (fn (action "changeToDayView") day.date)}}
       >
         {{moment-format day.date "ddd M/D"}}
       </div>

--- a/addon/templates/components/ilios-calendar.hbs
+++ b/addon/templates/components/ilios-calendar.hbs
@@ -2,28 +2,28 @@
   <li
     class="clickable highlight {{if this.showIcsFeed "on"}}"
     role="button"
-    {{action (toggle "showIcsFeed" this)}}
+    {{on "click" (toggle "showIcsFeed" this)}}
   >
     <FaIcon @icon="rss-square" />
   </li>
-  <li class="clickable" role="button" {{action @changeView "day"}}>
+  <li class="clickable" role="button" {{on "click" (fn @changeView "day")}}>
     {{t "general.day"}}
   </li>
-  <li class="clickable" role="button" {{action @changeView "week"}}>
+  <li class="clickable" role="button" {{on "click" (fn @changeView "week")}}>
     {{t "general.week"}}
   </li>
-  <li class="clickable" role="button" {{action @changeView "month"}}>
+  <li class="clickable" role="button" {{on "click" (fn @changeView "month")}}>
     {{t "general.month"}}
   </li>
 </ul>
 <ul class="inline calendar-time-picker">
-  <li class="clickable" role="button" {{action "goBack"}}>
+  <li class="clickable" role="button" {{on "click" (action "goBack")}}>
     <FaIcon @icon="backward" />
   </li>
-  <li class="clickable" role="button" {{action "gotoToday"}}>
+  <li class="clickable" role="button" {{on "click" (action "gotoToday")}}>
     {{t "general.today"}}
   </li>
-  <li class="clickable" role="button" {{action "goForward"}}>
+  <li class="clickable" role="button" {{on "click" (action "goForward")}}>
     <FaIcon @icon="forward" />
   </li>
 </ul>

--- a/addon/templates/components/ilios-course-details.hbs
+++ b/addon/templates/components/ilios-course-details.hbs
@@ -11,7 +11,7 @@
   <div
     class="detail-collapsed-control"
     role="button"
-    {{action this.setShowDetails true}}
+    {{on "click" (fn this.setShowDetails true)}}
   >
     <span>
       {{t "general.expandDetail"}}
@@ -33,7 +33,7 @@
     @setCourseCompetencyDetails={{action @setCourseCompetencyDetails}}
     @setCourseManageLeadership={{action @setCourseManageLeadership}}
   />
-  <div class="detail-collapsed-control" role="button" {{action "collapse"}}>
+  <div class="detail-collapsed-control" role="button" {{on "click" (action "collapse")}}>
     <span class="is-expanded">
       {{t "general.collapseDetail"}}
       <FaIcon @icon="minus-square" class="expand-collapse-icon" />

--- a/addon/templates/components/instructor-selection-manager.hbs
+++ b/addon/templates/components/instructor-selection-manager.hbs
@@ -5,7 +5,7 @@
   </h4>
   <ul class="instructors-list" data-test-instructors>
     {{#each (sort-by "fullName" (await @instructors)) as |user|}}
-      <li role="button" {{action "removeInstructor" user}}>
+      <li role="button" {{on "click" (fn (action "removeInstructor") user)}}>
         {{user.fullName}}
         <FaIcon @icon="times" class="remove" />
       </li>
@@ -21,7 +21,7 @@
   <div data-test-instructor-groups>
     {{#each (sort-by "title" (await @instructorGroups)) as |instructorGroup|}}
       <div class="instructor-group" data-test-instructor-group>
-        <span role="button" {{action "removeInstructorGroup" instructorGroup}} data-test-instructor-group-title>
+        <span role="button" data-test-instructor-group-title {{on "click" (fn (action "removeInstructorGroup") instructorGroup)}}>
           <FaIcon @icon="users" />
           {{instructorGroup.title}}
           <FaIcon @icon="times" class="remove" />

--- a/addon/templates/components/leadership-collapsed.hbs
+++ b/addon/templates/components/leadership-collapsed.hbs
@@ -1,4 +1,4 @@
-<div class="title clickable" role="button" {{action @expand}}>
+<div class="title clickable" role="button" {{on "click" @expand}}>
   {{@title}}
 </div>
 <div class="content">

--- a/addon/templates/components/leadership-search.hbs
+++ b/addon/templates/components/leadership-search.hbs
@@ -42,7 +42,7 @@
           role="button"
           data-test-result-index={{index}}
           data-test-result
-          {{action (perform this.clickUser) result.user}}
+          {{on "click" (fn (perform this.clickUser) result.user)}}
         >
           <span class="name">
             {{result.user.fullName}}

--- a/addon/templates/components/leadership-search.hbs
+++ b/addon/templates/components/leadership-search.hbs
@@ -2,11 +2,11 @@
 <input
   type="search"
   value={{this.searchValue}}
-  oninput={{perform this.searchForUsers value="target.value"}}
   placeholder={{t "general.searchForIliosUsers"}}
   incremental="true"
-  onsearch={{perform this.searchForUsers value="target.value"}}
-  onkeyup={{perform this.searchForUsers value="target.value"}}
+  {{on "input" (perform this.searchForUsers value="target.value")}}
+  {{on "search" (perform this.searchForUsers value="target.value")}}
+  {{on "keyup" (perform this.searchForUsers value="target.value")}}
 >
 <ul
   class="results

--- a/addon/templates/components/learnergroup-tree.hbs
+++ b/addon/templates/components/learnergroup-tree.hbs
@@ -1,8 +1,8 @@
 {{! template-lint-disable no-invalid-interactive}}
 <span
   class={{if this.selectable "clickable"}}
-  onclick={{if this.selectable (action @add @learnerGroup)}}
   role={{if this.selectable "button"}}
+  {{on "click" (fn this.add @learnerGroup)}}
 >
   {{@learnerGroup.title}}
 </span>

--- a/addon/templates/components/learning-materials-sort-manager.hbs
+++ b/addon/templates/components/learning-materials-sort-manager.hbs
@@ -1,9 +1,9 @@
 {{#unless this.loadAttr.isRunning}}
   <div class="actions">
-    <button class="bigadd" {{action "save"}}>
+    <button class="bigadd" {{on "click" (action "save")}}>
       <FaIcon @icon="check" />
     </button>
-    <button class="bigcancel" {{action "cancel"}}>
+    <button class="bigcancel" {{on "click" (action "cancel")}}>
       <FaIcon @icon="undo" />
     </button>
   </div>

--- a/addon/templates/components/learningmaterial-manager.hbs
+++ b/addon/templates/components/learningmaterial-manager.hbs
@@ -9,9 +9,9 @@
       <input
         type="text"
         value={{this.title}}
-        oninput={{action (mut this.title) value="target.value"}}
         disabled={{this.save.isRunning}}
-        onkeyup={{action "addErrorDisplayFor" "title"}}
+        {{on "input" (action (mut this.title) value="target.value")}}
+        {{on "keyup" (fn (action "addErrorDisplayFor") "title")}}
       >
       {{#if (and (v-get this "title" "isInvalid") (is-in this.showErrorsFor "title"))}}
         <span

--- a/addon/templates/components/learningmaterial-manager.hbs
+++ b/addon/templates/components/learningmaterial-manager.hbs
@@ -247,7 +247,7 @@
         {{/if}}
       </div>
       {{#if @editable}}
-        <button class="remove-date" {{action (mut this.startDate) null}}>
+        <button class="remove-date" {{on "click" (fn (mut this.startDate) null)}}>
           {{t "general.timedReleaseClearStartDate"}}
         </button>
       {{/if}}
@@ -256,7 +256,7 @@
         <button
           class="add-date"
           data-test-add-start-date
-          {{action "addDate" "startDate"}}
+          {{on "click" (fn (action "addDate") "startDate")}}
         >
           {{t "general.timedReleaseAddStartDate"}}
         </button>
@@ -301,7 +301,7 @@
         </span>
       {{/if}}
       {{#if @editable}}
-        <button class="remove-date" {{action (mut this.endDate) null}}>
+        <button class="remove-date" {{on "click" (fn (mut this.endDate) null)}}>
           {{t "general.timedReleaseClearEndDate"}}
         </button>
       {{/if}}
@@ -310,7 +310,7 @@
         <button
           class="add-date"
           data-test-add-end-date
-          {{action "addDate" "endDate"}}
+          {{on "click" (fn (action "addDate") "endDate")}}
         >
           {{t "general.timedReleaseAddEndDate"}}
         </button>
@@ -329,7 +329,7 @@
       <button
         class="done"
         disabled={{this.save.isRunning}}
-        {{action (perform this.save)}}
+        {{on "click" (perform this.save)}}
       >
         {{#if this.save.isRunning}}
           <LoadingSpinner />
@@ -337,11 +337,11 @@
           {{t "general.done"}}
         {{/if}}
       </button>
-      <button class="cancel" {{action @closeManager}}>
+      <button class="cancel" {{on "click" @closeManager}}>
         {{t "general.cancel"}}
       </button>
     {{else}}
-      <button {{action @closeManager}}>
+      <button {{on "click" @closeManager}}>
         {{t "general.close"}}
       </button>
     {{/if}}

--- a/addon/templates/components/learningmaterial-search.hbs
+++ b/addon/templates/components/learningmaterial-search.hbs
@@ -20,7 +20,7 @@
           ""
         }}
         role="button"
-        {{action (perform this.addLearningMaterial learningMaterial)}}
+        {{on "click" (perform this.addLearningMaterial learningMaterial)}}
       >
         <h4 class="learning-material-title">
           <LmTypeIcon
@@ -62,7 +62,7 @@
       <li>
         <button
           disabled={{if this.searchMore.isRunning true}}
-          {{action (perform this.searchMore)}}
+          {{on "click" (perform this.searchMore)}}
         >
           <FaIcon
             @icon={{if this.searchMore.isRunning "spinner"}}

--- a/addon/templates/components/mesh-manager.hbs
+++ b/addon/templates/components/mesh-manager.hbs
@@ -8,7 +8,7 @@
     <li
       class={{if @editable "clickable"}}
       role="button"
-      {{action "remove" term}}
+      {{on "click" (fn (action "remove") term)}}
     >
       <span class="term-title">
         {{term.name}}
@@ -48,7 +48,7 @@
         class={{unless term.isActive "disabled" ""}}
         role="button"
         data-test-search-result
-        {{action "add" term}}
+        {{on "click" (fn (action "add") term)}}
       >
         <span class="descriptor-name" data-test-name>
           {{term.name}}
@@ -78,7 +78,7 @@
   {{#if this.hasMoreSearchResults}}
     <button
       disabled={{if this.searchMore.isRunning true}}
-      {{action (perform this.searchMore)}}
+      {{on "click" (perform this.searchMore)}}
     >
       <FaIcon
         @icon={{if this.searchMore.isRunning "spinner"}}

--- a/addon/templates/components/my-materials.hbs
+++ b/addon/templates/components/my-materials.hbs
@@ -1,6 +1,6 @@
 <div class="material-list">
   <span class="course-filter">
-    <select onchange={{action @setCourseIdFilter value="target.value"}}>
+    <select {{on "change" (action @setCourseIdFilter value="target.value")}}>
       <option value="">
         {{t "general.allCourses"}}
       </option>
@@ -20,7 +20,7 @@
       placeholder={{t "general.filterPlaceholder"}}
       type="text"
       value={{@filter}}
-      oninput={{perform this.setQuery value="target.value"}}
+      {{on "input" (perform this.setQuery value="target.value")}}
     >
   </span>
   <table>

--- a/addon/templates/components/new-learningmaterial.hbs
+++ b/addon/templates/components/new-learningmaterial.hbs
@@ -197,14 +197,14 @@
   </div>
 {{/if}}
 <div class="buttons">
-  <button class="done text" {{action (perform this.prepareSave)}}>
+  <button class="done text" {{on "click" (perform this.prepareSave)}}>
     {{#if this.prepareSave.isRunning}}
       <LoadingSpinner />
     {{else}}
       {{t "general.done"}}
     {{/if}}
   </button>
-  <button class="cancel text" {{action @cancel}}>
+  <button class="cancel text" {{on "click" @cancel}}>
     {{t "general.cancel"}}
   </button>
 </div>

--- a/addon/templates/components/new-learningmaterial.hbs
+++ b/addon/templates/components/new-learningmaterial.hbs
@@ -6,9 +6,9 @@
     <input
       type="text"
       value={{this.title}}
-      oninput={{action (mut this.title) value="target.value"}}
       disabled={{this.prepareSave.isRunning}}
-      onkeyup={{action "addErrorDisplayFor" "title"}}
+      {{on "input" (action (mut this.title) value="target.value")}}
+      {{on "keyup" (fn (action "addErrorDisplayFor") "title")}}
     >
     {{#if (and (v-get this "title" "isInvalid") (is-in this.showErrorsFor "title"))}}
       <span class="validation-error-message">
@@ -22,7 +22,7 @@
     {{t "general.status"}}:
   </label>
   <span>
-    <select onchange={{action (mut this.statusId) value="target.value"}}>
+    <select {{on "change" (action (mut this.statusId) value="target.value")}}>
       {{#each @learningMaterialStatuses as |lmStatus|}}
         <option
           value={{lmStatus.id}}
@@ -50,9 +50,9 @@
     <input
       type="text"
       value={{this.originalAuthor}}
-      oninput={{action (mut this.originalAuthor) value="target.value"}}
       disabled={{this.prepareSave.isRunning}}
-      onkeyup={{action "addErrorDisplayFor" "originalAuthor"}}
+      {{on "input" (action (mut this.originalAuthor) value="target.value")}}
+      {{on "keyup" (fn (action "addErrorDisplayFor") "originalAuthor")}}
     >
     {{#if
       (and
@@ -71,7 +71,7 @@
     {{t "general.userRole"}}:
   </label>
   <span>
-    <select onchange={{action (mut this.userRoleId) value="target.value"}}>
+    <select {{on "change" (action (mut this.userRoleId) value="target.value")}}>
       {{#each @learningMaterialUserRoles as |role|}}
         <option value={{role.id}} selected={{is-equal role this.selectedUserRole}}>
           {{role.title}}
@@ -88,9 +88,9 @@
     <span>
       <input
         value={{this.link}}
-        oninput={{action (mut this.link) value="target.value"}}
         disabled={{this.prepareSave.isRunning}}
-        onkeyup={{action "addErrorDisplayFor" "link"}}
+        {{on "input" (action (mut this.link) value="target.value")}}
+        {{on "keyup" (fn (action "addErrorDisplayFor") "link")}}
       >
       {{#if (and (v-get this "link" "isInvalid") (is-in this.showErrorsFor "link"))}}
         <span class="validation-error-message">
@@ -141,7 +141,7 @@
         <input
           type="checkbox"
           checked={{this.copyrightPermission}}
-          onclick={{action (mut this.copyrightPermission)}}
+          {{on "click" (fn (mut this.copyrightPermission) (not this.copyrightPermission))}}
         >
         {{t "general.copyrightAgreement"}}
       </p>

--- a/addon/templates/components/new-objective.hbs
+++ b/addon/templates/components/new-objective.hbs
@@ -18,7 +18,7 @@
         (and (v-get this "title" "isInvalid") (is-in this.showErrorsFor "title"))
       }}
       class="done text"
-      {{action "save"}}
+      {{on "click" (action "save")}}
     >
       {{#if this.isSaving}}
         <LoadingSpinner />
@@ -26,7 +26,7 @@
         {{t "general.done"}}
       {{/if}}
     </button>
-    <button class="cancel text" {{action @cancel}}>
+    <button class="cancel text" {{on "click" @cancel}}>
       {{t "general.cancel"}}
     </button>
   </div>

--- a/addon/templates/components/new-session.hbs
+++ b/addon/templates/components/new-session.hbs
@@ -9,13 +9,13 @@
     <input
       type="text"
       value={{this.title}}
-      oninput={{action (mut this.title) value="target.value"}}
-      onkeyup={{action "addErrorDisplayFor" "title"}}
       class={{if
         (and (v-get this "title" "isInvalid") (is-in this.showErrorsFor "title"))
         "has-error"
       }}
       data-test-title
+      {{on "input" (action (mut this.title) value="target.value")}}
+      {{on "keyup" (fn (action "addErrorDisplayFor") "title")}}
     >
     {{#if (and (v-get this "title" "isInvalid") (is-in this.showErrorsFor "title"))}}
       <span class="validation-error-message">
@@ -28,10 +28,7 @@
       {{t "general.sessionType"}}:
     </label>
     {{#if (is-fulfilled this.activeSessionTypes)}}
-      <select
-        onchange={{action (mut this.selectedSessionTypeId) value="target.value"}}
-        data-test-type
-      >
+      <select data-test-type {{on "change" (action (mut this.selectedSessionTypeId) value="target.value")}}>
         {{#each (sort-by "title" (await this.activeSessionTypes)) as |sessionType|}}
           <option
             value={{sessionType.id}}

--- a/addon/templates/components/new-session.hbs
+++ b/addon/templates/components/new-session.hbs
@@ -50,7 +50,7 @@
     <button
       class="done text"
       data-test-save
-      {{action (perform this.saveNewSession)}}
+      {{on "click" (perform this.saveNewSession)}}
     >
       {{#if this.saveNewSession.isRunning}}
         <LoadingSpinner />
@@ -58,7 +58,7 @@
         {{t "general.save"}}
       {{/if}}
     </button>
-    <button class="cancel text" data-test-cancel {{action this.cancel}}>
+    <button class="cancel text" data-test-cancel {{on "click" this.cancel}}>
       {{t "general.cancel"}}
     </button>
   </div>

--- a/addon/templates/components/objective-manage-competency.hbs
+++ b/addon/templates/components/objective-manage-competency.hbs
@@ -14,22 +14,22 @@
             {{#if (eq domain.id @objective.competency.id)}}
               <input
                 type="checkbox"
-                checked=""
-                {{action "removeCurrentCompetency" domain}}
+                checked
+                {{on "click" (fn (action "removeCurrentCompetency") domain)}}
               >
               <span
                 class="clickable"
                 role="button"
-                {{action "removeCurrentCompetency" domain}}
+                {{on "click" (fn (action "removeCurrentCompetency") domain)}}
               >
                 {{domain.title}}
               </span>
             {{else}}
-              <input type="checkbox" {{action "changeCompetency" domain}}>
+              <input type="checkbox" {{on "click" (fn (action "changeCompetency") domain)}}>
               <span
                 class="clickable"
                 role="button"
-                {{action "changeCompetency" domain}}
+                {{on "click" (fn (action "changeCompetency") domain)}}
               >
                 {{domain.title}}
               </span>
@@ -60,25 +60,25 @@
                   {{#if (eq competency.id @objective.competency.id)}}
                     <input
                       type="checkbox"
-                      checked=""
-                      {{action "removeCurrentCompetency" competency}}
+                      checked
+                      {{on "click" (fn (action "removeCurrentCompetency") competency)}}
                     >
                     <span
                       class="clickable"
                       role="button"
-                      {{action "removeCurrentCompetency" competency}}
+                      {{on "click" (fn (action "removeCurrentCompetency") competency)}}
                     >
                       {{competency.title}}
                     </span>
                   {{else}}
                     <input
                       type="checkbox"
-                      {{action "changeCompetency" competency}}
+                      {{on "click" (fn (action "changeCompetency") competency)}}
                     >
                     <span
                       class="clickable"
                       role="button"
-                      {{action "changeCompetency" competency}}
+                      {{on "click" (fn (action "changeCompetency") competency)}}
                     >
                       {{competency.title}}
                     </span>

--- a/addon/templates/components/objective-sort-manager.hbs
+++ b/addon/templates/components/objective-sort-manager.hbs
@@ -1,9 +1,9 @@
 {{#unless this.loadAttr.isRunning}}
   <div class="actions">
-    <button class="bigadd" {{action "save"}}>
+    <button class="bigadd" {{on "click" (action "save")}}>
       <FaIcon @icon="check" />
     </button>
-    <button class="bigcancel" {{action "cancel"}}>
+    <button class="bigcancel" {{on "click" (action "cancel")}}>
       <FaIcon @icon="undo" />
     </button>
   </div>
@@ -31,4 +31,3 @@
     </SortableObjects>
   </div>
 {{/unless}}
-

--- a/addon/templates/components/offering-calendar.hbs
+++ b/addon/templates/components/offering-calendar.hbs
@@ -7,7 +7,7 @@
       @yes={{this.showLearnerGroupEvents}}
       @toggle={{action (mut this.showLearnerGroupEvents)}}
     />
-    <label onclick={{toggle "showLearnerGroupEvents" this}}>
+    <label {{on "click" (toggle "showLearnerGroupEvents" this)}}>
       {{t "general.showLearnerGroupEvents"}}
     </label>
   </span>
@@ -16,7 +16,7 @@
       @yes={{this.showSessionEvents}}
       @toggle={{action (mut this.showSessionEvents)}}
     />
-    <label onclick={{toggle "showSessionEvents" this}}>
+    <label {{on "click" (toggle "showSessionEvents" this)}}>
       {{! template-lint-disable no-triple-curlies }}
       {{{t "general.showSessionEvents" sessionTitle=@session.title}}}
     </label>

--- a/addon/templates/components/offering-form.hbs
+++ b/addon/templates/components/offering-form.hbs
@@ -53,7 +53,7 @@
               min="0"
               type="number"
               value={{this.durationHours}}
-              oninput={{perform this.updateDurationHours value="target.value"}}
+              {{on "input" (perform this.updateDurationHours value="target.value")}}
             >
             {{#if
               (and
@@ -72,8 +72,7 @@
         </div>
         <div class="minutes">
           <div class="minutes-container">
-            <input
-              class={{if
+            <input class={{if
                 (and
                   (v-get this "durationMinutes" "isInvalid")
                   (is-in this.showErrorsFor "durationMinutes")
@@ -84,8 +83,7 @@
               min="0"
               type="number"
               value={{this.durationMinutes}}
-              oninput={{perform this.updateDurationMinutes value="target.value"
-              }}
+              {{on "input" (perform this.updateDurationMinutes value="target.value")}}
             >
             {{#if
               (and
@@ -128,16 +126,15 @@
             <div class="make-recurring-days">
               {{#each this.recurringDayOptions as |obj i|}}
                 <div>
-                  <input
-                    id="make-recurring-day-input-{{i}}"
+                  <input id="make-recurring-day-input-{{i}}"
                     type="checkbox"
                     checked={{or
                       (is-in this.recurringDays obj.day)
                       (eq (moment-format this.startDate "d") obj.day)
                     }}
-                    onclick={{action "toggleRecurringDay" obj.day}}
                     disabled={{eq (moment-format this.startDate "d") obj.day}}
                     data-test-recurring-day-input={{i}}
+                    {{on "click" (fn (action "toggleRecurringDay") obj.day)}}
                   >
                   <label
                     class="day-of-week clickable"
@@ -150,11 +147,8 @@
               {{/each}}
             </div>
             <div class="make-recurring-input-container">
-              <input
-                type="text"
+              <input type="text"
                 value={{this.numberOfWeeks}}
-                oninput={{action (mut this.numberOfWeeks) value="target.value"}}
-                onkeyup={{action "addErrorDisplayFor" "numberOfWeeks"}}
                 class={{concat
                   "make-recurring-input "
                   (if
@@ -165,6 +159,8 @@
                     "has-error"
                   )
                 }}
+                {{on "input" (action (mut this.numberOfWeeks) value="target.value")}}
+                {{on "keyup" (fn (action "addErrorDisplayFor") "numberOfWeeks")}}
               >
               <label class="make-recurring-input-label">
                 {{t "general.weeks"}}
@@ -195,8 +191,8 @@
         <input
           type="text"
           value={{this.room}}
-          oninput={{action (mut this.room) value="target.value"}}
-          onkeyup={{action "addErrorDisplayFor" "room"}}
+          {{on "input" (action (mut this.room) value="target.value")}}
+          {{on "keyup" (fn (action "addErrorDisplayFor") "room")}}
         >
         {{#if (and (v-get this "room" "isInvalid") (is-in this.showErrorsFor "room"))}}
           <span class="validation-error-message">

--- a/addon/templates/components/offering-form.hbs
+++ b/addon/templates/components/offering-form.hbs
@@ -255,7 +255,7 @@
       <button
         class="done text"
         disabled={{or this.saveOffering.isRunning}}
-        {{action (perform this.validateThenSaveOffering)}}
+        {{on "click" (perform this.validateThenSaveOffering)}}
       >
         {{#if this.saveOffering.isRunning}}
           <LoadingSpinner />
@@ -263,7 +263,7 @@
           {{t "general.done"}}
         {{/if}}
       </button>
-      <button class="cancel text" {{action @close}}>
+      <button class="cancel text" {{on "click" @close}}>
         {{t "general.cancel"}}
       </button>
     </div>

--- a/addon/templates/components/offering-manager.hbs
+++ b/addon/templates/components/offering-manager.hbs
@@ -56,12 +56,12 @@
       <span
         class="clickable edit"
         role="button"
-        {{action (toggle "isEditing" this)}}
+        {{on "click" (toggle "isEditing" this)}}
       >
         <FaIcon @icon="edit" class="enabled" />
       </span>
       {{#if (await this.userCanDelete)}}
-        <span class="clickable remove" role="button" {{action "confirmRemove"}}>
+        <span class="clickable remove" role="button" {{on "click" (action "confirmRemove")}}>
           <FaIcon @icon="trash" class="enabled" />
         </span>
       {{else}}
@@ -78,10 +78,10 @@
         }}
         <br>
         <div class="confirm-buttons">
-          <button class="remove text" {{action "remove"}}>
+          <button class="remove text" {{on "click" (action "remove")}}>
             {{t "general.yes"}}
           </button>
-          <button class="cancel text" {{action "cancelRemove"}}>
+          <button class="cancel text" {{on "click" (action "cancelRemove")}}>
             {{t "general.cancel"}}
           </button>
         </div>

--- a/addon/templates/components/publish-all-sessions.hbs
+++ b/addon/templates/components/publish-all-sessions.hbs
@@ -221,7 +221,7 @@
                     <input
                       type="checkbox"
                       checked={{is-in this.sessionsToOverride session}}
-                      onclick={{action "toggleSession" session}}
+                      {{on "click" (fn (action "toggleSession") session)}}
                     >
                     <span
                       class="clickable"
@@ -235,7 +235,7 @@
                     <input
                       type="checkbox"
                       checked={{not-in this.sessionsToOverride session}}
-                      onclick={{action "toggleSession" session}}
+                      {{on "click" (fn (action "toggleSession") session)}}
                     >
                     <span
                       class="clickable"

--- a/addon/templates/components/publish-all-sessions.hbs
+++ b/addon/templates/components/publish-all-sessions.hbs
@@ -9,7 +9,7 @@
   <div
     class="title {{if this.unPublishableCollapsed "collapsed" "collapsible"}}"
     role="button"
-    {{action "toggleUnPublishableCollapsed"}}
+    {{on "click" (action "toggleUnPublishableCollapsed")}}
   >
     {{t "general.incompleteSessions"}} ({{get (await this.unPublishableSessions) "length"}})
   </div>
@@ -95,7 +95,7 @@
   <div
     class="title {{if this.publishableCollapsed "collapsed" "collapsible"}}"
     role="button"
-    {{action "togglePublishableCollapsed"}}
+    {{on "click" (action "togglePublishableCollapsed")}}
   >
     {{t "general.completeSessions"}} ({{get (await this.publishableSessions) "length"}})
   </div>
@@ -183,10 +183,10 @@
   </div>
   <div class="content">
     {{#if (get (await this.overridableSessions) "length")}}
-      <button disabled={{await this.allSessionsAsIs}} {{action "publishAllAsIs"}}>
+      <button disabled={{await this.allSessionsAsIs}} {{on "click" (action "publishAllAsIs")}}>
         {{t "general.publishAsIs"}}
       </button>
-      <button disabled={{this.noSessionsAsIs}} {{action "publishNoneAsIs"}}>
+      <button disabled={{this.noSessionsAsIs}} {{on "click" (action "publishNoneAsIs")}}>
         {{t "general.markAsScheduled"}}
       </button>
       <table>
@@ -226,7 +226,7 @@
                     <span
                       class="clickable"
                       role="button"
-                      {{action "toggleSession" session}}
+                      {{on "click" (fn (action "toggleSession") session)}}
                     >
                       {{t "general.publishAsIs"}}
                     </span>
@@ -240,7 +240,7 @@
                     <span
                       class="clickable"
                       role="button"
-                      {{action "toggleSession" session}}
+                      {{on "click" (fn (action "toggleSession") session)}}
                     >
                       {{t "general.markAsScheduled"}}
                     </span>
@@ -324,7 +324,7 @@
       ignoreCount=(await this.ignoreCount)
     }}
   </p>
-  <button {{action "save"}}>
+  <button {{on "click" (action "save")}}>
     {{t "general.go"}}
   </button>
 </div>

--- a/addon/templates/components/publish-menu.hbs
+++ b/addon/templates/components/publish-menu.hbs
@@ -7,7 +7,7 @@
     aria-expanded={{if this.isOpen "true" "false"}}
     data-level="toggle"
     data-test-toggle
-    {{action (toggle "isOpen" this)}}
+    {{on "click" (toggle "isOpen" this)}}
   >
     <FaIcon @icon={{if @icon @icon "cloud"}} />
     <span>
@@ -17,25 +17,25 @@
   {{#if this.isOpen}}
     <div class="menu" role="menu" data-test-menu>
       {{#if @showAsIs}}
-        <button class="danger" {{action "publish"}}>
+        <button class="danger" {{on "click" (action "publish")}}>
           {{t "general.publishAsIs"}}
         </button>
       {{/if}}
       {{#if @showPublish}}
-        <button class="good" {{action "publish"}}>
+        <button class="good" {{on "click" (action "publish")}}>
           {{t @publishTranslation}}
         </button>
       {{/if}}
       {{#if (and @showReview @reviewRoute @reviewObject)}}
         {{#if this.parentObject}}
-          <button class="good" {{action "scrollToSessionPublication"}}>
+          <button class="good" {{on "click" (action "scrollToSessionPublication")}}>
             {{t
               "general.reviewMissingItems"
               count=(get @reviewObject "allPublicationIssuesLength")
             }}
           </button>
         {{else}}
-          <button class="good" {{action "scrollToCoursePublication"}}>
+          <button class="good" {{on "click" (action "scrollToCoursePublication")}}>
             {{t
               "general.reviewMissingItems"
               count=(get @reviewObject "allPublicationIssuesLength")
@@ -44,12 +44,12 @@
         {{/if}}
       {{/if}}
       {{#if @showTbd}}
-        <button class="good" {{action "publishAsTbd"}}>
+        <button class="good" {{on "click" (action "publishAsTbd")}}>
           {{t "general.markAsScheduled"}}
         </button>
       {{/if}}
       {{#if @showUnPublish}}
-        <button class="danger" {{action "unpublish"}}>
+        <button class="danger" {{on "click" (action "unpublish")}}>
           {{t @unPublishTranslation}}
         </button>
       {{/if}}

--- a/addon/templates/components/search-box.hbs
+++ b/addon/templates/components/search-box.hbs
@@ -2,13 +2,13 @@
   class="search-input"
   type="search"
   value={{this.value}}
-  oninput={{action "update" value="target.value"}}
   placeholder={{@placeholder}}
+  {{on "input" (action "update" value="target.value")}}
 >
 <span
   class="search-icon"
-  onclick={{pipe-action (action "focus") (perform this.searchTask)}}
   role="button"
+  {{on "click" (pipe-action (action "focus") (perform this.searchTask))}}
 >
   <FaIcon @icon="search" />
 </span>

--- a/addon/templates/components/selected-term-tree.hbs
+++ b/addon/templates/components/selected-term-tree.hbs
@@ -4,9 +4,9 @@
       class="checkbox"
       type="checkbox"
       checked={{is-in @selectedTerms term}}
-      {{action @toggle term on="change"}}
+      {{on "change" (fn @toggle term)}}
     >
-    <span class="list-indentation" role="button" {{action @toggle term}}>
+    <span class="list-indentation" role="button" {{on "click" (fn @toggle term)}}>
       {{term.title}}
     </span>
     {{#if (gt (get (await term.children) "length") 0)}}

--- a/addon/templates/components/session-copy.hbs
+++ b/addon/templates/components/session-copy.hbs
@@ -86,7 +86,7 @@
         )
         true
       }}
-      {{action (perform this.save)}}
+      {{on "click" (perform this.save)}}
     >
       {{#if this.save.isRunning}}
         <LoadingSpinner />

--- a/addon/templates/components/session-copy.hbs
+++ b/addon/templates/components/session-copy.hbs
@@ -13,7 +13,7 @@
       {{t "general.year"}}:
     </label>
     {{#if (is-fulfilled this.years)}}
-      <select onchange={{action "changeSelectedYear" value="target.value"}}>
+      <select {{on "change" (action "changeSelectedYear" value="target.value")}}>
         {{#each (await this.years) as |year|}}
           <option
             value={{year}}
@@ -45,7 +45,7 @@
     </label>
     {{#if (is-fulfilled this.courses)}}
       {{#if (get (await this.courses) "length")}}
-        <select onchange={{action (mut this.selectedCourseId) value="target.value"}}>
+        <select {{on "change" (action (mut this.selectedCourseId) value="target.value")}}>
           {{#each (sort-by "title" (await this.courses)) as |course|}}
             <option
               value={{course.id}}

--- a/addon/templates/components/session-leadership-expanded.hbs
+++ b/addon/templates/components/session-leadership-expanded.hbs
@@ -1,5 +1,5 @@
 <div class="session-leadership-expanded-header">
-  <div class="title collapsible clickable" role="button" {{action @collapse}}>
+  <div class="title collapsible clickable" role="button" {{on "click" @collapse}}>
     {{t "general.sessionAdministration"}}
   </div>
   <div class="actions">
@@ -10,11 +10,11 @@
           @spin={{if this.isSaving true false}}
         />
       </button>
-      <button class="bigcancel" {{action @setIsManaging false}}>
+      <button class="bigcancel" {{on "click" (fn @setIsManaging false)}}>
         <FaIcon @icon="undo" />
       </button>
     {{else if @canUpdate}}
-      <button {{action @setIsManaging true}}>
+      <button {{on "click" (fn @setIsManaging true)}}>
         {{t "general.manageLeadership"}}
       </button>
     {{/if}}

--- a/addon/templates/components/session-leadership-expanded.hbs
+++ b/addon/templates/components/session-leadership-expanded.hbs
@@ -4,7 +4,7 @@
   </div>
   <div class="actions">
     {{#if @isManaging}}
-      <button class="bigadd" onclick={{perform this.save}}>
+      <button class="bigadd" {{on "click" (perform this.save)}}>
         <FaIcon
           @icon={{if this.save.isRunning "spinner" "check"}}
           @spin={{if this.isSaving true false}}

--- a/addon/templates/components/session-objective-list-item.hbs
+++ b/addon/templates/components/session-objective-list-item.hbs
@@ -30,7 +30,7 @@
           class="clickable link"
           data-test-parent
           role="button"
-          {{action @manageParents @objective}}
+          {{on "click" (fn @manageParents @objective)}}
         >
           {{parent.textTitle}}
         </span>
@@ -42,7 +42,7 @@
       {{/if}}
     {{/each}}
   {{else if @editable}}
-    <button role="button" {{action @manageParents @objective}}>
+    <button role="button" {{on "click" (fn @manageParents @objective)}}>
       {{t "general.addNew"}}
     </button>
   {{else}}
@@ -57,7 +57,7 @@
           class="clickable link"
           role="button"
           data-test-term
-          {{action @manageDescriptors @objective}}
+          {{on "click" (fn @manageDescriptors @objective)}}
         >
           {{descriptor.name}}
         </li>
@@ -69,7 +69,7 @@
     {{else}}
       <li>
         {{#if @editable}}
-          <button {{action @manageDescriptors @objective}}>
+          <button {{on "click" (fn @manageDescriptors @objective)}}>
             {{t "general.addNew"}}
           </button>
         {{else}}
@@ -81,7 +81,7 @@
 </td>
 <td class="text-left text-top" colspan="1">
   {{#if @editable}}
-    <span class="clickable remove" role="button" {{action @remove @objective}}>
+    <span class="clickable remove" role="button" {{on "click" (fn @remove @objective)}}>
       <FaIcon @icon="trash" class="enabled" />
     </span>
   {{else}}

--- a/addon/templates/components/session-objective-list.hbs
+++ b/addon/templates/components/session-objective-list.hbs
@@ -7,7 +7,7 @@
     />
   {{else if (get (await this.objectives) "length")}}
     {{#if (and @editable (await this.hasMoreThanOneObjective))}}
-      <button class="sort-materials-btn" {{action (mut this.isSorting) true}}>
+      <button class="sort-materials-btn" {{on "click" (fn (mut this.isSorting) true)}}>
         {{t "general.sortObjectives"}}
       </button>
     {{/if}}
@@ -49,12 +49,12 @@
                   {{t "general.confirmObjectiveRemoval"}}
                   <br>
                   <div class="confirm-buttons">
-                    <button class="remove text" {{action "remove" objective}}>
+                    <button class="remove text" {{on "click" (fn (action "remove") objective)}}>
                       {{t "general.yes"}}
                     </button>
                     <button
                       class="done text"
-                      {{action "cancelRemove" objective}}
+                      {{on "click" (fn (action "cancelRemove") objective)}}
                     >
                       {{t "general.cancel"}}
                     </button>

--- a/addon/templates/components/session-objective-manager.hbs
+++ b/addon/templates/components/session-objective-manager.hbs
@@ -13,13 +13,13 @@
           <li
             class="selected clickable"
             role="button"
-            {{action "removeParent" objective}}
+            {{on "click" (fn (action "removeParent") objective)}}
           >
             <Input @type="checkbox" @checked={{true}} />
             {{objective.textTitle}}
           </li>
         {{else}}
-          <li class="clickable" role="button" {{action "addParent" objective}}>
+          <li class="clickable" role="button" {{on "click" (fn (action "addParent") objective)}}>
             <Input @type="checkbox" @checked={{false}} />
             {{objective.textTitle}}
           </li>

--- a/addon/templates/components/session-overview.hbs
+++ b/addon/templates/components/session-overview.hbs
@@ -14,8 +14,8 @@
           type="text"
           value={{this.title}}
           disabled={{isSaving}}
-          oninput={{action (mut this.title) value="target.value"}}
-          onkeyup={{action "addErrorDisplayFor" "title"}}
+          {{on "input" (action (mut this.title) value="target.value")}}
+          {{on "keyup" (fn (action "addErrorDisplayFor") "title")}}
         >
         {{#if (and (v-get this "title" "isInvalid") (is-in this.showErrorsFor "title"))}}
           <span class="validation-error-message">{{v-get this "title" "message"}}</span>
@@ -210,9 +210,9 @@
               <input
                 type="text"
                 value={{this.hours}}
-                oninput={{action (mut this.hours) value="target.value"}}
                 disabled={{isSaving}}
-                onkeyup={{action "addErrorDisplayFor" "hours"}}
+                {{on "input" (action (mut this.hours) value="target.value")}}
+                {{on "keyup" (fn (action "addErrorDisplayFor") "hours")}}
               >
               {{#if (and (v-get this "hours" "isInvalid") (is-in this.showErrorsFor "hours"))}}
                 <span class="validation-error-message">{{v-get this "hours" "message"}}</span>
@@ -267,7 +267,7 @@
             save=(action "changePostrequisite")
             close=(action "revertPostrequisiteChanges")
           }}
-            <select onchange={{action "setPostrequisite" value="target.value"}}>
+            <select {{on "change" (action "setPostrequisite" value="target.value")}}>
               <option value="null" selected={{is-empty (await @session.postrequisite)}}>{{t "general.none"}}</option>
               {{#each (await this.linkablePostrequisites) as |linkablePostrequisite|}}
                 <option value={{linkablePostrequisite.id}} selected={{is-equal linkablePostrequisite (await @session.postrequisite)}}>

--- a/addon/templates/components/sessions-grid-header.hbs
+++ b/addon/templates/components/sessions-grid-header.hbs
@@ -4,7 +4,7 @@
   class="expand-collapse-control"
   role="button"
   data-test-expand-collapse-all
-  {{action (perform this.expandAll)}}
+  {{on "click" (perform this.expandAll)}}
 >
   {{#if @showExpandAll}}
     {{#if this.isExpanding}}

--- a/addon/templates/components/sessions-grid-offering.hbs
+++ b/addon/templates/components/sessions-grid-offering.hbs
@@ -47,9 +47,9 @@
           type="text"
           class="change-room"
           value={{this.room}}
-          oninput={{action (mut this.room) value="target.value"}}
           disabled={{isSaving}}
-          onkeyup={{action "addErrorDisplayFor" "room"}}
+          {{on "input" (action (mut this.room) value="target.value")}}
+          {{on "keyup" (fn (action "addErrorDisplayFor") "room")}}
         >
         {{#if (and (v-get this "room" "isInvalid") (is-in this.showErrorsFor "room"))
         }}

--- a/addon/templates/components/sessions-grid.hbs
+++ b/addon/templates/components/sessions-grid.hbs
@@ -125,7 +125,7 @@
             class="cancel"
             data-test-yes
             disabled={{this.removeSession.isRunning}}
-            onclick={{perform this.removeSession obj.session}}
+            {{on "click" (perform this.removeSession obj.session)}}
           >
             {{#if this.removeSession.isRunning}}
               <LoadingSpinner />
@@ -133,7 +133,7 @@
               {{t "general.yes"}}
             {{/if}}
           </button>
-          <button class="done" onclick={{action "cancelDelete" obj.session.id}}>
+          <button class="done" {{on "click" (fn (action "cancelDelete") obj.session.id)}}>
             {{t "general.cancel"}}
           </button>
         </div>

--- a/addon/templates/components/single-event-objective-list.hbs
+++ b/addon/templates/components/single-event-objective-list.hbs
@@ -3,7 +3,7 @@
   {{#if this.showDisplayModeToggle}}
     <button
       class={{if this.groupByCompetencies "active"}}
-      {{action (toggle "groupByCompetencies" this)}}
+      {{on "click" (toggle "groupByCompetencies" this)}}
     >
       {{#if this.groupByCompetencies}}
         <FaIcon @icon="indent" @title={{@listByPriorityPhrase}} />

--- a/addon/templates/components/taxonomy-manager.hbs
+++ b/addon/templates/components/taxonomy-manager.hbs
@@ -16,9 +16,7 @@
       <label>
         {{t "general.selectVocabulary"}}:
       </label>
-      <select
-        onchange={{action "changeSelectedVocabulary" value="target.value"}}
-      >
+      <select {{on "change" (action "changeSelectedVocabulary" value="target.value")}}>
         {{#each (await this.assignableVocabularies) as |vocab|}}
           <option value={{vocab.id}}>
             {{vocab.title}} ({{vocab.school.title}})
@@ -30,7 +28,7 @@
       type="search"
       value={{this.termFilter}}
       placeholder={{t "general.filterPlaceholder"}}
-      oninput={{perform this.setTermFilter value="target.value"}}
+      {{on "input" (perform this.setTermFilter value="target.value")}}
     >
   </div>
   <div class="terms-picker tag-tree">

--- a/addon/templates/components/time-picker.hbs
+++ b/addon/templates/components/time-picker.hbs
@@ -1,18 +1,18 @@
-<select onchange={{action "changeHour" value="target.value"}} class="hour">
+<select class="hour" {{on "change" (action "changeHour" value="target.value")}}>
   {{#each this.hours as |listHour|}}
     <option value={{listHour}} selected={{is-equal listHour this.hour}}>
       {{listHour}}
     </option>
   {{/each}}
 </select>
-<select onchange={{action "changeMinute" value="target.value"}} class="minute">
+<select class="minute" {{on "change" (action "changeMinute" value="target.value")}}>
   {{#each this.minutes as |listMinute|}}
     <option value={{listMinute}} selected={{is-equal listMinute this.minute}}>
       {{listMinute}}
     </option>
   {{/each}}
 </select>
-<select onchange={{action "changeAmPm" value="target.value"}} class="ampm">
+<select class="ampm" {{on "change" (action "changeAmPm" value="target.value")}}>
   {{#each this.ampms as |listAmPm|}}
     <option value={{listAmPm}} selected={{is-equal listAmPm this.ampm}}>
       {{listAmPm}}

--- a/addon/templates/components/toggle-buttons.hbs
+++ b/addon/templates/components/toggle-buttons.hbs
@@ -3,7 +3,7 @@
   id={{concat "first-toggle-" this.elementId}}
   name={{concat "toggle-" this.elementId}}
   checked={{eq @firstOptionSelected true}}
-  onclick={{action "firstChoice"}}
+  {{on "click" (action "firstChoice")}}
 >
 <label for={{concat "first-toggle-" this.elementId}}>
   {{@firstLabel}}
@@ -13,7 +13,7 @@
   id={{concat "second-toggle-" this.elementId}}
   name={{concat "toggle-" this.elementId}}
   checked={{eq @firstOptionSelected false}}
-  onclick={{action "secondChoice"}}
+  {{on "click" (action "secondChoice")}}
 >
 <label for={{concat "second-toggle-" this.elementId}}>
   {{@secondLabel}}

--- a/addon/templates/components/toggle-icons.hbs
+++ b/addon/templates/components/toggle-icons.hbs
@@ -4,7 +4,7 @@
     id={{concat "first-toggle-" this.elementId}}
     name={{concat "toggle-" this.elementId}}
     checked={{eq @firstOptionSelected true}}
-    onclick={{action "firstChoice"}}
+    {{on "click" (prevent-default (action "firstChoice"))}}
   >
   <label for={{concat "first-toggle-" this.elementId}}>
     {{@firstLabel}}
@@ -14,7 +14,7 @@
     id={{concat "second-toggle-" this.elementId}}
     name={{concat "toggle-" this.elementId}}
     checked={{eq @firstOptionSelected false}}
-    onclick={{action "secondChoice"}}
+    {{on "click" (prevent-default (action "secondChoice"))}}
   >
   <label for={{concat "second-toggle-" this.elementId}}>
     {{@secondLabel}}

--- a/addon/templates/components/user-search.hbs
+++ b/addon/templates/components/user-search.hbs
@@ -30,7 +30,7 @@
             class="active"
             role="button"
             data-test-result
-            {{action "addUser" proxy.content}}
+            {{on "click" (fn (action "addUser") proxy.content)}}
           >
             <div class="name">
               {{proxy.fullName}}
@@ -56,7 +56,7 @@
             class="active"
             role="button"
             data-test-result
-            {{action "addInstructorGroup" proxy.content}}
+            {{on "click" (fn (action "addInstructorGroup") proxy.content)}}
           >
             {{proxy.title}}
           </li>

--- a/addon/templates/components/week-glance.hbs
+++ b/addon/templates/components/week-glance.hbs
@@ -4,7 +4,7 @@
     {{if @collapsed "collapsed" "expanded"}}"
   role="button"
   data-test-week-title
-  {{action (optional @toggleCollapsed) @collapsed}}
+  {{on "click" (fn (optional @toggleCollapsed) @collapsed)}}
 >
   {{this.title}}
   {{#if @showFullTitle}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9463,6 +9463,14 @@
         "ember-cli-babel": "^7.1.3"
       }
     },
+    "ember-event-helpers": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ember-event-helpers/-/ember-event-helpers-0.1.0.tgz",
+      "integrity": "sha512-JdsYPmW0g0LLKmdRGxS9lRIdtB1Swc7Asr0XmUwhkjbFY40bfB0wlQ8P2yA3YLqbP/ToShBitN62t9Cy4PTazQ==",
+      "requires": {
+        "ember-cli-babel": "^7.7.3"
+      }
+    },
     "ember-export-application-global": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ember-export-application-global/-/ember-export-application-global-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "ember-cp-validations": "^4.0.0-beta.9",
     "ember-data": "3.14.0",
     "ember-drag-drop": "^0.7.0",
+    "ember-event-helpers": "^0.1.0",
     "ember-feature-flags": "^6.0.0",
     "ember-fetch": "^6.6.0",
     "ember-file-upload": "^2.5.0",

--- a/tests/integration/components/editable-field-test.js
+++ b/tests/integration/components/editable-field-test.js
@@ -102,10 +102,11 @@ module('Integration | Component | editable field', function(hooks) {
       hbs`<EditableField
             @value={{value}}
           >
-            <input />
+            <textarea></textarea>
           </EditableField>
       `);
     await click('[data-test-edit]');
-    assert.dom('input', this.element).isFocused();
+
+    assert.dom('textarea', this.element).isFocused();
   });
 });

--- a/tests/integration/components/expand-collapse-button-test.js
+++ b/tests/integration/components/expand-collapse-button-test.js
@@ -9,7 +9,8 @@ module('Integration | Component | expand collapse button', function(hooks) {
 
   test('renders with default value false', async function(assert) {
     assert.expect(1);
-    await render(hbs`<ExpandCollapseButton />`);
+    this.set('action', () => { });
+    await render(hbs`<ExpandCollapseButton @action={{this.action}} />`);
     assert.dom('svg').hasClass('fa-plus');
   });
 


### PR DESCRIPTION
Mostly a codmod with some cleanup. Events in template should now be written with the `{{on}}` syntax.