### PR TITLE
Give tooltips some z-index love

### DIFF
--- a/app/styles/ilios-common/components/ilios-tooltip.scss
+++ b/app/styles/ilios-common/components/ilios-tooltip.scss
@@ -1,5 +1,6 @@
 .ilios-tooltip {
   padding: 0 1em;
+  z-index: 100;
 
   .content {
     background: $background-grey;


### PR DESCRIPTION
This allows them to clear the navigation bar and anything else in their
way.

Fixes #1275