### PR TITLE
Keep track of ILM status in component

### DIFF
--- a/addon-test-support/ilios-common/page-objects/components/offering-form.js
+++ b/addon-test-support/ilios-common/page-objects/components/offering-form.js
@@ -20,7 +20,7 @@ export default {
   hours: fillable('.offering-duration .hours input'),
   minutes: fillable('.offering-duration .minutes input'),
   location: fillable('.room input'),
-  toggleRecurring: clickable('.make-recurring .toggle-yesno .switch-handle'),
+  toggleRecurring: clickable('.make-recurring [data-test-toggle-yesno] [data-test-handle]'),
   recurringWeeks: fillable('.make-recurring-input'),
   learnerGroupManager,
   instructorSelectionManager,

--- a/addon-test-support/ilios-common/page-objects/session.js
+++ b/addon-test-support/ilios-common/page-objects/session.js
@@ -90,24 +90,24 @@ export default create({
     supplemental: {
       scope: '.sessionsupplemental',
       isActive: is(':checked', 'input'),
-      click: clickable('.toggle-yesno .switch-handle'),
+      click: clickable('[data-test-toggle-yesno] [data-test-handle]'),
     },
     specialAttire: {
       scope: '.sessionspecialattire',
       isActive: is(':checked', 'input'),
-      click: clickable('.toggle-yesno .switch-handle'),
+      click: clickable('[data-test-toggle-yesno] [data-test-handle]'),
     },
     specialEquipment: {
       scope: '.sessionspecialequipment',
       isActive: is(':checked', 'input'),
-      click: clickable('.toggle-yesno .switch-handle'),
+      click: clickable('[data-test-toggle-yesno] [data-test-handle]'),
     },
     attendanceRequired: {
       scope: '.sessionattendancerequired',
       isActive: is(':checked', 'input'),
-      click: clickable('.toggle-yesno .switch-handle'),
+      click: clickable('[data-test-toggle-yesno] [data-test-handle]'),
     },
-    toggleIlm: clickable('.toggle-yesno .switch-handle', { scope: '.independentlearningcontrol' }),
+    toggleIlm: clickable('[data-test-toggle-yesno] [data-test-handle]', { scope: '.independentlearningcontrol' }),
     prerequisites: {
       scope: '.prerequisites',
     },

--- a/addon/components/offering-form.hbs
+++ b/addon/components/offering-form.hbs
@@ -150,7 +150,7 @@
         </label>
         <ToggleYesno
           @yes={{this.makeRecurring}}
-          @toggle={{this.toggle-action "makeRecurring" this}}
+          @toggle={{toggle-action "makeRecurring" this}}
         />
         {{#if this.makeRecurring}}
           <div class="make-recurring-options">

--- a/addon/components/session-overview.hbs
+++ b/addon/components/session-overview.hbs
@@ -162,10 +162,9 @@
           <label>{{t "general.independentLearning"}}:</label>
           <span class="independentlearningcontrol-value">
             {{#if @editable}}
-              <ToggleYesno @yes={{@session.isIndependentLearning}} @toggle={{this.saveIndependentLearning}}
-              />
+              <ToggleYesno @yes={{this.isIndependentLearning}} @toggle={{perform this.saveIndependentLearning}} />
             {{else}}
-              {{#if @session.isIndependentLearning}}
+              {{#if this.isIndependentLearning}}
                 <span class="add">{{t "general.yes"}}</span>
               {{else}}
                 <span class="remove">{{t "general.no"}}</span>
@@ -173,7 +172,7 @@
             {{/if}}
           </span>
         </div>
-        {{#if @session.isIndependentLearning}}
+        {{#if this.isIndependentLearning}}
           <div class="sessionilmhours block">
             <label>{{t "general.hours"}}:</label>
             <span>
@@ -346,7 +345,7 @@
             {{/if}}
           </span>
         </div>
-        {{#unless @session.isIndependentLearning}}
+        {{#unless this.isIndependentLearning}}
           <br>
           <div class="sessionassociatedgroups">
             <label>{{t "general.associatedGroups"}}:</label>

--- a/addon/components/toggle-yesno.hbs
+++ b/addon/components/toggle-yesno.hbs
@@ -12,5 +12,5 @@
     data-off={{t "general.no"}}
     {{on "click" (action "click")}}
   ></span>
-  <span class="switch-handle" role="button" {{on "click" (action "click")}}></span>
+  <span class="switch-handle" role="button" {{on "click" this.click}} data-test-handle></span>
 </span>

--- a/tests/integration/components/offering-form-test.js
+++ b/tests/integration/components/offering-form-test.js
@@ -83,7 +83,7 @@ module('Integration | Component | offering form', function(hooks) {
     const thursday = '[data-test-recurring-day-label="4"]';
     const friday = '[data-test-recurring-day-label="5"]';
     const saturday = '[data-test-recurring-day-label="6"]';
-    const toggle = '.make-recurring .toggle-yesno .switch-handle';
+    const toggle = '.make-recurring [data-test-toggle-yesno] [data-test-handle]';
 
     await click(toggle);
     assert.dom(sunday).hasText('Sunday');
@@ -102,7 +102,7 @@ module('Integration | Component | offering form', function(hooks) {
 
     const item = '.make-recurring-input-container';
     const error = `${item} .validation-error-message`;
-    const toggle = '.make-recurring .toggle-yesno .switch-handle';
+    const toggle = '.make-recurring [data-test-toggle-yesno] [data-test-handle]';
 
     await click(toggle);
     assert.dom(error).doesNotExist();
@@ -115,7 +115,7 @@ module('Integration | Component | offering form', function(hooks) {
     const item = '.make-recurring-input-container';
     const error = `${item} .validation-error-message`;
     const input = `${item} input`;
-    const toggle = '.make-recurring .toggle-yesno .switch-handle';
+    const toggle = '.make-recurring [data-test-toggle-yesno] [data-test-handle]';
 
     await click(toggle);
     const save = '.buttons .done';
@@ -130,7 +130,7 @@ module('Integration | Component | offering form', function(hooks) {
 
     const inputs = '.make-recurring-days input';
     const dayToday = moment().day();
-    const toggle = '.make-recurring .toggle-yesno .switch-handle';
+    const toggle = '.make-recurring [data-test-toggle-yesno] [data-test-handle]';
 
     await click(toggle);
     const checkbox = findAll(inputs)[dayToday];
@@ -290,7 +290,7 @@ module('Integration | Component | offering form', function(hooks) {
     const wednesday = moment().add(1, 'week').day(3);
     const thursday = wednesday.clone().add(1, 'day').day();
     const tuesday = wednesday.clone().subtract(1, 'day').day();
-    const toggle = '.make-recurring .toggle-yesno .switch-handle';
+    const toggle = '.make-recurring [data-test-toggle-yesno] [data-test-handle]';
     const startDateInput = '.start-date input';
     const newStartDate = wednesday.toDate();
 
@@ -337,7 +337,7 @@ module('Integration | Component | offering form', function(hooks) {
     const thursday = wednesday.clone().add(1, 'day').day();
     const tuesday = wednesday.clone().subtract(1, 'day').day();
     const weeks = '.make-recurring-input-container input';
-    const toggle = '.make-recurring .toggle-yesno .switch-handle';
+    const toggle = '.make-recurring [data-test-toggle-yesno] [data-test-handle]';
     const startDateInput = '.start-date input';
     const newStartDate = wednesday.toDate();
 


### PR DESCRIPTION
In Ember 3.16 the computed property in the session model isn't getting
re-computed when an ILM is added / removed from the session. Instead of
delegating that to the model we can just track it in session-overview
directly.