### PR TITLE
[Breaking] rm old validation libraries

### DIFF
--- a/addon/components/session-overview.hbs
+++ b/addon/components/session-overview.hbs
@@ -298,22 +298,17 @@
               <EditableField
                 @value={{this.description}}
                 @renderHtml={{true}}
-                @isSaveDisabled={{and
-                  (v-get this "description" "isInvalid")
-                  (contains "description" this.showErrorsFor)
-                }}
+                @isSaveDisabled={{await (compute (fn this.hasErrorFor) "description")}}
                 @save={{this.saveDescription}}
                 @close={{perform this.revertDescriptionChanges}}
                 @clickPrompt={{t "general.clickToEdit"}}
-
               >
                 <HtmlEditor @content={{this.description}} @update={{this.changeDescription}} />
-                {{#if (and (v-get this "description" "isInvalid") (contains "description" this.showErrorsFor))
-                }}
+                {{#each (await (compute (fn this.getErrorsFor) "description")) as |message|}}
                   <span class="validation-error-message">
-                    {{v-get this "description" "message"}}
+                    {{message}}
                   </span>
-                {{/if}}
+                {{/each}}
               </EditableField>
             {{else}}
               {{! template-lint-disable no-triple-curlies}}
@@ -328,22 +323,17 @@
               <EditableField
                 @value={{@session.instructionalNotes}}
                 @renderHtml={{true}}
-                @isSaveDisabled={{and
-                  (v-get this "instructionalNotes" "isInvalid")
-                  (contains "instructionalNotes" this.showErrorsFor)
-                }}
+                @isSaveDisabled={{await (compute (fn this.hasErrorFor) "instructionalNotes")}}
                 @save={{perform this.saveInstructionalNotes}}
                 @close={{this.revertInstructionalNotesChanges}}
                 @clickPrompt={{t "general.clickToEdit"}}
-
               >
                 <HtmlEditor @content={{this.instructionalNotes}} @update={{this.changeInstructionalNotes}} />
-                {{#if (and (v-get this "instructionalNotes" "isInvalid") (contains "instructionalNotes" this.showErrorsFor))
-                }}
+                {{#each (await (compute (fn this.getErrorsFor) "instructionalNotes")) as |message|}}
                   <span class="validation-error-message">
-                    {{v-get this "instructionalNotes" "message"}}
+                    {{message}}
                   </span>
-                {{/if}}
+                {{/each}}
               </EditableField>
             {{else}}
               {{! template-lint-disable no-triple-curlies}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3949,57 +3949,6 @@
         }
       }
     },
-    "@ember-intl/cp-validations": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@ember-intl/cp-validations/-/cp-validations-4.0.1.tgz",
-      "integrity": "sha512-zF8Znw88yE/T2XlyvCSFmXH1Cijmp6lHyFXiTv9BoSIcwF6SCW7VifIQe5qDGSNnQtSxp1S2I6hmX1KONsUN8g==",
-      "requires": {
-        "ember-cli-babel": "^6.7.1",
-        "ember-getowner-polyfill": "^2.0.1"
-      },
-      "dependencies": {
-        "broccoli-funnel": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
-          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
-          "requires": {
-            "array-equal": "^1.0.0",
-            "blank-object": "^1.0.1",
-            "broccoli-plugin": "^1.3.0",
-            "debug": "^2.2.0",
-            "fast-ordered-set": "^1.0.0",
-            "fs-tree-diff": "^0.5.3",
-            "heimdalljs": "^0.2.0",
-            "minimatch": "^3.0.0",
-            "mkdirp": "^0.5.0",
-            "path-posix": "^1.0.0",
-            "rimraf": "^2.4.3",
-            "symlink-or-copy": "^1.0.0",
-            "walk-sync": "^0.3.1"
-          }
-        },
-        "ember-cli-babel": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
-          "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
-          "requires": {
-            "amd-name-resolver": "1.2.0",
-            "babel-plugin-debug-macros": "^0.2.0-beta.6",
-            "babel-plugin-ember-modules-api-polyfill": "^2.6.0",
-            "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
-            "babel-polyfill": "^6.26.0",
-            "babel-preset-env": "^1.7.0",
-            "broccoli-babel-transpiler": "^6.5.0",
-            "broccoli-debug": "^0.6.4",
-            "broccoli-funnel": "^2.0.0",
-            "broccoli-source": "^1.1.0",
-            "clone": "^2.0.0",
-            "ember-cli-version-checker": "^2.1.2",
-            "semver": "^5.5.0"
-          }
-        }
-      }
-    },
     "@ember-intl/formatjs-extract-cldr-data": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@ember-intl/formatjs-extract-cldr-data/-/formatjs-extract-cldr-data-6.1.0.tgz",
@@ -13117,16 +13066,6 @@
         }
       }
     },
-    "ember-cp-validations": {
-      "version": "4.0.0-beta.10",
-      "resolved": "https://registry.npmjs.org/ember-cp-validations/-/ember-cp-validations-4.0.0-beta.10.tgz",
-      "integrity": "sha512-XaBdrtG6jGJBsCWyDpkdPAPziI1HBRAtdKhr1dNXIPDtBpMeGsgGM57n41O63i6KbA8efOpEgGUf/OvzZChoJg==",
-      "requires": {
-        "ember-cli-babel": "^7.1.2",
-        "ember-require-module": "^0.3.0",
-        "ember-validators": "^2.0.0"
-      }
-    },
     "ember-data": {
       "version": "3.17.0",
       "resolved": "https://registry.npmjs.org/ember-data/-/ember-data-3.17.0.tgz",
@@ -15356,56 +15295,6 @@
         "ember-cli-babel": "^7.13.2"
       }
     },
-    "ember-require-module": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/ember-require-module/-/ember-require-module-0.3.0.tgz",
-      "integrity": "sha512-rYN4YoWbR9VlJISSmx0ZcYZOgMcXZLGR7kdvp3zDerjIvYmHm/3p+K56fEAYmJILA6W4F+cBe41Tq2HuQAZizA==",
-      "requires": {
-        "ember-cli-babel": "^6.9.2"
-      },
-      "dependencies": {
-        "broccoli-funnel": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
-          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
-          "requires": {
-            "array-equal": "^1.0.0",
-            "blank-object": "^1.0.1",
-            "broccoli-plugin": "^1.3.0",
-            "debug": "^2.2.0",
-            "fast-ordered-set": "^1.0.0",
-            "fs-tree-diff": "^0.5.3",
-            "heimdalljs": "^0.2.0",
-            "minimatch": "^3.0.0",
-            "mkdirp": "^0.5.0",
-            "path-posix": "^1.0.0",
-            "rimraf": "^2.4.3",
-            "symlink-or-copy": "^1.0.0",
-            "walk-sync": "^0.3.1"
-          }
-        },
-        "ember-cli-babel": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
-          "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
-          "requires": {
-            "amd-name-resolver": "1.2.0",
-            "babel-plugin-debug-macros": "^0.2.0-beta.6",
-            "babel-plugin-ember-modules-api-polyfill": "^2.6.0",
-            "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
-            "babel-polyfill": "^6.26.0",
-            "babel-preset-env": "^1.7.0",
-            "broccoli-babel-transpiler": "^6.5.0",
-            "broccoli-debug": "^0.6.4",
-            "broccoli-funnel": "^2.0.0",
-            "broccoli-source": "^1.1.0",
-            "clone": "^2.0.0",
-            "ember-cli-version-checker": "^2.1.2",
-            "semver": "^5.5.0"
-          }
-        }
-      }
-    },
     "ember-resolver": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/ember-resolver/-/ember-resolver-7.0.0.tgz",
@@ -16637,57 +16526,6 @@
           "dev": true,
           "requires": {
             "got": "^8.0.1"
-          }
-        }
-      }
-    },
-    "ember-validators": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ember-validators/-/ember-validators-2.0.0.tgz",
-      "integrity": "sha512-OhXGN2UbFQY+lhkWOdW347NZsIWGj/fpTJbOfNxjyMQW/c3fvPEIvrhlvWf1JwHGKQTJDHpMQJgA/Luq39GDgQ==",
-      "requires": {
-        "ember-cli-babel": "^6.9.2",
-        "ember-require-module": "^0.3.0"
-      },
-      "dependencies": {
-        "broccoli-funnel": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
-          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
-          "requires": {
-            "array-equal": "^1.0.0",
-            "blank-object": "^1.0.1",
-            "broccoli-plugin": "^1.3.0",
-            "debug": "^2.2.0",
-            "fast-ordered-set": "^1.0.0",
-            "fs-tree-diff": "^0.5.3",
-            "heimdalljs": "^0.2.0",
-            "minimatch": "^3.0.0",
-            "mkdirp": "^0.5.0",
-            "path-posix": "^1.0.0",
-            "rimraf": "^2.4.3",
-            "symlink-or-copy": "^1.0.0",
-            "walk-sync": "^0.3.1"
-          }
-        },
-        "ember-cli-babel": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
-          "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
-          "requires": {
-            "amd-name-resolver": "1.2.0",
-            "babel-plugin-debug-macros": "^0.2.0-beta.6",
-            "babel-plugin-ember-modules-api-polyfill": "^2.6.0",
-            "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
-            "babel-polyfill": "^6.26.0",
-            "babel-preset-env": "^1.7.0",
-            "broccoli-babel-transpiler": "^6.5.0",
-            "broccoli-debug": "^0.6.4",
-            "broccoli-funnel": "^2.0.0",
-            "broccoli-source": "^1.1.0",
-            "clone": "^2.0.0",
-            "ember-cli-version-checker": "^2.1.2",
-            "semver": "^5.5.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
-    "@ember-intl/cp-validations": "^4.0.1",
     "@ember/render-modifiers": "^1.0.2",
     "@fortawesome/ember-fontawesome": "^0.2.0",
     "@fortawesome/free-brands-svg-icons": "^5.6.1",
@@ -52,7 +51,6 @@
     "ember-composable-helpers": "^4.0.0",
     "ember-concurrency": "^1.0.0",
     "ember-concurrency-decorators": "^1.0.0",
-    "ember-cp-validations": "^4.0.0-beta.9",
     "ember-data": "3.17.0",
     "ember-drag-drop": "^0.7.0",
     "ember-event-helpers": "^0.1.0",


### PR DESCRIPTION
add those as dev-dependencies in frontend's `package.json` with next common release bump there:

- `"@ember-intl/cp-validations": "^4.0.1",`
- `"ember-cp-validations": "^4.0.0-beta.9",`