### PR TITLE
Do not cache ilios app config

### DIFF
--- a/addon/services/ilios-config.js
+++ b/addon/services/ilios-config.js
@@ -5,17 +5,13 @@ import { isPresent } from '@ember/utils';
 export default Service.extend({
   fetch: service(),
   serverVariables: service(),
-  _configPromise: null,
 
   config: computed('apiHost', function () {
     return this.getConfig();
   }),
-  async getConfig() {
-    if (!this._configPromise) {
-      this._configPromise = this.fetch.getJsonFromApiHost('/application/config');
-    }
-    const config = await this._configPromise;
-    return config;
+
+  getConfig() {
+    return this.fetch.getJsonFromApiHost('/application/config');
   },
 
   async itemFromConfig(key) {


### PR DESCRIPTION
this rolls back the changes introduces by #1010.

i suspect that those changes are responsible for the shibboleth-based authn failures we've been seeing in production, although the code looks good to me atm.

see https://github.com/ilios/frontend/pull/5007