### PR TITLE
Don't rely on extending the string prototype

### DIFF
--- a/addon/adapters/ilios.js
+++ b/addon/adapters/ilios.js
@@ -2,6 +2,7 @@ import RESTAdapter from '@ember-data/adapter/rest';
 import { inject as service } from '@ember/service';
 import { reads } from '@ember/object/computed';
 import { pluralize } from 'ember-inflector';
+import { camelize } from '@ember/string';
 
 export default RESTAdapter.extend({
   iliosConfig: service(),
@@ -45,7 +46,7 @@ export default RESTAdapter.extend({
   },
 
   pathForType(type) {
-    return pluralize(type.camelize().toLowerCase());
+    return pluralize(camelize(type).toLowerCase());
   },
 
   sortQueryParams: false,


### PR DESCRIPTION
There are several ways this can be turned off in Ember, so we should use
the import instead for maximum reliability.