### PR TITLE
Cache config from API server

### DIFF
--- a/addon/services/ilios-config.js
+++ b/addon/services/ilios-config.js
@@ -5,12 +5,16 @@ import { isPresent } from '@ember/utils';
 export default Service.extend({
   fetch: service(),
   serverVariables: service(),
+  _config: null,
 
   config: computed('apiHost', function () {
     return this.getConfig();
   }),
-  getConfig() {
-    return this.fetch.getJsonFromApiHost('/application/config');
+  async getConfig() {
+    if (!this._config) {
+      this._config = await this.fetch.getJsonFromApiHost('/application/config');
+    }
+    return this._config;
   },
 
   async itemFromConfig(key) {


### PR DESCRIPTION
We don't want to fetch this every time we look up a new value so this
adds a local cache. It's temporary and can be removed once we move to an
ES Class for this service and then we can just set `config` on the
class.