### PR TITLE
Hide inactive objective parents

### DIFF
--- a/addon-mirage-support/factories/objective.js
+++ b/addon-mirage-support/factories/objective.js
@@ -3,4 +3,5 @@ import { Factory } from 'ember-cli-mirage';
 export default Factory.extend({
   title: i => `objective ${i}`,
   position: i => i,
+  active: true,
 });

--- a/addon/components/course/manage-objective-parents.hbs
+++ b/addon/components/course/manage-objective-parents.hbs
@@ -41,19 +41,21 @@
             </h4>
             <ul>
               {{#each (sort-by "title" competency.objectives) as |objective|}}
-                <li>
-                  <Course::ManageObjectiveParentsItem
-                    @title={{objective.title}}
-                    @allowMultipleParents={{this.selectedCohort.allowMultipleParents}}
-                    @isSelected={{contains objective @selected}}
-                    @add={{
-                      pipe
-                        (unless this.selectedCohort.allowMultipleParents (fn @removeFromCohort this.selectedCohort))
-                        (fn @add objective)
-                      }}
-                    @remove={{fn @remove objective}}
-                  />
-                </li>
+                {{#if (or (contains objective @selected) objective.active)}}
+                  <li>
+                    <Course::ManageObjectiveParentsItem
+                      @title={{objective.title}}
+                      @allowMultipleParents={{this.selectedCohort.allowMultipleParents}}
+                      @isSelected={{contains objective @selected}}
+                      @add={{
+                        pipe
+                          (unless this.selectedCohort.allowMultipleParents (fn @removeFromCohort this.selectedCohort))
+                          (fn @add objective)
+                        }}
+                      @remove={{fn @remove objective}}
+                    />
+                  </li>
+                {{/if}}
               {{/each}}
             </ul>
           </li>

--- a/addon/components/course/objective-list.js
+++ b/addon/components/course/objective-list.js
@@ -55,6 +55,7 @@ export default class CourseObjectiveListComponent extends Component {
         return {
           id: objective.id,
           title: objective.textTitle,
+          active: objective.active,
           competencyId,
           competencyTitle,
           cohortId: cohort.id,

--- a/tests/acceptance/course/objectiveparents-inactive-test.js
+++ b/tests/acceptance/course/objectiveparents-inactive-test.js
@@ -1,0 +1,77 @@
+import {
+  module,
+  test
+} from 'qunit';
+import { setupAuthentication } from 'ilios-common';
+
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import page from 'ilios-common/page-objects/course';
+
+module('Acceptance | Course - Objective Inactive Parents', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  hooks.beforeEach(async function () {
+    this.user = await setupAuthentication();
+    this.school =  this.server.create('school');
+  });
+
+  test('inactive program year objectives are hidden unless they are selected', async function (assert) {
+    const program = this.server.create('program', { school: this.school });
+    const programYear = this.server.create('programYear', { program });
+    const cohort = this.server.create('cohort', {
+      programYear
+    });
+    const competency = this.server.create('competency', {
+      school: this.school,
+      programYears: [programYear],
+    });
+    this.server.create('objective', {
+      title: 'active',
+      programYears: [programYear],
+      competency,
+      active: true,
+    });
+    this.server.create('objective', {
+      title: 'inactive',
+      programYears: [programYear],
+      competency,
+      active: false,
+    });
+    const parent = this.server.create('objective', {
+      title: 'inactive selected',
+      programYears: [programYear],
+      competency,
+      active: false,
+    });
+    const objective = this.server.create('objective', { parents: [parent] });
+    this.server.create('course', {
+      year: 2013,
+      school: this.school,
+      objectives: [objective],
+      cohorts: [cohort]
+    });
+
+    this.user.update({ administeredSchools: [this.school] });
+    await page.visit({ courseId: 1, details: true, courseObjectiveDetails: true });
+    const { objectives } = page.objectives.objectiveList;
+    assert.equal(objectives.length, 1);
+
+    assert.equal(objectives[0].description.text, 'objective 3');
+    assert.equal(objectives[0].parents.list.length, 1);
+    assert.equal(objectives[0].parents.list[0].text, 'inactive selected');
+
+    await objectives[0].parents.list[0].manage();
+    const m = objectives[0].parentManager;
+
+    assert.equal(m.selectedCohortTitle, 'program 0 cohort 0');
+    assert.equal(m.competencies.length, 1);
+    assert.equal(m.competencies[0].title, 'competency 0');
+    assert.ok(m.competencies[0].selected);
+    assert.equal(m.competencies[0].objectives.length, 2);
+    assert.equal(m.competencies[0].objectives[0].title, 'active');
+    assert.ok(m.competencies[0].objectives[0].notSelected);
+    assert.equal(m.competencies[0].objectives[1].title, 'inactive selected');
+    assert.ok(m.competencies[0].objectives[1].selected);
+  });
+});


### PR DESCRIPTION
When a program year objective is marked as inactive it can not be
selected as a parent, if it has already been selected as the parent it
will continue to show up.

Refs: ilios/frontend#3003

Requires: 
- [x] #1286
- [x] ilios/frontend#5236
- [x] https://github.com/ilios/ilios/pull/2851
- [ ] UI for PY objectives to activate / deactive them