### PR TITLE
Temporary re-enable all cookies again

### DIFF
--- a/addon/adapters/ilios.js
+++ b/addon/adapters/ilios.js
@@ -59,10 +59,12 @@ export default RESTAdapter.extend({
    * this is important for us because we store the JWT in a cookie so if we send cookies it will
    * send the JWT at least twice (sometimes more depending on the auth options used)
    */
-  ajaxOptions() {
-    return {
-      ...this._super(...arguments),
-      credentials: 'omit'
-    };
-  },
+
+  /** TEMPORARY DISABLE - LM uploads aren't working on load balanced machines  **/
+  // ajaxOptions() {
+  //   return {
+  //     ...this._super(...arguments),
+  //     credentials: 'omit'
+  //   };
+  // },
 });


### PR DESCRIPTION
When the API is load balanced it needs a cookie to know where to send
requests. LMs files are uploaded temporarily in the first request and then
attached to an LM in a second request, right now both of those requests
have to go to the same server.