### PR TITLE
Add and use new TruncateText component

### DIFF
--- a/addon/components/dashboard-materials.hbs
+++ b/addon/components/dashboard-materials.hbs
@@ -88,7 +88,7 @@
               {{lmObject.sessionTitle}}
             </td>
             <td colspan="1" class="hide-from-small-screen">
-              <BigText
+              <TruncateText
                 @length={{25}}
                 @text={{join
                   ", "

--- a/addon/components/editable-field.hbs
+++ b/addon/components/editable-field.hbs
@@ -10,15 +10,38 @@
             @click={{perform this.edit}}
           />
         {{else}}
-          <BigText
+          <TruncateText
             @renderHtml={{this.renderHtml}}
             @text={{@value}}
             @onEdit={{perform this.edit}}
-          />
+            as |displayText expand isTruncated|
+          >
+            <span
+              class="clickable editable"
+              aria-label={{t "general.edit"}}
+              data-test-edit
+              role="button"
+              {{on "click" (perform this.edit)}}
+            >
+              {{displayText}}
+            </span>
+            {{#if isTruncated}}
+              <FaIcon @icon="ellipsis-h" @transform="down-6" />
+              <button
+                class="expand-text-button"
+                aria-label={{t "general.expand"}}
+                data-test-expand
+                {{on "click" expand}}
+              >
+                <FaIcon @icon="info-circle" />
+              </button>
+            {{/if}}
+          </TruncateText>
         {{/if}}
       {{else}}
         <span
           class="clickable editable"
+          aria-label={{t "general.edit"}}
           data-test-edit
           role="button"
           {{on "click" (perform this.edit)}}

--- a/addon/components/my-materials.hbs
+++ b/addon/components/my-materials.hbs
@@ -144,7 +144,7 @@
               {{/if}}
             </td>
             <td class="hide-from-small-screen" colspan="1" data-test-instructor>
-              <BigText
+              <TruncateText
                 @length={{25}}
                 @text={{join
                   ", "

--- a/addon/components/objective-sort-manager.hbs
+++ b/addon/components/objective-sort-manager.hbs
@@ -23,7 +23,7 @@
           <FaIcon @icon="arrows-alt" />
           <span class="draggable-object-content">
             <span>
-              <BigText @text={{item.title}} />
+              <TruncateText @text={{item.title}} />
             </span>
           </span>
         </DraggableObject>

--- a/addon/components/truncate-text.hbs
+++ b/addon/components/truncate-text.hbs
@@ -1,16 +1,17 @@
 {{#if (has-block)}}
-  {{yield this.displayText this.expand}}
+  {{yield this.displayText this.expand this.isTruncated}}
 {{else}}
   <span class="truncate-text" ...attributes>
     {{this.displayText}}
-    {{#if this.showIcons}}
+    {{#if this.isTruncated}}
+      <FaIcon @icon="ellipsis-h" @transform="down-6" />
       <button
         class="expand-buttons"
         aria-label={{t "general.expand"}}
         data-test-expand
         {{on "click" this.expand}}
       >
-        <FaIcon @icon="ellipsis-h" /> <FaIcon @icon="info-circle" />
+        <FaIcon @icon="info-circle" />
       </button>
     {{/if}}
   </span>

--- a/addon/components/truncate-text.hbs
+++ b/addon/components/truncate-text.hbs
@@ -1,0 +1,17 @@
+{{#if (has-block)}}
+  {{yield this.displayText this.expand}}
+{{else}}
+  <span class="truncate-text" ...attributes>
+    {{this.displayText}}
+    {{#if this.showIcons}}
+      <button
+        class="expand-buttons"
+        aria-label={{t "general.expand"}}
+        data-test-expand
+        {{on "click" this.expand}}
+      >
+        <FaIcon @icon="ellipsis-h" /> <FaIcon @icon="info-circle" />
+      </button>
+    {{/if}}
+  </span>
+{{/if}}

--- a/addon/components/truncate-text.js
+++ b/addon/components/truncate-text.js
@@ -40,7 +40,7 @@ export default class TruncateTextComponent extends Component {
     const truncatedText = this.cleanText.substring(0, this.length);
     return new htmlSafe(truncatedText);
   }
-  get showIcons() {
+  get isTruncated() {
     if(this.args.renderHtml){
       return this.displayText.toString() !== this.text;
     } else {

--- a/addon/components/truncate-text.js
+++ b/addon/components/truncate-text.js
@@ -1,0 +1,54 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { typeOf } from '@ember/utils';
+import { htmlSafe } from '@ember/string';
+import { action } from '@ember/object';
+
+export default class TruncateTextComponent extends Component {
+  @tracked expanded = false;
+
+  get length() {
+    return this.args.length ?? 200;
+  }
+  get slippage() {
+    return this.args.slippage ?? 25;
+  }
+  get text() {
+    if (!this.args.text) {
+      return '';
+    }
+    if (typeOf(this.args.text) !== 'string'){
+      return this.args.text.toString();
+    }
+
+    return this.args.text;
+  }
+  get cleanText() {
+    return this.text.replace(/(<([^>]+)>)/ig,"");
+  }
+  get totalLength() {
+    return this.length + this.slippage;
+  }
+  get displayText() {
+    if(this.expanded || this.cleanText.length < this.totalLength){
+      if(this.args.renderHtml){
+        return new htmlSafe(this.text);
+      } else {
+        return new htmlSafe(this.cleanText);
+      }
+    }
+    const truncatedText = this.cleanText.substring(0, this.length);
+    return new htmlSafe(truncatedText);
+  }
+  get showIcons() {
+    if(this.args.renderHtml){
+      return this.displayText.toString() !== this.text;
+    } else {
+      return this.displayText.toString() !== this.cleanText;
+    }
+  }
+  @action
+  expand() {
+    this.expanded = true;
+  }
+}

--- a/addon/components/week-glance-event.hbs
+++ b/addon/components/week-glance-event.hbs
@@ -92,7 +92,7 @@
   {{/if}}
   {{#if @event.sessionDescription.length}}
     <p class="description" data-test-description>
-      <BigText @text={{@event.sessionDescription}} @length={{50}} />
+      <TruncateText @text={{@event.sessionDescription}} @length={{50}} />
     </p>
   {{/if}}
   <ul class="learning-materials" data-test-learning-materials>
@@ -178,7 +178,7 @@
           {{/if}}
           {{#if lm.publicNotes}}
             <p class="public-notes" data-test-public-notes>
-              <BigText @text={{lm.publicNotes}} @length={{50}} />
+              <TruncateText @text={{lm.publicNotes}} @length={{50}} />
             </p>
           {{/if}}
         {{/if}}

--- a/app/components/truncate-text.js
+++ b/app/components/truncate-text.js
@@ -1,0 +1,1 @@
+export { default } from 'ilios-common/components/truncate-text';

--- a/app/styles/ilios-common/components.scss
+++ b/app/styles/ilios-common/components.scss
@@ -103,6 +103,7 @@
 @import 'components/toggle-buttons';
 @import 'components/toggle-icons';
 @import 'components/toggle-yesno';
+@import 'components/truncate-text';
 @import 'components/user-search';
 @import 'components/visualizer-course-instructor-session-type';
 @import 'components/visualizer-course-instructors';

--- a/app/styles/ilios-common/components/editinplace.scss
+++ b/app/styles/ilios-common/components/editinplace.scss
@@ -66,4 +66,9 @@
   .fa-edit {
     @include icon;
   }
+
+  .expand-text-button {
+    @include ilios-link-button;
+    display: inline;
+  }
 }

--- a/app/styles/ilios-common/components/truncate-text.scss
+++ b/app/styles/ilios-common/components/truncate-text.scss
@@ -1,0 +1,5 @@
+.truncate-text {
+  .expand-buttons {
+    @include ilios-link-button;
+  }
+}

--- a/index.js
+++ b/index.js
@@ -10,7 +10,10 @@ module.exports = {
 
   options: {
     babel: {
-      plugins: [ require.resolve('ember-auto-import/babel-plugin') ]
+      plugins: [
+        require.resolve('ember-auto-import/babel-plugin'),
+        require.resolve('@babel/plugin-proposal-nullish-coalescing-operator'),
+      ]
     }
   },
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:all": "ember try:each"
   },
   "dependencies": {
+    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.4.4",
     "@ember-intl/cp-validations": "^4.0.1",
     "@ember/render-modifiers": "^1.0.2",
     "@fortawesome/ember-fontawesome": "^0.2.0",

--- a/tests/integration/components/truncate-text-test.js
+++ b/tests/integration/components/truncate-text-test.js
@@ -1,0 +1,142 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | truncate-text', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders empty', async function(assert) {
+    await render(hbs`<TruncateText />`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    await render(hbs`
+      <TruncateText>
+        template block text
+      </TruncateText>
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+
+  test('it truncates long text', async function (assert) {
+    this.set('longText', 't'.repeat(400));
+    await render(hbs`<TruncateText @text={{this.longText}} />`);
+    assert.equal(this.element.textContent.trim(), 't'.repeat(200));
+    await render(hbs`
+      <TruncateText @text={{this.longText}} as |displayText|>
+        Content: {{displayText}}
+      </TruncateText>
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'Content: ' + 't'.repeat(200));
+  });
+
+  test('it does not truncate long text with slippage', async function (assert) {
+    this.set('longText', 't'.repeat(224));
+    await render(hbs`<TruncateText @text={{this.longText}} />`);
+    assert.equal(this.element.textContent.trim(), 't'.repeat(224));
+    await render(hbs`
+      <TruncateText @text={{this.longText}} as |displayText|>
+        Content: {{displayText}}
+      </TruncateText>
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'Content: ' + 't'.repeat(224));
+  });
+
+  test('slippage is configurable', async function (assert) {
+    this.set('longText', 't'.repeat(250));
+    await render(hbs`<TruncateText @slippage=75 @text={{this.longText}} />`);
+    assert.equal(this.element.textContent.trim(), 't'.repeat(250));
+    await render(hbs`
+      <TruncateText @slippage=75 @text={{this.longText}} as |displayText|>
+        Content: {{displayText}}
+      </TruncateText>
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'Content: ' + 't'.repeat(250));
+  });
+
+  test('it strips HTML in collapsedText', async function (assert) {
+    this.set('longText', '<h1>Text</h1>' + 't'.repeat(400));
+    await render(hbs`<TruncateText @text={{this.longText}} />`);
+    assert.equal(this.element.textContent.trim(), 'Text' + 't'.repeat(196));
+    await render(hbs`
+      <TruncateText @text={{this.longText}} as |displayText|>
+        Content: {{displayText}}
+      </TruncateText>
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'Content: ' + 'Text' + 't'.repeat(196));
+  });
+
+  test('it strips HTML when text is short', async function (assert) {
+    this.set('longText', '<h1>Text</h1>');
+    await render(hbs`<TruncateText @text={{this.longText}} />`);
+    assert.equal(this.element.textContent.trim(), 'Text');
+    await render(hbs`
+      <TruncateText @text={{this.longText}} as |displayText|>
+        Content: {{displayText}}
+      </TruncateText>
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'Content: ' + 'Text');
+  });
+
+  test('it preserves HTML when requested when text is short', async function (assert) {
+    this.set('longText', '<h1>Text</h1>');
+    await render(hbs`<TruncateText @renderHtml={{true}} @text={{this.longText}} />`);
+    assert.dom('h1').exists();
+    assert.dom('h1').hasText('Text');
+    await render(hbs`
+      <TruncateText @renderHtml={{true}} @text={{this.longText}} as |displayText|>
+        Content: {{displayText}}
+      </TruncateText>
+    `);
+    assert.dom('h1').exists();
+    assert.dom('h1').hasText('Text');
+  });
+
+  test('clicking expand reveals all text', async function (assert) {
+    this.set('longText', 't'.repeat(400));
+    await render(hbs`<TruncateText @text={{this.longText}} />`);
+    assert.equal(this.element.textContent.trim(), 't'.repeat(200));
+    await click('[data-test-expand]');
+    assert.equal(this.element.textContent.trim(), 't'.repeat(400));
+  });
+
+  test('yielded expand reveals all text', async function (assert) {
+    this.set('longText', 't'.repeat(400));
+    await render(hbs`
+      <TruncateText @text={{this.longText}} as |displayText expand|>
+        {{displayText}}
+        <button {{on "click" expand}}>Expand</button>
+      </TruncateText>
+    `);
+    assert.dom(this.element).hasText('t'.repeat(200) + ' Expand');
+    await click('button');
+    assert.dom(this.element).hasText('t'.repeat(400) + ' Expand');
+  });
+
+  test('it preserves HTML when expanded', async function (assert) {
+    this.set('longText', 't'.repeat(400));
+    await render(hbs`<TruncateText @renderHtml={{true}} @text={{this.longText}} />`);
+    await click('[data-test-expand]');
+    assert.dom('h1').exists();
+    assert.dom('h1').hasText('Text');
+    assert.dom(this.element).hasText('t'.repeat(400));
+    assert.equal(this.element.textContent.trim(), '<h1>Text</h1>');
+    await render(hbs`
+      <TruncateText @renderHtml={{true}} @text={{this.longText}} as |displayText expand|>
+        {{displayText}}
+        <button {{on "click" expand}}>Expand</button>
+      </TruncateText>
+    `);
+    await click('button');
+    assert.dom('h1').exists();
+    assert.dom('h1').hasText('Text');
+    assert.dom(this.element).hasText('t'.repeat(400));
+  });
+});

--- a/tests/integration/components/truncate-text-test.js
+++ b/tests/integration/components/truncate-text-test.js
@@ -121,13 +121,12 @@ module('Integration | Component | truncate-text', function(hooks) {
   });
 
   test('it preserves HTML when expanded', async function (assert) {
-    this.set('longText', 't'.repeat(400));
+    this.set('longText', '<h1>Text</h1>' + 't'.repeat(400));
     await render(hbs`<TruncateText @renderHtml={{true}} @text={{this.longText}} />`);
     await click('[data-test-expand]');
     assert.dom('h1').exists();
     assert.dom('h1').hasText('Text');
-    assert.dom(this.element).hasText('t'.repeat(400));
-    assert.equal(this.element.textContent.trim(), '<h1>Text</h1>');
+    assert.dom(this.element).includesText('t'.repeat(400));
     await render(hbs`
       <TruncateText @renderHtml={{true}} @text={{this.longText}} as |displayText expand|>
         {{displayText}}
@@ -137,6 +136,30 @@ module('Integration | Component | truncate-text', function(hooks) {
     await click('button');
     assert.dom('h1').exists();
     assert.dom('h1').hasText('Text');
-    assert.dom(this.element).hasText('t'.repeat(400));
+    assert.dom(this.element).includesText('t'.repeat(400));
+  });
+
+  test('it yields isTruncated when not truncated', async function (assert) {
+    this.set('text', 'abc');
+    await render(hbs`
+      <TruncateText @text={{this.text}} as |displayText expand isTruncated|>
+        {{isTruncated}}
+        <button {{on "click" expand}}>Expand</button>
+      </TruncateText>
+    `);
+    assert.dom(this.element).includesText('false');
+  });
+
+  test('it yields isTruncated when truncated', async function (assert) {
+    this.set('longText', 't'.repeat(400));
+    await render(hbs`
+      <TruncateText @text={{this.longText}} as |displayText expand isTruncated|>
+        {{isTruncated}}
+        <button {{on "click" expand}}>Expand</button>
+      </TruncateText>
+    `);
+    assert.dom(this.element).includesText('true');
+    await click('button');
+    assert.dom(this.element).includesText('false');
   });
 });


### PR DESCRIPTION
Meant to be a more functional replacement for `<BigText>` with better a11y
and improved ability to use it inside of `<EditableField>`.

Improved fix for ilios/frontend#2519