### PR TITLE
Add methods to mirror service computed properties

### DIFF
--- a/addon/services/api-version.js
+++ b/addon/services/api-version.js
@@ -15,4 +15,9 @@ export default Service.extend({
     const serverApiVersion = await this.iliosConfig.apiVersion;
     return serverApiVersion !== this.version;
   }),
+
+  async getIsMismatched() {
+    const serverApiVersion = await this.iliosConfig.apiVersion;
+    return serverApiVersion !== this.version;
+  }
 });

--- a/addon/services/ilios-config.js
+++ b/addon/services/ilios-config.js
@@ -6,49 +6,74 @@ export default Service.extend({
   fetch: service(),
   serverVariables: service(),
 
-  config: computed('apiHost', function(){
-    return this.fetch.getJsonFromApiHost('/application/config');
+  config: computed('apiHost', function () {
+    return this.getConfig();
   }),
+  getConfig() {
+    return this.fetch.getJsonFromApiHost('/application/config');
+  },
 
-  itemFromConfig(key){
-    return this.get('config').then(config => {
-      const obj = config.config;
-
-      return key in obj?obj[key]:null;
-    });
+  async itemFromConfig(key) {
+    const config = await this.getConfig();
+    const obj = config.config;
+    return key in obj?obj[key]:null;
   },
 
   userSearchType: computed('config.userSearchType', function(){
-    return this.itemFromConfig('userSearchType');
+    return this.getUserSearchType();
   }),
+  async getUserSearchType() {
+    return this.itemFromConfig('userSearchType');
+  },
 
   authenticationType: computed('config.type', function(){
-    return this.itemFromConfig('type');
+    return this.getUserSearchType();
   }),
+  async getAuthenticationType() {
+    return this.itemFromConfig('type');
+  },
 
   maxUploadSize: computed('config.maxUploadSize', function(){
-    return this.itemFromConfig('maxUploadSize');
+    return this.getMaxUploadSize();
   }),
+  async getMaxUploadSize() {
+    return this.itemFromConfig('maxUploadSize');
+  },
 
   apiVersion: computed('config.apiVersion', function(){
-    return this.itemFromConfig('apiVersion');
+    return this.getApiVersion();
   }),
+  async getApiVersion() {
+    return this.itemFromConfig('apiVersion');
+  },
 
   trackingEnabled: computed('config.trackingEnabled', function(){
-    return this.itemFromConfig('trackingEnabled');
+    return this.getTrackingEnabled();
   }),
+  async getTrackingEnabled() {
+    return this.itemFromConfig('trackingEnabled');
+  },
 
   trackingCode: computed('config.trackingCode', function(){
-    return this.itemFromConfig('trackingCode');
+    return this.getTrackingCode();
   }),
+  async getTrackingCode() {
+    return this.itemFromConfig('trackingCode');
+  },
 
   loginUrl: computed('config.loginUrl', function(){
-    return this.itemFromConfig('loginUrl');
+    return this.getLoginUrl();
   }),
+  async getLoginUrl() {
+    return this.itemFromConfig('loginUrl');
+  },
 
   casLoginUrl: computed('config.casLoginUrl', function(){
-    return this.itemFromConfig('casLoginUrl');
+    return this.getCasLoginUrl();
   }),
+  async getCasLoginUrl() {
+    return this.itemFromConfig('casLoginUrl');
+  },
 
   apiNameSpace: computed('serverVariables.apiNameSpace', function(){
     const serverVariables = this.get('serverVariables');
@@ -81,6 +106,9 @@ export default Service.extend({
   }),
 
   searchEnabled: computed('config.searchEnabled', async function(){
+    return this.getSearchEnabled();
+  }),
+  async getSearchEnabled() {
     const searchEnabled = await this.itemFromConfig('searchEnabled');
     if (searchEnabled === null) {
       return false;
@@ -90,5 +118,5 @@ export default Service.extend({
     }
 
     return searchEnabled === 'true';
-  }),
+  },
 });

--- a/addon/services/permission-matrix.js
+++ b/addon/services/permission-matrix.js
@@ -4,6 +4,9 @@ import { computed } from '@ember/object';
 export default Service.extend({
   store: service(),
   permissionMatrix: computed(async function(){
+    return this.getPermissionMatrix();
+  }),
+  async getPermissionMatrix() {
     const store = this.get('store');
     const schools = await store.findAll('school');
     const schoolIds = schools.mapBy('id');
@@ -245,9 +248,9 @@ export default Service.extend({
     });
 
     return matrix;
-  }),
+  },
   async hasPermission(school, capability, userRoles) {
-    const matrix = await this.get('permissionMatrix');
+    const matrix = await this.getPermissionMatrix();
     const schoolId = school.get('id');
     if (!Object.prototype.hasOwnProperty.call(matrix, schoolId)) {
       return false;
@@ -262,7 +265,7 @@ export default Service.extend({
     return matchedRoles.length > 0;
   },
   async getPermittedRoles(school, capability) {
-    const matrix = await this.get('permissionMatrix');
+    const matrix = await this.getPermissionMatrix();
     const schoolId = school.get('id');
     if (!Object.prototype.hasOwnProperty.call(matrix, schoolId)) {
       return [];


### PR DESCRIPTION
We're going to want to remove these async computeds when converting
these service Objects to ES Classes. First step in this transition is to
rely on async methods in each service.