### PR TITLE
Add My Materials link to the dashboard

### DIFF
--- a/addon/components/dashboard-materials.hbs
+++ b/addon/components/dashboard-materials.hbs
@@ -3,6 +3,12 @@
   {{did-insert (perform this.load)}}
   {{did-update (perform this.load)}}
 >
+  <div class="all-materials" data-test-all-materials-link>
+    {{t "general.view"}}:
+    <LinkTo @route="mymaterials">
+      {{t "general.myMaterials"}}
+    </LinkTo>
+  </div>
   <h3>
     {{t "general.upcomingMaterials" days=this.daysInAdvance}}
   </h3>

--- a/app/styles/ilios-common/components/dashboard-materials.scss
+++ b/app/styles/ilios-common/components/dashboard-materials.scss
@@ -16,6 +16,20 @@
     @include ilios-table-colors;
   }
 
+  .all-materials {
+    display: flex;
+    justify-content: flex-end;
+
+    @include for-tablet-and-up {
+      float: right;
+    }
+
+    a {
+      @include ilios-link;
+      margin-left: .25rem;
+    }
+  }
+
   .lm-type-icon {
     color: $dark-grey;
   }

--- a/tests/integration/components/dashboard-materials-test.js
+++ b/tests/integration/components/dashboard-materials-test.js
@@ -71,7 +71,7 @@ module('Integration | Component | dashboard materials', function(hooks) {
 
 
   test('it renders with materials', async function(assert) {
-    assert.expect(41);
+    assert.expect(42);
     const currentUserMock = Service.extend({
       currentUserId: 11
     });
@@ -143,6 +143,7 @@ module('Integration | Component | dashboard materials', function(hooks) {
     const fifthFirstOffering = `${materials}:nth-of-type(5) td:nth-of-type(5)`;
 
     assert.dom(this.element.querySelector(title)).hasText('My Learning Materials for the next 60 days');
+    assert.dom('[data-test-all-materials-link]').hasText('View: My Materials');
 
     assert.ok(find(firstLmTitle).textContent.includes('title1'));
     assert.equal(find(firstLmLink).href, 'http://myhost.com/url1?inline');
@@ -185,7 +186,7 @@ module('Integration | Component | dashboard materials', function(hooks) {
   });
 
   test('it renders blank', async function(assert) {
-    assert.expect(8);
+    assert.expect(9);
     const currentUserMock = Service.extend({
       currentUserId: 11
     });
@@ -213,6 +214,7 @@ module('Integration | Component | dashboard materials', function(hooks) {
     const body = 'p';
 
     await render(hbs`<DashboardMaterials />`);
+    assert.dom('[data-test-all-materials-link]').hasText('View: My Materials');
     assert.dom(this.element.querySelector(title)).hasText('My Learning Materials for the next 60 days');
     assert.dom(this.element.querySelector(body)).hasText('None');
   });

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -173,6 +173,7 @@ general:
   multidayEvents: "Multiday Events"
   multiple: Multiple
   mustBeSameDayOfWeekAsCurrentStartDate: "Must be same day of week as current start date"
+  myMaterials: "My Materials"
   mySchedule: "My Schedule"
   newObjective: "New Objective"
   newObjectiveSaved: "New Objective Saved"

--- a/translations/es.yaml
+++ b/translations/es.yaml
@@ -173,6 +173,7 @@ general:
   multidayEvents: "Eventos de Varios Días"
   multiple: "Múltiple "
   mustBeSameDayOfWeekAsCurrentStartDate: "Debe ser el mismo día de la semana en curso como fecha de inicio"
+  myMaterials: "Mis Materiales"
   mySchedule: "Mi Horario"
   newObjective: "Nuevo Objetivo"
   newObjectiveSaved: "Nuevo Objetivo Guardado"

--- a/translations/fr.yaml
+++ b/translations/fr.yaml
@@ -173,6 +173,7 @@ general:
   multidayEvents: "Événements de plusieurs jours"
   multiple: Multiple
   mustBeSameDayOfWeekAsCurrentStartDate: "Doit être le même jour de la semaine que le courant date de début"
+  myMaterials: "Mes Matériels d'étude"
   mySchedule: "Mon Calendrier (liste)"
   newObjective: "Nouvel Objectif"
   newObjectiveSaved: "Nouvel objective sauvé"


### PR DESCRIPTION
When browsing the materials view on the dashboard it's not intuitive to
go to the user profile dropdown to navigate to My Materials, instead
this adds a link in the same place as WaaG to get to that view.