### PR TITLE
Improve Session Overview Loading

### DIFF
--- a/addon/components/session-overview.hbs
+++ b/addon/components/session-overview.hbs
@@ -3,7 +3,7 @@
   {{did-insert (perform this.load) @session @sessionTypes}}
   {{did-update (perform this.load) @session @sessionTypes}}
 >
-  {{#unless this.load.isRunning}}
+  {{#if this.load.performCount}}
     <div class="session-header">
       <span class="title">
         {{#if @editable}}
@@ -372,5 +372,5 @@
         {{/unless}}
       </div>
     </section>
-  {{/unless}}
+  {{/if}}
 </div>


### PR DESCRIPTION
All of the individual promises getting read in the load method was
causing a significant rendering delay as each one moved in and out of
the main thread. This appeared as a jump in the screen when a session was first loaded as the overview just didn't display at all for a few seconds.


Loading them all at the same time solves that issue. As
long as the load has run at least once we should display the data. Also
moved one method from a task to a plain async method which it seems to
be.