### PR TITLE
Run the correct tests

### DIFF
--- a/.github/workflows/future-ci.yaml
+++ b/.github/workflows/future-ci.yaml
@@ -28,7 +28,7 @@ jobs:
     - name: lint hbs
       run: npm run lint:hbs
     - name: test
-      run: npm test
+      run: npm run test:ember
   try-scenarios:
     name: ember-try
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: install dependencies
       run: npm ci
     - name: test
-      run: npm test
+      run: npm run test:ember
 
   publish-npm:
     needs: build


### PR DESCRIPTION
The latest update to ember-cli added way more tests to the basic npm
test command. We need to specify only the ember tests, otherwise we're
testing a lot more than we meant to.