### PR TITLE
Force babel to only work with parallel builds

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -16,6 +16,9 @@ module.exports = function(defaults) {
         }
       }
     },
+    'ember-cli-babel': {
+      throwUnlessParallelizable: true
+    }
   });
 
   /*


### PR DESCRIPTION
This flag ensures we don't include anything that won't build quickly
using all available processors.

This will fail until we get new versions of `ember-simple-set-helper` and `ember-page-title` addons which fix issues that stop parallel builds from working. Opening it anyway as a reminder and to track progress.