### PR TITLE
Add ember-ref-modifier as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "ember-page-title": "^5.0.1",
     "ember-pikaday": "^2.2.6",
     "ember-promise-helpers": "1.0.9",
+    "ember-ref-modifier": "^0.1.3",
     "ember-simple-auth-token": "^4.0.4",
     "ember-simple-charts": "^2.0.2",
     "ember-simple-set-helper": "^0.1.0",


### PR DESCRIPTION
We're using this in a few places, but we were getting it from somewhere
else and needed to install it directly.