### PR TITLE
Add splatributes to editable field

### DIFF
--- a/addon/components/editable-field.hbs
+++ b/addon/components/editable-field.hbs
@@ -1,6 +1,4 @@
-<div
-  class="editinplace"
->
+<div class="editinplace" ...attributes>
   <span class="content">
     {{#unless this.isEditing}}
       <span>


### PR DESCRIPTION
This allows properties to be passed in from the calling side, like
data-test- or additional classes. Used in the frontend [instructorgroup-header](https://github.com/ilios/frontend/blob/7e070fa61d70a7b6525e4db649a5882d655104ed/app/components/instructorgroup-header.hbs#L9).