### PR TITLE
Silence common.async-computed deprecation

### DIFF
--- a/tests/dummy/config/deprecation-workflow.js
+++ b/tests/dummy/config/deprecation-workflow.js
@@ -11,5 +11,6 @@ window.deprecationWorkflow.config = {
     { handler: "silence", matchId: "ember-runtime.deprecate-copy-copyable"},
     { handler: "silence", matchId: "computed-property.volatile"},
     { handler: "silence", matchId: "ember-component.is-visible"},
+    { handler: "silence", matchId: "common.async-computed"},
   ]
 };


### PR DESCRIPTION
This is our own deprecation, but it's very noisy in tests so I've
silenced it until we can fix.