### PR TITLE
Fix boolean expression in week-glance.js

### DIFF
--- a/addon/components/week-glance.js
+++ b/addon/components/week-glance.js
@@ -35,7 +35,7 @@ export default class WeeklyGlance extends Component {
   }
 
   get title() {
-    if (!this.midnightAtTheStartOfThisWeek || !this.midnightAtTheStartOfThisWeek) {
+    if (!this.midnightAtTheStartOfThisWeek && !this.midnightAtTheEndOfThisWeek) {
       return '';
     }
 

--- a/addon/components/week-glance.js
+++ b/addon/components/week-glance.js
@@ -35,7 +35,7 @@ export default class WeeklyGlance extends Component {
   }
 
   get title() {
-    if (!this.midnightAtTheStartOfThisWeek && !this.midnightAtTheEndOfThisWeek) {
+    if (!this.midnightAtTheStartOfThisWeek || !this.midnightAtTheEndOfThisWeek) {
       return '';
     }
 


### PR DESCRIPTION
The boolean expression checks .midnightAtTheStartOfThisWeek twice. One of
them was meant to be .midnightAtTheEndOfThisWeek instead.

Boolean OR was used where Boolean AND was meant. (If it is not midnight
at the begining of the week OR it is not midnight at the end of the
week, then the expression will always be TRUE. If AND is used instead, it excludes
midnight at the start or end of the week.)