### PR TITLE
Don't send cookies with API requests

### DIFF
--- a/addon/adapters/ilios.js
+++ b/addon/adapters/ilios.js
@@ -50,4 +50,19 @@ export default RESTAdapter.extend({
   },
 
   sortQueryParams: false,
+
+  /**
+   * Don't send cookies with API requests
+   * https://github.com/emberjs/data/issues/6413
+   * Providing the 'omit' option to fetch parameters causes it not to send any cookies
+   * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters
+   * this is important for us because we store the JWT in a cookie so if we send cookies it will
+   * send the JWT at least twice (sometimes more depending on the auth options used)
+   */
+  ajaxOptions() {
+    return {
+      ...this._super(...arguments),
+      credentials: 'omit'
+    };
+  },
 });


### PR DESCRIPTION
Limit the unnecessary network traffic of sending the JWT and other
cookies over and over to the API server when the only thing we require
is the JWT that is getting sent as a header anyway.

There is a bug in FF dev tools that indicated to me that we were sendning 1.5mb of cookies with each request, turns out to be 1.5kb, so this change is trivial, but I don't see any reason not to include it and our CAS authentication will benefit as it would end up sending triple JWT data.

For some testing reference the netlify build currently doesn't send any cookies because it isn't on the same server as the API and it works well. So the session cookies are already not expected to be sent, this just guarantees that they never are.