### PR TITLE
Glimmer <CourseHeader>

### DIFF
--- a/addon-test-support/ilios-common/page-objects/components/course-header.js
+++ b/addon-test-support/ilios-common/page-objects/components/course-header.js
@@ -1,0 +1,23 @@
+import {
+  create,
+  clickable,
+  fillable,
+  text,
+  isVisible,
+} from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-course-header]',
+  title: {
+    scope: '[data-test-title]',
+    value: text('[data-test-edit]'),
+    edit: clickable('[data-test-edit]'),
+    set: fillable('input'),
+    save: clickable('.done'),
+    cancel: clickable('.cancel'),
+    hasError: isVisible('.validation-error-message')
+  },
+};
+
+export default definition;
+export const component = create(definition);

--- a/addon-test-support/ilios-common/page-objects/components/course/publication-menu.js
+++ b/addon-test-support/ilios-common/page-objects/components/course/publication-menu.js
@@ -1,0 +1,26 @@
+import {
+  create,
+  triggerable,
+  isVisible,
+  isHidden
+} from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-course-publication-menu]',
+  toggle: {
+    scope: '[data-test-toggle]',
+    enter: triggerable('keydown', '', { eventProperties: { key: 'Enter' } }),
+    down: triggerable('keydown', '', { eventProperties: { key: 'ArrowDown' } }),
+    esc: triggerable('keydown', '', { eventProperties: { key: 'Escape' } }),
+  },
+  menuClosed: isHidden('[data-test-menu]'),
+  menuOpen: isVisible('[data-test-menu]'),
+  hasPublishAsIs: isVisible('[data-test-publish-as-is]'),
+  hasPublish: isVisible('[data-test-publish]'),
+  hasReview: isVisible('[data-test-review]'),
+  hasTbd: isVisible('[data-test-tbd]'),
+  hasUnPublish: isVisible('[data-test-un-publish]'),
+};
+
+export default definition;
+export const component = create(definition);

--- a/addon/components/course-header.hbs
+++ b/addon/components/course-header.hbs
@@ -1,64 +1,47 @@
-<span class="title">
-  {{#if @course.locked}}
-    <FaIcon @icon="lock" />
-  {{/if}}
-  {{#if @editable}}
-    {{#if @course}}
+<div
+  class="course-header"
+  data-test-course-header
+  {{did-insert this.revertTitleChanges}}
+  {{did-update this.revertTitleChanges}}
+>
+  <span class="title" data-test-title>
+    {{#if @editable}}
       <EditableField
         @value={{this.courseTitle}}
-        @save={{action "changeTitle"}}
-        @close={{action "revertTitleChanges"}}
+        @save={{perform this.changeTitle}}
+        @close={{this.revertTitleChanges}}
         @saveOnEnter={{true}}
         @closeOnEscape={{true}} as |isSaving|
       >
-        <input
+        <Input
           type="text"
-          value={{this.courseTitle}}
+          @value={{this.courseTitle}}
+          @key-press={{fn this.addErrorDisplayFor "courseTitle"}}
           disabled={{isSaving}}
-          {{on "input" (action (mut this.courseTitle) value="target.value")}}
-          {{on "keyup" (fn (action "addErrorDisplayFor") "courseTitle")}}
-        >
-        {{#if
-          (and
-            (v-get this "courseTitle" "isInvalid")
-            (contains "courseTitle" this.showErrorsFor)
-          )
-        }}
+        />
+        {{#each (await (compute (fn this.getErrorsFor) "courseTitle")) as |message|}}
           <span class="validation-error-message">
-            {{v-get this "courseTitle" "message"}}
+            {{message}}
           </span>
-        {{/if}}
+        {{/each}}
       </EditableField>
+    {{else}}
+      <h2>
+        {{#if @course.locked}}
+          <FaIcon @icon="lock" />
+        {{/if}}
+        {{@course.title}}
+      </h2>
     {{/if}}
-  {{else if @course}}
-    <h2>
-      {{@course.title}}
-    </h2>
-  {{/if}}
-  <h4>
-    {{@course.academicYear}}
-  </h4>
-</span>
-<span class="course-publication">
-  {{#if @editable}}
-    <PublishMenu
-      @title={{this.menuTitle}}
-      @icon={{this.menuIcon}}
-      @publicationStatus={{this.publicationStatus}}
-      @showAsIs={{this.showAsIs}}
-      @showPublish={{this.showPublish}}
-      @showReview={{this.showReview}}
-      @showTbd={{this.showTbd}}
-      @showUnPublish={{this.showUnPublish}}
-      @reviewRoute="course.publication_check"
-      @reviewObject={{@course}}
-      @publishTranslation="general.publishCourse"
-      @unPublishTranslation="general.unPublishCourse"
-      @publish={{action "publish"}}
-      @publishAsTbd={{action "publishAsTbd"}}
-      @unpublish={{action "unpublish"}}
-    />
-  {{else}}
-    <PublicationStatus @item={{@course}} />
-  {{/if}}
-</span>
+    <h3>
+      {{@course.academicYear}}
+    </h3>
+  </span>
+  <span class="course-publication">
+    {{#if @editable}}
+      <Course::PublicationMenu @course={{@course}} />
+    {{else}}
+      <PublicationStatus @item={{@course}} />
+    {{/if}}
+  </span>
+</div>

--- a/addon/components/course-header.js
+++ b/addon/components/course-header.js
@@ -10,6 +10,7 @@ export default class CourseHeaderComponent extends Component {
 
   @restartableTask
   *changeTitle() {
+    this.courseTitle = this.courseTitle.trim();
     this.addErrorDisplayFor('courseTitle');
     const isValid = yield this.isValid('courseTitle');
     if (!isValid) {

--- a/addon/components/course/publication-menu.hbs
+++ b/addon/components/course/publication-menu.hbs
@@ -1,0 +1,100 @@
+<div
+  role="menubar"
+  class="publish-menu {{this.publicationStatus}}"
+  data-test-course-publication-menu
+  {{handle-click-outside (set this.isOpen false)}}
+>
+  <button
+    aria-label={{this.title}}
+    role="menuitem"
+    class="toggle"
+    aria-haspopup="true"
+    aria-expanded={{if this.isOpen "true" "false"}}
+    data-test-toggle
+    {{on "click" (toggle "isOpen" this)}}
+    {{on "keydown" (fn this.toggleMenu)}}
+  >
+    <FaIcon @icon={{this.icon}} />
+    <span>
+      {{this.title}}
+    </span>
+  </button>
+  {{#if this.isOpen}}
+    <div
+      class="menu"
+      role="menu"
+      {{ref this "menuElement"}}
+      {{did-insert this.focusOnFirstItem}}
+      data-test-menu
+    >
+      {{#if this.showAsIs}}
+        <button
+          class="danger"
+          role="menuitemradio"
+          tabindex="-1"
+          {{on "click" this.publish}}
+          {{on "keydown" (fn this.moveFocus)}}
+          {{on "mouseenter" (fn this.clearFocus)}}
+          data-test-publish-as-is
+        >
+          {{t "general.publishAsIs"}}
+        </button>
+      {{/if}}
+      {{#if this.showPublish}}
+        <button
+          class="good"
+          role="menuitemradio"
+          tabindex="-1"
+          {{on "click" this.publish}}
+          {{on "keydown" (fn this.moveFocus)}}
+          {{on "mouseenter" (fn this.clearFocus)}}
+          data-test-publish
+        >
+          {{t "general.publishCourse"}}
+        </button>
+      {{/if}}
+      {{#if this.showReview}}
+        <button
+          class="good"
+          role="menuitemradio"
+          tabindex="-1"
+          {{on "click" this.scrollToCoursePublication}}
+          {{on "keydown" (fn this.moveFocus)}}
+          {{on "mouseenter" (fn this.clearFocus)}}
+          data-test-review
+        >
+          {{t
+            "general.reviewMissingItems"
+            count=(get @course "allPublicationIssuesLength")
+          }}
+        </button>
+      {{/if}}
+      {{#if this.showTbd}}
+        <button
+          class="good"
+          role="menuitemradio"
+          tabindex="-1"
+          {{on "click" this.publishAsTbd}}
+          {{on "keydown" (fn this.moveFocus)}}
+          {{on "mouseenter" (fn this.clearFocus)}}
+          data-test-tbd
+        >
+          {{t "general.markAsScheduled"}}
+        </button>
+      {{/if}}
+      {{#if this.showUnPublish}}
+        <button
+          class="danger"
+          role="menuitemradio"
+          tabindex="-1"
+          {{on "click" this.unpublish}}
+          {{on "keydown" (fn this.moveFocus)}}
+          {{on "mouseenter" (fn this.clearFocus)}}
+          data-test-un-publish
+        >
+          {{t "general.unPublishCourse"}}
+        </button>
+      {{/if}}
+    </div>
+  {{/if}}
+</div>

--- a/addon/components/course/publication-menu.js
+++ b/addon/components/course/publication-menu.js
@@ -1,0 +1,146 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import scrollIntoView from 'scroll-into-view';
+
+export default class CoursePublicationMenuComponent extends Component {
+  @service router;
+  @service intl;
+  @service flashMessages;
+  @tracked isOpen = false;
+
+  get title(){
+    if(this.args.course.publishedAsTbd){
+      return this.intl.t('general.scheduled');
+    }
+    if(this.args.course.published){
+      return this.intl.t('general.published');
+    }
+    return this.intl.t('general.notPublished');
+  }
+  get icon(){
+    if(this.args.course.publishedAsTbd){
+      return 'clock';
+    }
+    if(this.args.course.published){
+      return 'star';
+    }
+    return 'cloud';
+  }
+
+  get showTbd() {
+    return !this.args.course.publishedAsTbd;
+  }
+  get showAsIs(){
+    return (
+      (!this.args.course.published || this.args.course.publishedAsTbd) &&
+      this.args.course.requiredPublicationIssues.length === 0 &&
+      this.args.course.allPublicationIssuesLength !== 0
+    );
+  }
+  get showReview() {
+    if (this.router.currentRouteName === 'course.publication_check') {
+      return false;
+    }
+    return this.args.course.allPublicationIssuesLength > 0;
+  }
+  get showPublish(){
+    return (
+      (!this.args.course.published || this.args.course.publishedAsTbd) &&
+      this.args.course.allPublicationIssuesLength === 0
+    );
+  }
+  get showUnPublish() {
+    return this.args.course.published || this.args.course.publishedAsTbd;
+  }
+  get publicationStatus(){
+    if(this.args.course.publishedAsTbd){
+      return 'scheduled';
+    } else if (this.args.course.published){
+      return 'published';
+    }
+
+    return 'notpublished';
+  }
+
+  focusOnFirstItem(menuElement) {
+    menuElement.querySelector('button:first-of-type').focus();
+  }
+
+  @action
+  moveFocus({ key, target }) {
+    switch (key) {
+    case 'ArrowDown':
+      if (target.nextElementSibling) {
+        target.nextElementSibling.focus();
+      } else {
+        this.menuElement.querySelector('button:nth-of-type(1)').focus();
+      }
+      break;
+    case 'ArrowUp':
+      if (target.previousElementSibling) {
+        target.previousElementSibling.focus();
+      } else {
+        this.menuElement.querySelector('button:last-of-type').focus();
+      }
+      break;
+    case 'Escape':
+    case 'Tab':
+    case 'ArrowRight':
+    case 'ArrowLeft':
+      this.isOpen = false;
+      break;
+    }
+  }
+  @action
+  clearFocus() {
+    const buttons = this.menuElement.querySelectorAll('button');
+    buttons.forEach(el => el.blur());
+  }
+  @action
+  toggleMenu({ key }) {
+    switch (key) {
+    case 'ArrowDown':
+      this.isOpen = true;
+      break;
+    case 'Escape':
+    case 'Tab':
+    case 'ArrowRight':
+    case 'ArrowLeft':
+      this.isOpen = false;
+      break;
+    }
+  }
+
+  @action
+  scrollToCoursePublication() {
+    this.isOpen = false;
+    this.router.transitionTo('course.publication_check', this.args.course);
+    scrollIntoView('.course-publicationcheck');
+  }
+  @action
+  async publish() {
+    this.isOpen = false;
+    this.args.course.set('publishedAsTbd', false);
+    this.args.course.set('published', true);
+    await this.args.course.save();
+    this.flashMessages.success('general.publishedSuccessfully');
+  }
+  @action
+  async unpublish() {
+    this.isOpen = false;
+    this.args.course.set('publishedAsTbd', false);
+    this.args.course.set('published', false);
+    await this.args.course.save();
+    this.flashMessages.success('general.unPublishedSuccessfully');
+  }
+  @action
+  async publishAsTbd() {
+    this.isOpen = false;
+    this.args.course.set('publishedAsTbd', true);
+    this.args.course.set('published', true);
+    await this.args.course.save();
+    this.flashMessages.success('general.scheduledSuccessfully');
+  }
+}

--- a/addon/decorators/validation.js
+++ b/addon/decorators/validation.js
@@ -1,11 +1,13 @@
 import { BeforeDate }  from './validation/before-date';
 import { AfterDate }  from './validation/after-date';
 import { Length }  from './validation/length';
+import { NotBlank }  from './validation/not-blank';
 import { validatable } from './validation/validatable';
 
 export {
   AfterDate,
   BeforeDate,
   Length,
+  NotBlank,
   validatable
 };

--- a/addon/decorators/validation/length.js
+++ b/addon/decorators/validation/length.js
@@ -14,6 +14,8 @@ export function Length(min, max, validationOptions) {
           if (!constraints || constraints.length < 2) {
             throw new Error(`You must pass a min and max length to the Length validator on ${property}`);
           }
+          value = value || '';
+          value = value.trim();
           if (!value) {
             return true;
           }

--- a/addon/decorators/validation/not-blank.js
+++ b/addon/decorators/validation/not-blank.js
@@ -1,0 +1,25 @@
+import { registerDecorator } from "class-validator";
+import { getOwner } from '@ember/application';
+
+export function NotBlank(validationOptions) {
+  return function (object, propertyName) {
+    registerDecorator({
+      name: 'notBlank',
+      target: object.constructor,
+      propertyName: propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value) {
+          return value !== null && value !== undefined && value !== '';
+        },
+        defaultMessage({ object: target }) {
+          const owner = getOwner(target);
+          const intl = owner.lookup('service:intl');
+          const description = intl.t('errors.description');
+
+          return intl.t('errors.blank', { description });
+        }
+      },
+    });
+  };
+}

--- a/addon/decorators/validation/not-blank.js
+++ b/addon/decorators/validation/not-blank.js
@@ -10,7 +10,7 @@ export function NotBlank(validationOptions) {
       options: validationOptions,
       validator: {
         validate(value) {
-          return value !== null && value !== undefined && value !== '';
+          return value !== null && value !== undefined && value.trim() !== '';
         },
         defaultMessage({ object: target }) {
           const owner = getOwner(target);

--- a/app/components/course/publication-menu.js
+++ b/app/components/course/publication-menu.js
@@ -1,0 +1,1 @@
+export { default } from 'ilios-common/components/course/publication-menu';

--- a/app/styles/ilios-common/components/course-header.scss
+++ b/app/styles/ilios-common/components/course-header.scss
@@ -18,7 +18,8 @@
     }
 
     .editable,
-    h4 {
+    h2,
+    h3 {
       display: block;
       font-size: 1.5rem;
 
@@ -28,8 +29,8 @@
     }
 
     @include for-tablet-and-up {
-      h4 {
-        margin-left: 1rem;
+      h3 {
+        margin-left: .5rem;
       }
     }
   }

--- a/app/styles/ilios-common/components/publish-menu.scss
+++ b/app/styles/ilios-common/components/publish-menu.scss
@@ -35,14 +35,20 @@
       text-decoration: none;
       white-space: nowrap;
 
-      &.danger:hover {
-        background-color: $ilios-red;
-        color: $white;
+      &.danger {
+        &:hover,
+        &:focus {
+          background-color: $ilios-red;
+          color: $white;
+        }
       }
 
-      &.good:hover {
-        background-color: $ilios-green;
-        color: $white;
+      &.good {
+        &:hover,
+        &:focus {
+          background-color: $ilios-green;
+          color: $white;
+        }
       }
     }
   }

--- a/tests/acceptance/course/publish-test.js
+++ b/tests/acceptance/course/publish-test.js
@@ -1,6 +1,5 @@
 import {
   click,
-  currentRouteName,
   visit,
   findAll
 } from '@ember/test-helpers';
@@ -20,93 +19,6 @@ module('Acceptance | Course - Publish', function(hooks) {
     this.user = await setupAuthentication();
     this.school = this.server.create('school');
     this.server.create('cohort');
-  });
-
-  test('check published course', async function(assert) {
-    this.user.update({ administeredSchools: [this.school] });
-    this.server.create('course', {
-      year: 2013,
-      schoolId: 1,
-      published: true,
-      cohortIds: [1],
-    });
-    this.server.create('course', {
-      year: 2013,
-      schoolId: 1,
-      published: true,
-      publishedAsTbd: true,
-      cohortIds: [1],
-    });
-    this.server.create('course', {
-      year: 2013,
-      schoolId: 1,
-      cohortIds: [1],
-    });
-    await visit('/courses/1');
-
-    assert.equal(currentRouteName(), 'course.index');
-    const menu = '[data-test-course-header] .publish-menu';
-    const selector = `${menu} [data-test-toggle]`;
-    const choices = `${menu} [data-test-menu] button`;
-    assert.equal(await getElementText(selector), getText('Published'));
-    //we have to click the button to create the options
-    await click(selector);
-    const items = findAll(choices);
-    assert.equal(items.length, 3);
-    const expectedItems = ['Review 3 Missing Items', 'Mark as Scheduled', 'UnPublish Course'];
-    for(let i = 0; i < items.length; i++){
-      assert.equal(await getElementText(items[i]), getText(expectedItems[i]));
-    }
-  });
-
-  test('check scheduled course', async function(assert) {
-    this.user.update({ administeredSchools: [this.school] });
-    this.server.create('course', {
-      year: 2013,
-      schoolId: 1,
-      published: true,
-      publishedAsTbd: true,
-      cohortIds: [1],
-    });
-    await visit('/courses/1');
-
-    assert.equal(currentRouteName(), 'course.index');
-    const menu = '[data-test-course-header] .publish-menu';
-    const selector = `${menu} [data-test-toggle]`;
-    const choices = `${menu} [data-test-menu] button`;
-    assert.equal(await getElementText(selector), getText('Scheduled'));
-    //we have to click the button to create the options
-    await click(selector);
-    const items = findAll(choices);
-    assert.equal(items.length, 3);
-    const expectedItems = ['Publish As-is', 'Review 3 Missing Items', 'UnPublish Course'];
-    for(let i = 0; i < items.length; i++){
-      assert.equal(await getElementText(items[i]), getText(expectedItems[i]));
-    }
-  });
-
-  test('check draft course', async function(assert) {
-    this.user.update({ administeredSchools: [this.school] });
-    this.server.create('course', {
-      year: 2013,
-      schoolId: 1,
-      cohortIds: [1],
-    });
-    await visit('/courses/1');
-
-    assert.equal(currentRouteName(), 'course.index');
-    const menu = '[data-test-course-header] .publish-menu';
-    const selector = `${menu} [data-test-toggle]`;
-    const choices = `${menu} [data-test-menu] button`;
-    assert.equal(await getElementText(selector), getText('Not Published'));
-    //we have to click the button to create the options
-    await click(selector);
-    const items = findAll(choices);
-    assert.equal(items.length, 3);
-    const expectedItems = ['Publish As-is', 'Review 3 Missing Items', 'Mark as Scheduled'];
-    for(let i = 0; i < items.length; i++){
-      assert.equal(await getElementText(items[i]), getText(expectedItems[i]));
-    }
   });
 
   test('check publish draft course', async function(assert) {

--- a/tests/integration/components/course-header-test.js
+++ b/tests/integration/components/course-header-test.js
@@ -81,6 +81,36 @@ module('Integration | Component | course-header', function(hooks) {
     assert.ok(component.title.hasError);
   });
 
+  test('course title validation fails if value is too short, ignoring whitespace', async function (assert) {
+    const course = this.server.create('course');
+    const courseModel = await this.store.find('course', course.id);
+    this.set('course', courseModel);
+    await render(hbs`<CourseHeader @course={{course}} @editable={{true}} />`);
+
+    assert.ok(component.title.isVisible);
+    assert.equal(component.title.value, 'course 0');
+    await component.title.edit();
+    assert.notOk(component.title.hasError);
+    await component.title.set('         ab              ');
+    await component.title.save();
+    assert.ok(component.title.hasError);
+  });
+
+  test('course title validation fails if value is blank string of any length', async function (assert) {
+    const course = this.server.create('course');
+    const courseModel = await this.store.find('course', course.id);
+    this.set('course', courseModel);
+    await render(hbs`<CourseHeader @course={{course}} @editable={{true}} />`);
+
+    assert.ok(component.title.isVisible);
+    assert.equal(component.title.value, 'course 0');
+    await component.title.edit();
+    assert.notOk(component.title.hasError);
+    await component.title.set('                       ');
+    await component.title.save();
+    assert.ok(component.title.hasError);
+  });
+
   test('cancel course title changes', async function(assert) {
     const course = this.server.create('course');
     const courseModel = await this.store.find('course', course.id);

--- a/tests/integration/components/course-header-test.js
+++ b/tests/integration/components/course-header-test.js
@@ -1,0 +1,97 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import a11yAudit from 'ember-a11y-testing/test-support/audit';
+import { component } from 'ilios-common/page-objects/components/course-header';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+
+module('Integration | Component | course-header', function(hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    this.store = this.owner.lookup('service:store');
+  });
+
+  test('it renders and is accessible', async function (assert) {
+    const course = this.server.create('course', {
+      published: true
+    });
+    const courseModel = await this.store.find('course', course.id);
+    this.set('course', courseModel);
+    await render(hbs`<CourseHeader @course={{course}} @editable={{true}} />`);
+    await a11yAudit(this.element);
+    assert.ok(true, 'not a11y violations');
+  });
+
+  test('it renders and is accessible when not editable', async function (assert) {
+    const course = this.server.create('course', {
+      published: true
+    });
+    const courseModel = await this.store.find('course', course.id);
+    this.set('course', courseModel);
+    await render(hbs`<CourseHeader @course={{course}} @editable={{false}} />`);
+    await a11yAudit(this.element);
+    assert.ok(true, 'not a11y violations');
+  });
+
+  test('course title validation fails if value is empty', async function(assert) {
+    const course = this.server.create('course');
+    const courseModel = await this.store.find('course', course.id);
+    this.set('course', courseModel);
+    await render(hbs`<CourseHeader @course={{course}} @editable={{true}} />`);
+
+    assert.ok(component.title.isVisible);
+    assert.equal(component.title.value, 'course 0');
+    await component.title.edit();
+    assert.notOk(component.title.hasError);
+    await component.title.set('');
+    await component.title.save();
+    assert.ok(component.title.hasError);
+  });
+
+  test('course title validation fails if value is too short', async function(assert) {
+    const course = this.server.create('course');
+    const courseModel = await this.store.find('course', course.id);
+    this.set('course', courseModel);
+    await render(hbs`<CourseHeader @course={{course}} @editable={{true}} />`);
+
+    assert.ok(component.title.isVisible);
+    assert.equal(component.title.value, 'course 0');
+    await component.title.edit();
+    assert.notOk(component.title.hasError);
+    await component.title.set('a');
+    await component.title.save();
+    assert.ok(component.title.hasError);
+  });
+
+  test('course title validation fails if value is too long', async function (assert) {
+    const course = this.server.create('course');
+    const courseModel = await this.store.find('course', course.id);
+    this.set('course', courseModel);
+    await render(hbs`<CourseHeader @course={{course}} @editable={{true}} />`);
+
+    assert.ok(component.title.isVisible);
+    assert.equal(component.title.value, 'course 0');
+    await component.title.edit();
+    assert.notOk(component.title.hasError);
+    await component.title.set('tooLong'.repeat(50));
+    await component.title.save();
+    assert.ok(component.title.hasError);
+  });
+
+  test('cancel course title changes', async function(assert) {
+    const course = this.server.create('course');
+    const courseModel = await this.store.find('course', course.id);
+    this.set('course', courseModel);
+    await render(hbs`<CourseHeader @course={{course}} @editable={{true}} />`);
+
+    assert.ok(component.title.isVisible);
+    assert.equal(component.title.value, 'course 0');
+    await component.title.edit();
+    await component.title.set('blue fish');
+    await component.title.cancel();
+    assert.equal(component.title.value, 'course 0');
+  });
+});

--- a/tests/integration/components/course/publication-menu-test.js
+++ b/tests/integration/components/course/publication-menu-test.js
@@ -1,0 +1,186 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { component } from 'ilios-common/page-objects/components/course/publication-menu';
+import a11yAudit from 'ember-a11y-testing/test-support/audit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+
+module('Integration | Component | course/publication-menu', function(hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  test('it renders and is accessible for draft course', async function (assert) {
+    this.server.create('course');
+    const courseModel = await this.owner.lookup('service:store').find('course', 1);
+    this.set('course', courseModel);
+    await render(hbs`<Course::PublicationMenu @course={{this.course}} />`);
+
+    await a11yAudit(this.element, {
+      rules: {
+        'color-contrast': {
+          enabled: false
+        }
+      }
+    });
+    assert.equal(component.text, 'Not Published');
+    await component.toggle.click();
+    await a11yAudit(this.element, {
+      rules: {
+        'color-contrast': {
+          enabled: false
+        }
+      }
+    });
+    assert.ok(true, 'no a11y errors found!');
+  });
+
+  test('it renders and is accessible for scheduled course', async function (assert) {
+    this.server.create('course', {
+      published: true,
+      publishedAsTbd: true,
+    });
+    const courseModel = await this.owner.lookup('service:store').find('course', 1);
+    this.set('course', courseModel);
+    await render(hbs`<Course::PublicationMenu @course={{this.course}} />`);
+
+    await a11yAudit(this.element);
+    assert.equal(component.text, 'Scheduled');
+    await component.toggle.click();
+    await a11yAudit(this.element);
+    assert.ok(true, 'no a11y errors found!');
+  });
+
+  test('it renders and is accessible for published course', async function (assert) {
+    this.server.create('course', {
+      published: true,
+      publishedAsTbd: false,
+    });
+    const courseModel = await this.owner.lookup('service:store').find('course', 1);
+    this.set('course', courseModel);
+    await render(hbs`<Course::PublicationMenu @course={{this.course}} />`);
+
+    await a11yAudit(this.element);
+    assert.equal(component.text, 'Published');
+    await component.toggle.click();
+    await a11yAudit(this.element);
+    assert.ok(true, 'no a11y errors found!');
+  });
+
+  test('click opens menu', async function(assert) {
+    this.server.create('course');
+    const courseModel = await this.owner.lookup('service:store').find('course', 1);
+    this.set('course', courseModel);
+    await render(hbs`<Course::PublicationMenu @course={{this.course}} />`);
+    assert.ok(component.menuClosed);
+    await component.toggle.click();
+    assert.ok(component.menuOpen);
+  });
+
+  test('correct actions for unpublished course', async function(assert) {
+    this.server.create('course');
+    const courseModel = await this.owner.lookup('service:store').find('course', 1);
+    this.set('course', courseModel);
+    await render(hbs`<Course::PublicationMenu @course={{this.course}} />`);
+    await component.toggle.click();
+    assert.ok(component.menuOpen);
+    assert.notOk(component.hasPublishAsIs);
+    assert.notOk(component.hasPublish);
+    assert.ok(component.hasReview);
+    assert.ok(component.hasTbd);
+    assert.notOk(component.hasUnPublish);
+  });
+
+  test('correct actions for unpublished course with required cohort', async function (assert) {
+    const cohort = this.server.create('cohort');
+    this.server.create('course', {
+      cohorts: [cohort],
+    });
+    const courseModel = await this.owner.lookup('service:store').find('course', 1);
+    this.set('course', courseModel);
+    await render(hbs`<Course::PublicationMenu @course={{this.course}} />`);
+    await component.toggle.click();
+    assert.ok(component.menuOpen);
+    assert.ok(component.hasPublishAsIs);
+    assert.notOk(component.hasPublish);
+    assert.ok(component.hasReview);
+    assert.ok(component.hasTbd);
+    assert.notOk(component.hasUnPublish);
+  });
+
+  test('correct actions for scheduled course', async function(assert) {
+    this.server.create('course', {
+      published: true,
+      publishedAsTbd: true,
+    });
+    const courseModel = await this.owner.lookup('service:store').find('course', 1);
+    this.set('course', courseModel);
+    await render(hbs`<Course::PublicationMenu @course={{this.course}} />`);
+    await component.toggle.click();
+    assert.ok(component.menuOpen);
+    assert.notOk(component.hasPublishAsIs);
+    assert.notOk(component.hasPublish);
+    assert.ok(component.hasReview);
+    assert.notOk(component.hasTbd);
+    assert.ok(component.hasUnPublish);
+  });
+
+  test('correct actions for scheduled course with required cohort', async function (assert) {
+    const cohort = this.server.create('cohort');
+    this.server.create('course', {
+      cohorts: [cohort],
+      published: true,
+      publishedAsTbd: true,
+    });
+    const courseModel = await this.owner.lookup('service:store').find('course', 1);
+    this.set('course', courseModel);
+    await render(hbs`<Course::PublicationMenu @course={{this.course}} />`);
+    await component.toggle.click();
+    assert.ok(component.menuOpen);
+    assert.ok(component.hasPublishAsIs);
+    assert.notOk(component.hasPublish);
+    assert.ok(component.hasReview);
+    assert.notOk(component.hasTbd);
+    assert.ok(component.hasUnPublish);
+  });
+
+  test('correct actions for published course', async function(assert) {
+    this.server.create('course', {
+      published: true,
+      publishedAsTbd: false,
+    });
+    const courseModel = await this.owner.lookup('service:store').find('course', 1);
+    this.set('course', courseModel);
+    await render(hbs`<Course::PublicationMenu @course={{this.course}} />`);
+    await component.toggle.click();
+    assert.ok(component.menuOpen);
+    assert.notOk(component.hasPublishAsIs);
+    assert.notOk(component.hasPublish);
+    assert.ok(component.hasReview);
+    assert.ok(component.hasTbd);
+    assert.ok(component.hasUnPublish);
+  });
+
+  test('down opens menu', async function(assert) {
+    this.server.create('course');
+    const courseModel = await this.owner.lookup('service:store').find('course', 1);
+    this.set('course', courseModel);
+    await render(hbs`<Course::PublicationMenu @course={{this.course}} />`);
+
+    assert.ok(component.menuClosed);
+    await component.toggle.down();
+    assert.ok(component.menuOpen);
+  });
+
+  test('escape closes menu', async function(assert) {
+    this.server.create('course');
+    const courseModel = await this.owner.lookup('service:store').find('course', 1);
+    this.set('course', courseModel);
+    await render(hbs`<Course::PublicationMenu @course={{this.course}} />`);
+
+    await component.toggle.down();
+    assert.ok(component.menuOpen);
+    await component.toggle.esc();
+    assert.ok(component.menuClosed);
+  });
+});


### PR DESCRIPTION
Unwraps some previously shared publish menu functionality in order to avoid a mixin and creates a publish course component instead. Also fixes some layout problems with locked courses.

It turns out our existing brown scheduled course color doesn't have enough contrast, but I've allowed that to pass here anyway.