### PR TITLE
Prevent scroll issues

### DIFF
--- a/addon/components/sessions-grid.js
+++ b/addon/components/sessions-grid.js
@@ -55,10 +55,12 @@ export default class SessionsGrid extends Component {
 
   @action
   setScroll() {
-    const isCourseRoute = this.router.currentRouteName === 'course.index';
-    if (isCourseRoute) {
-      const yPos = window.scrollY;
-      this.preserveScroll.set('yPos', yPos === 0 ? null : yPos);
+    if (!this.isDestroying && !this.isDestroyed) {
+      const isCourseRoute = this.router.currentRouteName === 'course.index';
+      if (isCourseRoute) {
+        const yPos = window.scrollY;
+        this.preserveScroll.set('yPos', yPos === 0 ? null : yPos);
+      }
     }
   }
 


### PR DESCRIPTION
This protects the scroll method when it is called after the component is
destroyed (or in the case of tests after the entire container is
destroyed).