### PR TITLE
Improve loading of course print view

### DIFF
--- a/addon/components/print-course.js
+++ b/addon/components/print-course.js
@@ -37,12 +37,7 @@ export default Component.extend(SortableByPosition, {
         sortedMeshDescriptors: sort('content.meshDescriptors', 'sortTitle'),
         sessionLearningMaterials: computed('content', function(){
           return new RSVPPromise(resolve => {
-            const session = this.get('content').get('id');
-            this.get('store').query('sessionLearningMaterial', {
-              filters: {
-                session
-              }
-            }).then(learningMaterials => {
+            this.content.get('learningMaterials').then(learningMaterials => {
               resolve(learningMaterials.toArray().sort(this.get('positionSortingCallback')));
             });
           });
@@ -69,12 +64,7 @@ export default Component.extend(SortableByPosition, {
 
   courseLearningMaterials: computed('course', function(){
     return new RSVPPromise(resolve => {
-      const course = this.get('course').get('id');
-      this.get('store').query('courseLearningMaterial', {
-        filters: {
-          course
-        }
-      }).then(learningMaterials => {
+      this.course.get('learningMaterials').then(learningMaterials => {
         resolve(learningMaterials.toArray().sort(this.get('positionSortingCallback')));
       });
     });

--- a/addon/mixins/course/index-route.js
+++ b/addon/mixins/course/index-route.js
@@ -1,7 +1,7 @@
 import Mixin from '@ember/object/mixin';
 import { get } from '@ember/object';
 import { inject as service } from '@ember/service';
-import { all } from 'rsvp';
+import preloadCourse from 'ilios-common/utils/preload-course';
 
 export default Mixin.create({
   permissionChecker: service(),
@@ -20,42 +20,8 @@ export default Mixin.create({
    * Prefetch related data to limit network requests
    */
   async afterModel(model) {
-    const store = this.get('store');
-    const courses = [model.get('id')];
-    const course = model.get('id');
-    const school = model.belongsTo('school').id();
-    const sessions = model.hasMany('sessions').ids();
-    const existingSessionsInStore = store.peekAll('session');
-    const existingSessionIds = existingSessionsInStore.mapBy('id');
-    const unloadedSessions = sessions.filter(id => !existingSessionIds.includes(id));
-    await this.fillPermissions(model);
-
-    //if we have already loaded all of these sessions we can just proceed normally
-    if (unloadedSessions.length === 0) {
-      return;
-    }
-
-    const promises = [
-      store.query('session', { filters: { course } }),
-      store.query('offering', { filters: { courses } }),
-      store.query('ilm-session', { filters: { courses } }),
-      store.query('objective', { filters: { courses } }),
-      store.query('cohort', { filters: { courses } }),
-      store.query('programYear', { filters: { courses } }),
-      store.query('program', { filters: { courses } }),
-      store.query('competency', { filters: { school } }),
-    ];
-    const maximumSessionLoad = 100;
-    if (sessions.length < maximumSessionLoad) {
-      promises.pushObject(store.query('session-type', { filters: { sessions } }));
-    } else {
-      for (let i = 0; i < sessions.length; i += maximumSessionLoad) {
-        const slice = sessions.slice(i, i + maximumSessionLoad);
-        promises.pushObject(store.query('session-type', { filters: { sessions: slice } }));
-      }
-    }
-
-    return all(promises);
+    await preloadCourse(this.store, model);
+    return this.fillPermissions(model);
   },
   setupController(controller, model) {
     this._super(controller, model);

--- a/addon/mixins/print-course-route.js
+++ b/addon/mixins/print-course-route.js
@@ -1,6 +1,6 @@
 import Mixin from '@ember/object/mixin';
-import { all }  from 'rsvp';
 import { inject as service } from '@ember/service';
+import preloadCourse from 'ilios-common/utils/preload-course';
 
 export default Mixin.create({
   currentUser: service(),
@@ -12,11 +12,7 @@ export default Mixin.create({
     const canViewUnpublished = currentUser.get('performsNonLearnerFunction');
     this.set('canViewUnpublished', canViewUnpublished);
     if (canViewUnpublished || course.get('isPublishedOrScheduled')) {
-      return all([
-        course.get('sessions'),
-        course.get('competencies'),
-        course.get('objectives'),
-      ]);
+      return await preloadCourse(this.store, course);
     }
 
     transition.abort();

--- a/addon/utils/preload-course.js
+++ b/addon/utils/preload-course.js
@@ -1,0 +1,47 @@
+export default async function preloadCourse(store, courseModel) {
+  const courses = [courseModel.get('id')];
+  const course = courseModel.get('id');
+  const school = courseModel.belongsTo('school').id();
+  const sessions = courseModel.hasMany('sessions').ids();
+  const existingSessionsInStore = store.peekAll('session');
+  const existingSessionIds = existingSessionsInStore.mapBy('id');
+  const unloadedSessions = sessions.filter(id => !existingSessionIds.includes(id));
+
+  //if we have already loaded all of these sessions we can just proceed normally
+  if (unloadedSessions.length === 0) {
+    return;
+  }
+
+  const promises = [
+    store.query('session', { filters: { course } }),
+    store.query('offering', { filters: { courses } }),
+    store.query('ilm-session', { filters: { courses } }),
+    store.query('objective', { filters: { courses } }),
+    store.query('cohort', { filters: { courses } }),
+    store.query('programYear', { filters: { courses } }),
+    store.query('program', { filters: { courses } }),
+    store.query('objective', { filters: { courses } }),
+    store.query('course-learning-material', { filters: { course: courses } }),
+    store.query('competency', { filters: { school } }),
+    store.query('term', { filters: { courses } }),
+  ];
+  const maximumSessionLoad = 100;
+  if (sessions.length < maximumSessionLoad) {
+    promises.push(store.query('session-type', { filters: { sessions } }));
+    promises.push(store.query('objective', { filters: { sessions } }));
+    promises.push(store.query('term', { filters: { sessions } }));
+    promises.push(store.query('session-learning-material', { filters: { session: sessions } }));
+    promises.push(store.query('session-description', { filters: { session: sessions } }));
+  } else {
+    for (let i = 0; i < sessions.length; i += maximumSessionLoad) {
+      const slice = sessions.slice(i, i + maximumSessionLoad);
+      promises.push(store.query('session-type', { filters: { sessions: slice } }));
+      promises.push(store.query('objective', { filters: { sessions: slice } }));
+      promises.push(store.query('term', { filters: { sessions: slice } }));
+      promises.push(store.query('session-learning-material', { filters: { session: slice } }));
+      promises.push(store.query('session-description', { filters: { session: slice } }));
+    }
+  }
+
+  return Promise.all(promises);
+}

--- a/app/utils/preload-course.js
+++ b/app/utils/preload-course.js
@@ -1,0 +1,1 @@
+export { default } from 'ilios-common/utils/preload-course';

--- a/tests/acceptance/course/printcourse-test.js
+++ b/tests/acceptance/course/printcourse-test.js
@@ -75,7 +75,7 @@ module('Acceptance | Course - Print Course', function(hooks) {
     assert.dom('[data-test-course-mesh] ul li').hasText('Flux Capacitor');
   });
 
-  test('test print course learning materials', async function (assert) {
+  test('print course learning materials', async function (assert) {
     assert.expect(4);
     await setupAuthentication( { school: this.school });
     await visit('/course/1/print');


### PR DESCRIPTION
Some larger courses were making 300+ network requests to load
the print view. This change optimizes the network loading in the same
way it is improved for the course editor and brings the number of
requests down into the 20-30 range.

I extracted this loading work into a utility so it's now shared between
these two routes.