### PR TITLE
Add deprecation message for async computed properties

### DIFF
--- a/addon/services/api-version.js
+++ b/addon/services/api-version.js
@@ -1,6 +1,7 @@
 import Service, { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
 import { getOwner } from '@ember/application';
+import { deprecate } from '@ember/debug';
 
 export default Service.extend({
   iliosConfig: service(),
@@ -12,6 +13,7 @@ export default Service.extend({
   }),
 
   isMismatched: computed('iliosConfig.apiVersion', 'version', async function () {
+    deprecate('Async Computed Called', false, {id: 'common.async-computed', until: '40'});
     const serverApiVersion = await this.iliosConfig.getApiVersion();
     return serverApiVersion !== this.version;
   }),

--- a/addon/services/current-user.js
+++ b/addon/services/current-user.js
@@ -3,6 +3,7 @@ import { get, computed } from '@ember/object';
 import Service, { inject as service } from '@ember/service';
 import moment from 'moment';
 import jwtDecode from '../utils/jwt-decode';
+import { deprecate } from '@ember/debug';
 
 export default Service.extend({
   store: service(),
@@ -18,6 +19,7 @@ export default Service.extend({
   }),
 
   model: computed('currentUserId', async function(){
+    deprecate('Async Computed Called', false, {id: 'common.async-computed', until: '40'});
     return this.getModel();
   }),
   async getModel() {
@@ -37,6 +39,7 @@ export default Service.extend({
   },
 
   userRoleTitles: computed('model.roles.[]', async function(){
+    deprecate('Async Computed Called', false, {id: 'common.async-computed', until: '40'});
     return this.getUserRoleTitles();
   }),
   async getUserRoleTitles() {
@@ -49,6 +52,7 @@ export default Service.extend({
   },
 
   userIsStudent: computed('useRoleTitles.[]', async function(){
+    deprecate('Async Computed Called', false, {id: 'common.async-computed', until: '40'});
     return this.getIsStudent();
   }),
   async getIsStudent() {
@@ -57,6 +61,7 @@ export default Service.extend({
   },
 
   userIsFormerStudent: computed('useRoleTitles.[]', async function(){
+    deprecate('Async Computed Called', false, {id: 'common.async-computed', until: '40'});
     return this.isFormerStudent();
   }),
   async isFormerStudent() {
@@ -73,6 +78,7 @@ export default Service.extend({
     'model.administeredCourses.[]',
     'model.instructorIlmSessions.[]',
     async function(){
+      deprecate('Async Computed Called', false, {id: 'common.async-computed', until: '40'});
       return this.getActiveRelatedCoursesInThisYearAndLastYear();
     }
   ),

--- a/addon/services/ilios-config.js
+++ b/addon/services/ilios-config.js
@@ -1,6 +1,7 @@
 import Service, { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
 import { isPresent } from '@ember/utils';
+import { deprecate } from '@ember/debug';
 
 export default Service.extend({
   fetch: service(),
@@ -8,6 +9,7 @@ export default Service.extend({
   _configPromise: null,
 
   config: computed('apiHost', function () {
+    deprecate('Async Computed Called', false, {id: 'common.async-computed', until: '40'});
     return this.getConfig();
   }),
   async getConfig() {
@@ -25,6 +27,7 @@ export default Service.extend({
   },
 
   userSearchType: computed('config.userSearchType', function(){
+    deprecate('Async Computed Called', false, {id: 'common.async-computed', until: '40'});
     return this.getUserSearchType();
   }),
   async getUserSearchType() {
@@ -32,6 +35,7 @@ export default Service.extend({
   },
 
   authenticationType: computed('config.type', function(){
+    deprecate('Async Computed Called', false, {id: 'common.async-computed', until: '40'});
     return this.getAuthenticationType();
   }),
   async getAuthenticationType() {
@@ -39,6 +43,7 @@ export default Service.extend({
   },
 
   maxUploadSize: computed('config.maxUploadSize', function(){
+    deprecate('Async Computed Called', false, {id: 'common.async-computed', until: '40'});
     return this.getMaxUploadSize();
   }),
   async getMaxUploadSize() {
@@ -46,6 +51,7 @@ export default Service.extend({
   },
 
   apiVersion: computed('config.apiVersion', function(){
+    deprecate('Async Computed Called', false, {id: 'common.async-computed', until: '40'});
     return this.getApiVersion();
   }),
   async getApiVersion() {
@@ -53,6 +59,7 @@ export default Service.extend({
   },
 
   trackingEnabled: computed('config.trackingEnabled', function(){
+    deprecate('Async Computed Called', false, {id: 'common.async-computed', until: '40'});
     return this.getTrackingEnabled();
   }),
   async getTrackingEnabled() {
@@ -60,6 +67,7 @@ export default Service.extend({
   },
 
   trackingCode: computed('config.trackingCode', function(){
+    deprecate('Async Computed Called', false, {id: 'common.async-computed', until: '40'});
     return this.getTrackingCode();
   }),
   async getTrackingCode() {
@@ -67,6 +75,7 @@ export default Service.extend({
   },
 
   loginUrl: computed('config.loginUrl', function(){
+    deprecate('Async Computed Called', false, {id: 'common.async-computed', until: '40'});
     return this.getLoginUrl();
   }),
   async getLoginUrl() {
@@ -74,6 +83,7 @@ export default Service.extend({
   },
 
   casLoginUrl: computed('config.casLoginUrl', function(){
+    deprecate('Async Computed Called', false, {id: 'common.async-computed', until: '40'});
     return this.getCasLoginUrl();
   }),
   async getCasLoginUrl() {
@@ -111,6 +121,7 @@ export default Service.extend({
   }),
 
   searchEnabled: computed('config.searchEnabled', async function(){
+    deprecate('Async Computed Called', false, {id: 'common.async-computed', until: '40'});
     return this.getSearchEnabled();
   }),
   async getSearchEnabled() {

--- a/addon/services/permission-matrix.js
+++ b/addon/services/permission-matrix.js
@@ -1,9 +1,11 @@
 import Service, { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
+import { deprecate } from '@ember/debug';
 
 export default Service.extend({
   store: service(),
   permissionMatrix: computed(async function(){
+    deprecate('Async Computed Called', false, {id: 'common.async-computed', until: '40'});
     return this.getPermissionMatrix();
   }),
   async getPermissionMatrix() {


### PR DESCRIPTION
There are method replacements for each of these, deprecate them so we
can find any remaining usages and remove them.