### PR TITLE
Switch from section to div on dashboard

### DIFF
--- a/addon/components/common-dashboard.hbs
+++ b/addon/components/common-dashboard.hbs
@@ -1,4 +1,4 @@
-<section class="common-dashboard" data-test-common-dashboard>
+<div class="common-dashboard" data-test-common-dashboard>
   <DashboardViewPicker @show={{@show}} @change={{@setShow}} />
   {{#if (eq @show "calendar")}}
     <DashboardCalendar
@@ -40,4 +40,4 @@
   {{else if (eq @show "week")}}
     <DashboardWeek />
   {{/if}}
-</section>
+</div>


### PR DESCRIPTION
This isn't a semantic use of section as it encompasses many things, we
could add a label to it, but since all the elements in the tree are
actually labeled with good headers it makes more sense to switch this to
a semantically meaningless div that contains other content.