### PR TITLE
Fix detail filter on calendar

### DIFF
--- a/addon/components/dashboard-calendar.js
+++ b/addon/components/dashboard-calendar.js
@@ -174,7 +174,7 @@ export default class DashboardCalendarComponent extends Component {
   }
 
   get cohorts() {
-    return this.cohortProxies.mapBy('cohort');
+    return this.cohortProxies?.mapBy('cohort');
   }
 
   get filteredEvents() {

--- a/tests/acceptance/dashboard/calendar-test.js
+++ b/tests/acceptance/dashboard/calendar-test.js
@@ -897,4 +897,28 @@ module('Acceptance | Dashboard Calendar', function(hooks) {
     await triggerEvent('[data-test-ilios-calendar-event]>div', 'mouseenter');
     assert.ok(isVisible('.ilios-calendar-event-tooltip'), 'Now shown');
   });
+
+  test('visit with course filters open #5098', async function(assert) {
+    const today = moment().hour(8);
+    this.server.create('userevent', {
+      user: parseInt(this.user.id, 10),
+      startDate: today.format(),
+      endDate: today.clone().add(1, 'hour').format(),
+      cohorts: [{ id: 1 }],
+    });
+    await visit('/dashboard?show=calendar&showFilters=true&courseFilters=true');
+    assert.equal(findAll('div.event').length, 1);
+  });
+
+  test('visit with detail filters open #5098', async function(assert) {
+    const today = moment().hour(8);
+    this.server.create('userevent', {
+      user: parseInt(this.user.id, 10),
+      startDate: today.format(),
+      endDate: today.clone().add(1, 'hour').format(),
+      cohorts: [{ id: 1 }],
+    });
+    await visit('/dashboard?show=calendar&showFilters=true&courseFilters=false');
+    assert.equal(findAll('div.event').length, 1);
+  });
 });


### PR DESCRIPTION
When the page was loaded directly with the detail filter open the
cohortProxies property was not yet set. Since the template looks for
this.cohorts to be an array adding an option chain here returns
undefined until the cohortProxies is set and then returns the array as
intended.

Fixes ilios/frontend#5098