### PR TITLE
fixes scroll into view upon offering form closing.

### DIFF
--- a/addon/components/sessions-grid-offering.hbs
+++ b/addon/components/sessions-grid-offering.hbs
@@ -3,6 +3,7 @@
   data-test-sessions-grid-offering
   {{did-insert this.revertRoomChanges}}
   {{did-update this.revertRoomChanges}}
+  {{ref this "row"}}
 >
   {{#if (and this.isEditing (is-fulfilled @offering.session.course.cohorts))}}
     <td colspan="10" class="expanded-offering-manager">

--- a/addon/components/sessions-grid-offering.js
+++ b/addon/components/sessions-grid-offering.js
@@ -20,7 +20,7 @@ export default class SessionsGridOffering extends Component {
   @action
   close() {
     this.isEditing = false;
-    scrollIntoView(this.element);
+    scrollIntoView(this.row);
   }
 
   @dropTask


### PR DESCRIPTION
this is an un-ticketed regression that i found when working on something else.

in the sessions list, when you close the embedded offering form, you end up with this dreadful error message:

```
Uncaught Error: You attempted to access the 'element' property on a Glimmer Component, but that property does not exist in Ember.js applications, it only exists in Glimmer.js apps. You define a class field with the same name on your component class and it will overwrite this error message, but it will not be used by the framework.
```

this was an oversight during glimmerization of this component, using a ref-modifier fixes that issue.