### PR TITLE
Align common with frontend styles

### DIFF
--- a/app/styles/ilios-common/components/body.scss
+++ b/app/styles/ilios-common/components/body.scss
@@ -1,6 +1,7 @@
 html {
   box-sizing: border-box;
   font-size: 16px;
+  line-height: $base-line-height;
   @include for-desktop-and-up {
     font-size: 20px;
   }

--- a/app/styles/ilios-common/variables.scss
+++ b/app/styles/ilios-common/variables.scss
@@ -3,7 +3,7 @@ $black: #000;
 $grey: #eee;
 $maroon: #800;
 
-$base-line-height: 1.5;
+$base-line-height: 1.1; //line-height from normalize.css
 $base-border-radius: 3px;
 
 $ilios-orange: #c60;

--- a/index.js
+++ b/index.js
@@ -20,6 +20,9 @@ module.exports = {
   included: function() {
     this._super.included.apply(this, arguments);
 
+    // Import normalize.css style
+    this.import(path.join('node_modules', 'normalize.css', 'normalize.css'));
+
     // Import the froala editor styles
     let froalaPath = path.join('node_modules', 'froala-editor');
     this.import(path.join(froalaPath, 'css', 'froala_editor.css'));

--- a/package-lock.json
+++ b/package-lock.json
@@ -16630,6 +16630,11 @@
         }
       }
     },
+    "normalize.css": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
+      "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg=="
+    },
     "npm-git-info": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/npm-git-info/-/npm-git-info-1.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "ember-truth-helpers": "^2.0.0",
     "froala-editor": "^3.0.6",
     "liquid-fire": "^0.31.0",
+    "normalize.css": "^8.0.1",
     "query-string": "^6.8.3",
     "scroll-into-view": "^1.9.3",
     "striptags": "^3.1.1"


### PR DESCRIPTION
We use normalize.css on the frontend which causes some issues
particularly around line-height and alignment. To ensure that this is
easier to see I'm adding normalize.css here and ensuring that the line
height gets set specifically.