### PR TITLE
Stop removing focus outline from buttons

### DIFF
--- a/app/styles/ilios-common/components/dashboard-view-picker.scss
+++ b/app/styles/ilios-common/components/dashboard-view-picker.scss
@@ -31,9 +31,5 @@
     &.active {
       background-color: $ilios-green;
     }
-
-    &:focus {
-      outline: 0;
-    }
   }
 }

--- a/app/styles/ilios-common/components/single-event-objective-list.scss
+++ b/app/styles/ilios-common/components/single-event-objective-list.scss
@@ -4,10 +4,6 @@
     &.active {
       background-color: $ilios-green;
     }
-
-    &:focus {
-      outline: 0;
-    }
   }
 
   .list-in-order {


### PR DESCRIPTION
This is important for a11y keyboard navigation.