### PR TITLE
Temporarily disable tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,9 @@ jobs:
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
     - env: EMBER_TRY_SCENARIO=ember-release
-    - env: EMBER_TRY_SCENARIO=ember-beta
-    - env: EMBER_TRY_SCENARIO=ember-canary
+    # disabled temporarily re: https://github.com/ilios/common/issues/1123
+    # - env: EMBER_TRY_SCENARIO=ember-beta
+    # - env: EMBER_TRY_SCENARIO=ember-canary
 
 script:
   - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO


### PR DESCRIPTION
These are filing due to an unknown condition in ember beta/canary.
Disabling them while we track that down.

Refs #1123