### PR TITLE
Fix file upload button display

### DIFF
--- a/app/styles/ilios-common/components/learning-material-uploader.scss
+++ b/app/styles/ilios-common/components/learning-material-uploader.scss
@@ -5,8 +5,9 @@
     border-radius: $base-border-radius;
     color: $text-grey;
     cursor: pointer;
+    display: inline-block;
     font-size: 1rem;
-    padding: .1em 1em;
+    padding: .3em 1em;
     &:hover {
       background-color: $dark-grey;
       color: $white;


### PR DESCRIPTION
Added padding to make it look like other buttons.

The label was squished into the button because the button isn't real,
it's a span.