### PR TITLE
Improve display of long offering location values

### DIFF
--- a/addon/components/offering-manager.hbs
+++ b/addon/components/offering-manager.hbs
@@ -42,7 +42,7 @@
       </ul>
     </div>
     <div class="offering-manager-location">
-      {{@offering.room}}
+      <TruncateText @text={{@offering.room}} @length={{10}} />
     </div>
     <div class="offering-manager-instructors">
       <ul>

--- a/addon/components/sessions-grid-offering.hbs
+++ b/addon/components/sessions-grid-offering.hbs
@@ -38,7 +38,7 @@
         </span>
       </td>
     {{/if}}
-    <td>
+    <td class="room">
       {{#if @canUpdate}}
         <EditableField
           @value={{this.room}}
@@ -61,7 +61,7 @@
           {{/each}}
         </EditableField>
       {{else}}
-        {{this.room}}
+        <TruncateText @text={{this.room}} @length={{10}} />
       {{/if}}
     </td>
     <td class="text-center">

--- a/app/styles/ilios-common/components/offering-manager.scss
+++ b/app/styles/ilios-common/components/offering-manager.scss
@@ -15,6 +15,7 @@
 
   .offering-manager-location {
     grid-column-start: 3;
+    overflow-wrap: anywhere;
   }
 
   .offering-manager-instructors {

--- a/app/styles/ilios-common/components/sessions-grid-offering-table.scss
+++ b/app/styles/ilios-common/components/sessions-grid-offering-table.scss
@@ -59,6 +59,9 @@
     &.was-updated {
       background-color: lighten($ilios-green, 30%);
     }
+    .room {
+      overflow-wrap: anywhere;
+    }
   }
 
   .first-row td {


### PR DESCRIPTION
When links are placed in location it was breaking the offering manager
and session offerings grid's. When possible we can truncate this text
and wherever it is we can overflow it so it doesn't blow out the
available space.

Fixes #1347