### PR TITLE
Make new objectives active by default

### DIFF
--- a/addon/models/objective.js
+++ b/addon/models/objective.js
@@ -29,7 +29,9 @@ export default Model.extend({
     inverse: 'ancestor',
     async: true
   }),
-  active: attr('boolean'),
+  active: attr('boolean', {
+    defaultValue: true,
+  }),
   //While it is possible at some point that objectives will be allowed to
   //link to multiple courses, for now we just reflect a many to one relationship
   course: alias('courses.firstObject'),

--- a/tests/unit/models/objective-test.js
+++ b/tests/unit/models/objective-test.js
@@ -9,6 +9,12 @@ module('Unit | Model | Objective', function(hooks) {
     assert.ok(!!model);
   });
 
+  test('active defaults to true', function(assert) {
+    const model = this.owner.lookup('service:store').createRecord('objective');
+    assert.ok(!!model);
+    assert.ok(model.active);
+  });
+
   test('top parent with no parents should be self', async function(assert) {
     assert.expect(2);
 


### PR DESCRIPTION
Oversight here, these should always have been marked active, there is no
reason to create a new inactive objective.