### PR TITLE
alternative component validator

### DIFF
--- a/addon/components/course-overview.hbs
+++ b/addon/components/course-overview.hbs
@@ -65,10 +65,10 @@
             <Input
               type="text"
               @value={{this.externalId}}
-              @key-press={{fn this.addErrorDisplayFor "externalId"}}
+              @key-down={{fn this.addErrorDisplayFor "externalId"}}
               disabled={{isSaving}}
             />
-            {{#each (await (compute (fn this.getErrorsFor) "externalId")) as |message|}}
+            {{#each this.externalIdValidationErrors as |message|}}
               <span class="validation-error-message">
                 {{message}}
               </span>
@@ -127,10 +127,9 @@
             <PikadayInput
               @value={{this.startDate}}
               @format="L"
-              @onSelection={{fn (set this.startDate)}}
-              @focusOut={{fn this.addErrorDisplayFor "startDate"}}
+              @onSelection={{queue (fn this.addErrorDisplayFor "startDate") (fn (set this.startDate))}}
             />
-            {{#each (await (compute (fn this.getErrorsFor) "startDate")) as |message|}}
+            {{#each this.startDateValidationErrors as |message|}}
               <span class="validation-error-message">
                 {{message}}
               </span>
@@ -153,10 +152,9 @@
             <PikadayInput
               @value={{this.endDate}}
               @format="L"
-              @onSelection={{fn (set this.endDate)}}
-              @focusOut={{fn this.addErrorDisplayFor "endDate"}}
+              @onSelection={{queue (fn this.addErrorDisplayFor "endDate") (fn (set this.endDate))}}
             />
-            {{#each (await (compute (fn this.getErrorsFor) "endDate")) as |message|}}
+            {{#each this.endDateValidationErrors as |message|}}
               <span class="validation-error-message">
                 {{message}}
               </span>

--- a/addon/components/course-overview.js
+++ b/addon/components/course-overview.js
@@ -61,7 +61,7 @@ export default class CourseOverview extends Component {
     } else if (length > maxLength) {
       errors.push(this.intl.t('errors.tooLong', {
         description,
-        min: maxLength
+        max: maxLength
       }));
     }
     return errors;

--- a/addon/decorators/validation/validatable-component.js
+++ b/addon/decorators/validation/validatable-component.js
@@ -1,0 +1,82 @@
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export function validatableComponent(component) {
+  return class extends component {
+    @tracked _registry = [];
+    @tracked _showAllErrors = false;
+
+    @action
+    clearErrorDisplay() {
+      this._registry = [];
+      this._showAllErrors = false;
+    }
+
+    @action
+    removeErrorDisplayFor(field) {
+      if (this.hasErrorDisplayFor(field)) {
+        this._showAllErrors = false;
+        this._registry = this._registry.filter(f => f !== field);
+      }
+    }
+
+    @action
+    addErrorDisplayForAllFields() {
+      this._showAllErrors = true;
+    }
+
+    @action
+    addErrorDisplayFor(field) {
+      if (this.hasErrorDisplayFor(field)) {
+        return;
+      }
+      this._registry.push(field);
+    }
+
+    @action
+    validate() {
+      const errorsByField = {};
+      let hasErrors = false;
+      this._registry.forEach(field => {
+        const errors = this[this._getFieldValidationGetterName(field)]; // invoke validation getter for the given field.
+        if (!errors.length) {
+          return;
+        }
+        errorsByField[field] = errors;
+        if (errors.length) {
+          hasErrors = true;
+        }
+      });
+      errorsByField._hasErrors = hasErrors;
+      return errorsByField;
+    }
+
+    @action
+    isValid(field = null) {
+      const errors = this.validate();
+      if (field === null) {
+        return !errors._hasErrors;
+      }
+      return !(field in errors);
+    }
+
+    @action
+    getErrorsFor(field) {
+      if (this._showAllErrors || this.hasErrorDisplayFor(field)) {
+        const errors = this.validate();
+        if (field in errors) {
+          return errors[field];
+        }
+      }
+      return [];
+    }
+
+    hasErrorDisplayFor(field) {
+      return this._registry.includes(field);
+    }
+
+    _getFieldValidationGetterName(field) {
+      return `${field}ValidationErrors`;
+    }
+  };
+}

--- a/addon/decorators/validation/validatable-component.js
+++ b/addon/decorators/validation/validatable-component.js
@@ -4,25 +4,17 @@ import { action } from '@ember/object';
 export function validatableComponent(component) {
   return class extends component {
     @tracked _registry = [];
-    @tracked _showAllErrors = false;
 
     @action
     clearErrorDisplay() {
       this._registry = [];
-      this._showAllErrors = false;
     }
 
     @action
     removeErrorDisplayFor(field) {
       if (this.hasErrorDisplayFor(field)) {
-        this._showAllErrors = false;
         this._registry = this._registry.filter(f => f !== field);
       }
-    }
-
-    @action
-    addErrorDisplayForAllFields() {
-      this._showAllErrors = true;
     }
 
     @action
@@ -62,7 +54,7 @@ export function validatableComponent(component) {
 
     @action
     getErrorsFor(field) {
-      if (this._showAllErrors || this.hasErrorDisplayFor(field)) {
+      if (this.hasErrorDisplayFor(field)) {
         const errors = this.validate();
         if (field in errors) {
           return errors[field];


### PR DESCRIPTION
hybrid approach to component validation by using a class decorator for plumbing (validation registry etc), and using class getters for porcelain (the specific field validation implementations).

the getters are a bit long-handed atm, but can be refactored for improved usability.

this should regain us the flexibility to build arbitrarily complex component validations. 

todo:

- [ ] decorator test coverage
- [ ] a second component conversion - use `course-rollover`.

other things of note:
- unlike the original decorators that were built on top of the `class-decorator` library, this implementation is not asyncronous. this can be changed if necessary if need be down the road.