### PR TITLE
Fix boolean expression in not-blank validation decorator

### DIFF
--- a/addon/decorators/validation/not-blank.js
+++ b/addon/decorators/validation/not-blank.js
@@ -13,7 +13,7 @@ export function NotBlank(validationOptions) {
           if (typeof value === 'string') {
             return value.trim() !== '';
           }
-          return value !== null || value !== undefined;
+          return value !== null && value !== undefined;
         },
         defaultMessage({ object: target }) {
           const owner = getOwner(target);


### PR DESCRIPTION
Boolean OR was used where AND was intended. As previously written, the
expression will always evaluate to TRUE.