### PR TITLE
Silence is-visible deprecation

### DIFF
--- a/tests/dummy/config/deprecation-workflow.js
+++ b/tests/dummy/config/deprecation-workflow.js
@@ -10,5 +10,6 @@ window.deprecationWorkflow.config = {
     { handler: "silence", matchId: "computed-property.override"}, //ember-modal
     { handler: "silence", matchId: "ember-runtime.deprecate-copy-copyable"},
     { handler: "silence", matchId: "computed-property.volatile"},
+    { handler: "silence", matchId: "ember-component.is-visible"},
   ]
 };


### PR DESCRIPTION
This is getting thrown from <LearnerergroupTree> using isVisible, but
we'll refactor that out when we octanify that component so I'm just
silencing it for now.