### PR TITLE
Replace save status modal with a live button

### DIFF
--- a/addon/components/offering-form.hbs
+++ b/addon/components/offering-form.hbs
@@ -257,21 +257,18 @@
         {{/each}}
       </div>
       <div class="buttons" {{ref this "scrollTo"}}>
-        <button
+        <SaveButton
           class="done text"
-          type="button"
-          disabled={{or this.saveOffering.isRunning}}
-          {{on "click" (perform this.validateThenSaveOffering)}}
+          @isSaving={{this.saveOffering.isRunning}}
+          @saveProgressPercent={{this.saveProgressPercent}}
+          {{on "click" (perform this.saveOffering)}}
         >
-          {{#if this.saveOffering.isRunning}}
-            <LoadingSpinner />
-          {{else}}
-            {{t "general.done"}}
-          {{/if}}
-        </button>
+          {{t "general.save"}}
+        </SaveButton>
         <button
           class="cancel text"
           type="button"
+          disabled={{this.saveOffering.isRunning}}
           {{on "click" @close}}
         >
           {{t "general.cancel"}}
@@ -279,11 +276,4 @@
       </div>
     </div>
   {{/unless}}
-  {{#if this.saveOffering.isRunning}}
-    <WaitSaving
-      @showProgress={{true}}
-      @totalProgress={{this.offeringsToSave}}
-      @currentProgress={{this.savedOfferings}}
-    />
-  {{/if}}
 </div>

--- a/addon/components/publish-all-sessions.hbs
+++ b/addon/components/publish-all-sessions.hbs
@@ -314,17 +314,12 @@
         ignoreCount=this.ignoreCount
       }}
     </p>
-    <button type="button" {{on "click" (perform this.save)}}>
+    <SaveButton
+      @isSaving={{this.save.isRunning}}
+      @saveProgressPercent={{this.saveProgressPercent}}
+      {{on "click" (perform this.save)}}
+    >
       {{t "general.go"}}
-    </button>
+    </SaveButton>
   </div>
 </div>
-
-
-{{#if this.save.isRunning}}
-  <WaitSaving
-    @showProgress={{true}}
-    @totalProgress={{this.totalSessionsToSave}}
-    @currentProgress={{this.currentSessionsSaved}}
-  />
-{{/if}}

--- a/addon/components/save-button.hbs
+++ b/addon/components/save-button.hbs
@@ -1,0 +1,14 @@
+<button type="button" disabled={{@isSaving}} ...attributes>
+  {{#if @isSaving}}
+    {{#if (eq @saveProgressPercent 100)}}
+      <FaIcon @icon="check" />
+    {{else}}
+      <FaIcon @icon="spinner" @spin={{true}} />
+    {{/if}}
+    {{#if @saveProgressPercent}}
+      {{@saveProgressPercent}}%
+    {{/if}}
+  {{else}}
+    {{yield}}
+  {{/if}}
+</button>

--- a/app/components/save-button.js
+++ b/app/components/save-button.js
@@ -1,0 +1,1 @@
+export { default } from 'ilios-common/components/save-button';

--- a/tests/integration/components/save-button-test.js
+++ b/tests/integration/components/save-button-test.js
@@ -1,0 +1,31 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | save-button', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    await render(hbs`<SaveButton>Save</SaveButton>`);
+    assert.dom().hasText('Save');
+  });
+
+  test('it displays save percent and spinner when saving', async function(assert) {
+    await render(hbs`<SaveButton @isSaving={{true}} @saveProgressPercent={{11}}>Save</SaveButton>`);
+    assert.dom('[data-icon="spinner"]').exists();
+    assert.dom().hasText('11%');
+  });
+
+  test('icon is a check at 100%', async function(assert) {
+    await render(hbs`<SaveButton @isSaving={{true}} @saveProgressPercent={{100}}>Save</SaveButton>`);
+    assert.dom('[data-icon="check"]').exists();
+    assert.dom().hasText('100%');
+  });
+
+  test('binds passed action', async function (assert) {
+    this.set('click', () => assert.ok(true));
+    await render(hbs`<SaveButton data-test-save {{on "click" this.click}}>Save</SaveButton>`);
+    await click('[data-test-save]');
+  });
+});


### PR DESCRIPTION
Because WaitSaving uses a modal dialog that gets wormholed out to a
different location in the DOM it is susceptible to missing it's queue to
be destroyed when the component containing it is removed. Instead of a
modal this makes the button into their own live saving state with a
spinner, percentage, and check mark when complete.

Fixes #1345