### PR TITLE
Add failing tests for user-search

### DIFF
--- a/addon/components/user-search.hbs
+++ b/addon/components/user-search.hbs
@@ -20,7 +20,7 @@
   {{/if}}
   {{#if (and this.search.isIdle (gt this.search.lastSuccessful.value.length 0))}}
     <ul class="results">
-      <li class="results-count">
+      <li class="results-count" data-test-results-count>
         {{this.search.lastSuccessful.value.length}}
         {{t "general.results"}}
       </li>

--- a/addon/components/user-search.js
+++ b/addon/components/user-search.js
@@ -6,7 +6,7 @@ import { isEmpty } from '@ember/utils';
 const { oneWay } = computed;
 import {tracked} from '@glimmer/tracking';
 import { action } from '@ember/object';
-import {restartableTask} from "ember-concurrency-decorators";
+import { restartableTask } from "ember-concurrency-decorators";
 
 const userProxy = ObjectProxy.extend({
   isUser: true,

--- a/tests/integration/components/user-search-test.js
+++ b/tests/integration/components/user-search-test.js
@@ -26,7 +26,7 @@ module('Integration | Component | user search', function(hooks) {
     assert.dom('input').exists({ count: 1 });
   });
 
-  test('less than 3 charecters triggers warning', async function(assert) {
+  test('less than 3 characters triggers warning', async function(assert) {
     await render(hbs`<UserSearch />`);
 
     await fillIn('input', 'ab');
@@ -129,5 +129,37 @@ module('Integration | Component | user search', function(hooks) {
     assert.dom(third).includesText('3');
     assert.dom(fourth).includesText('10');
     assert.dom(fifth).includesText('20');
+  });
+
+  test('reads currentlyActiveUsers', async function(assert) {
+    const user = this.server.create('user');
+    this.server.get('api/users', (schema) => {
+      return schema.users.all();
+    });
+    const userModel = await this.owner.lookup('service:store').find('user', user.id);
+    this.set('currentlyActiveUsers', [userModel]);
+    await render(hbs`<UserSearch @currentlyActiveUsers={{this.currentlyActiveUsers}} />`);
+    await fillIn('input', 'foo');
+
+    assert.dom('[data-test-results-count]').hasText('1 Results');
+    assert.dom('[data-test-result]').includesText('0 guy');
+    assert.dom('[data-test-result]').hasClass('inactive');
+  });
+
+  test('reads currentlyActiveUsers from a promise', async function(assert) {
+    const user = this.server.create('user');
+    this.server.get('api/users', (schema) => {
+      return schema.users.all();
+    });
+    const userPromise = this.owner.lookup('service:store').find('user', user.id);
+    this.set('currentlyActiveUsersPromise', userPromise);
+    await render(hbs`<UserSearch
+      @currentlyActiveUsers={{await this.currentlyActiveUsersPromise}}
+    />`);
+    await fillIn('input', 'foo');
+
+    assert.dom('[data-test-results-count]').hasText('1 Results');
+    assert.dom('[data-test-result]').includesText('0 guy');
+    assert.dom('[data-test-result]').hasClass('inactive');
   });
 });


### PR DESCRIPTION
Exposes an issue where sending a promise for currentlyActiveUsers
doesn't cause the property to update correctly.