### PR TITLE
Fix a11y issue with download icons

### DIFF
--- a/addon/components/single-event-learningmaterial-list.hbs
+++ b/addon/components/single-event-learningmaterial-list.hbs
@@ -22,11 +22,21 @@
               {{/if}}
               {{#if lm.absoluteFileUri}}
                 {{#if (eq lm.mimetype "application/pdf")}}
-                  <a href="{{lm.absoluteFileUri}}?inline">
+                  <a id={{concat this.uniqueId lm.id "lm"}} href="{{lm.absoluteFileUri}}?inline">
                     {{lm.title}}
                   </a>
-                  <a target="_blank" href={{lm.absoluteFileUri}} rel="noopener">
-                    <FaIcon @icon="download" @title={{t "general.download"}} />
+                  <a
+                    id={{concat this.uniqueId lm.id "lmdownload"}}
+                    target="_blank"
+                    href={{lm.absoluteFileUri}}
+                    rel="noopener"
+                    aria-label={{t "general.download"}}
+                    aria-labelledby="
+                      {{concat this.uniqueId lm.id "lmdownload"}}
+                      {{concat this.uniqueId lm.id "lm"}}
+                    "
+                  >
+                    <FaIcon @icon="download" />
                   </a>
                 {{else}}
                   <a target="_blank" href={{lm.absoluteFileUri}} rel="noopener">

--- a/addon/components/single-event-learningmaterial-list.js
+++ b/addon/components/single-event-learningmaterial-list.js
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+import { guidFor } from '@ember/object/internals';
+import { tracked } from '@glimmer/tracking';
+
+export default class SingleEventLearningmaterialListComponent extends Component {
+  @tracked uniqueId;
+  constructor() {
+    super(...arguments);
+    this.uniqueId = guidFor(this);
+  }
+}

--- a/tests/integration/components/single-event-learningmaterial-list-test.js
+++ b/tests/integration/components/single-event-learningmaterial-list-test.js
@@ -2,12 +2,13 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Integration | Component | ilios calendar single event learningmaterial list', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function(assert) {
-    assert.expect(10);
+    assert.expect(11);
 
     this.set('learningMaterials', [
       {title: 'first one', mimetype: 'application/pdf', absoluteFileUri: 'http://firstlink'},
@@ -16,7 +17,7 @@ module('Integration | Component | ilios calendar single event learningmaterial l
     ]);
     await render(hbs`<SingleEventLearningmaterialList @learningMaterials={{learningMaterials}} />`);
 
-    assert.dom('li:nth-of-type(1) .single-event-learningmaterial-item-title').hasText('first one Download');
+    assert.dom('li:nth-of-type(1) .single-event-learningmaterial-item-title').hasText('first one');
     assert.dom('li:nth-of-type(1) .fa-file-pdf').exists('LM type icon is present.');
     assert.dom('li:nth-of-type(1) a').hasAttribute('href', 'http://firstlink?inline');
     assert.dom('li:nth-of-type(1) a:nth-of-type(1)').hasAttribute('href', 'http://firstlink?inline');
@@ -26,14 +27,18 @@ module('Integration | Component | ilios calendar single event learningmaterial l
     assert.dom('li:nth-of-type(2) a').hasAttribute('href','http://secondlink');
     assert.dom('li:nth-of-type(3) .single-event-learningmaterial-item-title').hasText('third one');
     assert.dom('li:nth-of-type(3) .fa-clock').exists('LM type icon is present.');
+    await a11yAudit(this.element);
+    assert.ok(true, 'no a11y errors found!');
   });
 
   test('displays `None` when provided no content', async function(assert) {
-    assert.expect(1);
+    assert.expect(2);
 
     this.set('learningMaterials', []);
     await render(hbs`<SingleEventLearningmaterialList @learningMaterials={{learningMaterials}} />`);
 
     assert.dom('.no-content').hasText('None');
+    await a11yAudit(this.element);
+    assert.ok(true, 'no a11y errors found!');
   });
 });

--- a/tests/integration/components/single-event-test.js
+++ b/tests/integration/components/single-event-test.js
@@ -5,6 +5,7 @@ import hbs from 'htmlbars-inline-precompile';
 import moment from 'moment';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { component } from 'ilios-common/page-objects/components/single-event';
+import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Integration | Component | ilios calendar single event', function(hooks) {
   setupRenderingTest(hooks);
@@ -15,7 +16,7 @@ module('Integration | Component | ilios calendar single event', function(hooks) 
   });
 
   test('it renders', async function(assert) {
-    assert.expect(22);
+    assert.expect(23);
 
     const now = moment().hour(8).minute(0).second(0);
     const course = this.server.create('course', {
@@ -154,6 +155,8 @@ module('Integration | Component | ilios calendar single event', function(hooks) 
     assert.dom(`${courseObjectivesSelector} ul.tree > li:nth-of-type(1) li:nth-of-type(2)`).hasText('Course Objective A');
     assert.dom(`${courseObjectivesSelector} ul.tree > li:nth-of-type(2)`).containsText('Domain B (Domain B)');
     assert.dom(`${courseObjectivesSelector} ul.tree > li:nth-of-type(2) li:nth-of-type(1)`).hasText('Course Objective C');
+    await a11yAudit(this.element);
+    assert.ok(true, 'no a11y errors found!');
   });
 
   test('unlinked event date and title are displayed', async function(assert) {


### PR DESCRIPTION
Modifies the LM downloads so that the screen reader title combines the
name of the file as well as the word download this matches the same
setup we use on week at a glance materials.