### PR TITLE
Validate copyright on LMs

### DIFF
--- a/addon-test-support/ilios-common/page-objects/components/learning-materials.js
+++ b/addon-test-support/ilios-common/page-objects/components/learning-materials.js
@@ -50,8 +50,11 @@ const definition = {
     status: fillable('select', { at: 0 }),
     role: fillable('select', { at: 1 }),
     description: pageObjectFillInFroalaEditor('[data-test-html-editor]'),
+    rationale: fillable('[data-test-copyright-rationale]'),
+    agreement: clickable('[data-test-copyright-agreement]'),
     save: clickable('.done'),
     cancel: clickable('.cancel'),
+    hasAgreementValidationError: isVisible('[data-test-agreement-validation-error-message]'),
   },
   manager: {
     scope: '.learningmaterial-manager',
@@ -108,7 +111,7 @@ const definition = {
       ampm: fillable('select', { at: 2 }),
     },
     hasEndDateValidationError: isVisible('[data-test-end-date-validation-error-message]'),
-    hasTitleValidationError: isVisible('[data-test-title-validation-error-message]')
+    hasTitleValidationError: isVisible('[data-test-title-validation-error-message]'),
   },
   sortManager: {
     scope: '[data-test-detail-learning-materials-sort-manager]',

--- a/addon/components/new-learningmaterial.hbs
+++ b/addon/components/new-learningmaterial.hbs
@@ -132,8 +132,15 @@
             type="checkbox"
             checked={{this.copyrightPermission}}
             {{on "click" (set this.copyrightPermission (not this.copyrightPermission))}}
+            data-test-copyright-agreement
           >
           {{t "general.copyrightAgreement"}}
+          {{#if (await (compute (fn this.hasErrorFor) "copyrightPermission"))}}
+            <br>
+            <span class="validation-error-message" data-test-agreement-validation-error-message>
+              {{t "errors.agreementRequired"}}
+            </span>
+          {{/if}}
         </p>
       </span>
     </div>
@@ -146,6 +153,7 @@
           <Textarea
             @value={{this.copyrightRationale}}
             @focus-out={{fn this.addErrorDisplayFor "copyrightRationale"}}
+            data-test-copyright-rationale
           />
         {{#each (await (compute (fn this.getErrorsFor) "copyrightRationale")) as |message|}}
           <span class="validation-error-message">
@@ -164,6 +172,11 @@
         @setFilename={{set this.filename}}
         @setFileHash={{set this.fileHash}}
       />
+      {{#each (await (compute (fn this.getErrorsFor) "filename")) as |message|}}
+        <span class="validation-error-message">
+          {{message}}
+        </span>
+      {{/each}}
     </div>
   {{/if}}
   <div class="buttons">

--- a/addon/components/new-learningmaterial.js
+++ b/addon/components/new-learningmaterial.js
@@ -3,7 +3,7 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { dropTask } from 'ember-concurrency-decorators';
-import { validatable, Length, NotBlank } from 'ilios-common/decorators/validation';
+import { validatable, Length, NotBlank, IsTrue } from 'ilios-common/decorators/validation';
 import { ValidateIf } from "class-validator";
 import { guidFor } from '@ember/object/internals';
 
@@ -21,7 +21,7 @@ export default class NewLearningmaterialComponent extends Component {
   @NotBlank() @Length(2, 80) @tracked originalAuthor;
   @NotBlank() @Length(4, 120) @tracked title;
   @ValidateIf(o => o.isLink) @NotBlank() @tracked link = 'http://';
-  @tracked copyrightPermission = false;
+  @ValidateIf(o => o.isFile && !o.copyrightRationale) @IsTrue() @tracked copyrightPermission = false;
   @ValidateIf(o => o.isFile) @Length(2, 65000) @tracked copyrightRationale;
   @tracked owner;
   @ValidateIf(o => o.isCitation) @NotBlank() @tracked citation;

--- a/addon/decorators/validation.js
+++ b/addon/decorators/validation.js
@@ -7,6 +7,7 @@ import { Gte } from './validation/gte';
 import { Gt } from './validation/gt';
 import { Lte } from './validation/lte';
 import { IsInt } from './validation/is-int';
+import { IsTrue } from './validation/is-true';
 import { validatable } from './validation/validatable';
 import { ArrayNotEmpty } from './validation/array-not-empty';
 
@@ -16,6 +17,7 @@ export {
   Gte,
   Lte,
   IsInt,
+  IsTrue,
   AfterDate,
   BeforeDate,
   Length,

--- a/addon/decorators/validation/is-true.js
+++ b/addon/decorators/validation/is-true.js
@@ -1,0 +1,25 @@
+import { registerDecorator } from "class-validator";
+import { getOwner } from '@ember/application';
+
+export function IsTrue(validationOptions) {
+  return function (object, propertyName) {
+    registerDecorator({
+      name: 'isTrue',
+      target: object.constructor,
+      propertyName: propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value) {
+          return value === true;
+        },
+        defaultMessage({ object: target }) {
+          const owner = getOwner(target);
+          const intl = owner.lookup('service:intl');
+          const description = intl.t('errors.description');
+
+          return intl.t('errors.blank', { description });
+        }
+      },
+    });
+  };
+}

--- a/tests/acceptance/course/learningmaterials-test.js
+++ b/tests/acceptance/course/learningmaterials-test.js
@@ -616,6 +616,23 @@ module('Acceptance | Course - Learning Materials', function(hooks) {
       await page.learningMaterials.manager.save();
       assert.ok(page.learningMaterials.manager.hasTitleValidationError);
     });
+
+    test('missing copyright info #1204', async function (assert) {
+      this.user.update({ administeredSchools: [this.school] });
+      await page.visit({ courseId: 1, details: true });
+      await page.learningMaterials.createNew();
+      await page.learningMaterials.pickNew('File');
+
+      assert.notOk(page.learningMaterials.newLearningMaterial.hasAgreementValidationError);
+      await page.learningMaterials.newLearningMaterial.save();
+      assert.ok(page.learningMaterials.newLearningMaterial.hasAgreementValidationError);
+      await page.learningMaterials.newLearningMaterial.agreement();
+      assert.notOk(page.learningMaterials.newLearningMaterial.hasAgreementValidationError);
+      await page.learningMaterials.newLearningMaterial.agreement();
+      assert.ok(page.learningMaterials.newLearningMaterial.hasAgreementValidationError);
+      await page.learningMaterials.newLearningMaterial.rationale('mine!');
+      assert.notOk(page.learningMaterials.newLearningMaterial.hasAgreementValidationError);
+    });
   });
 
   module('Double Linked Materials', function (hooks2) {

--- a/tests/acceptance/course/session/learningmaterials-test.js
+++ b/tests/acceptance/course/session/learningmaterials-test.js
@@ -615,6 +615,23 @@ module('Acceptance | Session - Learning Materials', function(hooks) {
       assert.ok(page.learningMaterials.manager.hasTitleValidationError);
     });
 
+    test('missing copyright info #1204', async function (assert) {
+      this.user.update({ administeredSchools: [this.school] });
+      await page.visit({ courseId: 1, sessionId: 1 });
+      await page.learningMaterials.createNew();
+      await page.learningMaterials.pickNew('File');
+
+      assert.notOk(page.learningMaterials.newLearningMaterial.hasAgreementValidationError);
+      await page.learningMaterials.newLearningMaterial.save();
+      assert.ok(page.learningMaterials.newLearningMaterial.hasAgreementValidationError);
+      await page.learningMaterials.newLearningMaterial.agreement();
+      assert.notOk(page.learningMaterials.newLearningMaterial.hasAgreementValidationError);
+      await page.learningMaterials.newLearningMaterial.agreement();
+      assert.ok(page.learningMaterials.newLearningMaterial.hasAgreementValidationError);
+      await page.learningMaterials.newLearningMaterial.rationale('mine!');
+      assert.notOk(page.learningMaterials.newLearningMaterial.hasAgreementValidationError);
+    });
+
   });
   module('Double Linked Materials', function (hooks2) {
     hooks2.beforeEach(function () {

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -332,6 +332,7 @@ general:
 errors:
   accepted: "{description} must be accepted"
   after: "{description} must be after {after}"
+  agreementRequired: "Agreement or alternate rationale is required for upload"
   before: "{description} must be before {before}"
   blank: "{description} can not be blank"
   collection: "{description} must be a collection"

--- a/translations/es.yaml
+++ b/translations/es.yaml
@@ -332,6 +332,7 @@ general:
 errors:
   accepted: "{description} debe ser aceptado"
   after: "{description} necesita estar después de {after}"
+  agreementRequired: "Acuerdo o se requiere una justificación alternativa para cargar"
   before: "{description} necesita estar antes de {before}"
   blank: "{description} no puede estar en blanco"
   collection: "{description} necesita ser una colección"

--- a/translations/fr.yaml
+++ b/translations/fr.yaml
@@ -332,6 +332,7 @@ general:
 errors:
   accepted: "{description} doit être accepté"
   after: "{description} doit être après {after}"
+  agreementRequired: "Entente ou autre justification requise pour le téléchargement"
   before: "{description} doit être avant {before}"
   blank: "{description} ne doit pas être blanc"
   collection: "{description} doit être un collection"


### PR DESCRIPTION
Adds validation and error messaging when either the rationale or the
agreement are not provided for new file learning materials.

Fixes #1204