### PR TITLE
Add edit button to learning material list

### DIFF
--- a/addon/components/detail-learning-materials.hbs
+++ b/addon/components/detail-learning-materials.hbs
@@ -169,13 +169,12 @@
               </td>
               <td class="text-left text-center" colspan="1">
                 {{#if @editable}}
-                  <span
-                    class="clickable remove"
-                    role="button"
-                    {{on "click" (fn this.confirmRemoval lmProxy)}}
-                  >
-                    <FaIcon @icon="trash" class="enabled" />
-                  </span>
+                  <button type="button" class="icon-button" {{on "click" (fn (set this.managingMaterial lmProxy.content))}}>
+                    <FaIcon @icon="edit" />
+                  </button>
+                  <button type="button" class="icon-button remove" {{on "click" (fn this.confirmRemoval lmProxy)}}>
+                    <FaIcon @icon="trash" />
+                  </button>
                 {{else}}
                   <FaIcon @icon="trash" class="disabled" />
                 {{/if}}

--- a/app/styles/ilios-common/components/detail-learningmaterials.scss
+++ b/app/styles/ilios-common/components/detail-learningmaterials.scss
@@ -96,9 +96,12 @@
       }
     }
 
-
-    .fa-trash {
-      @include icon;
+    .icon-button {
+      @include ilios-button-reset;
+      color: $ilios-blue;
+      &.remove {
+        color: $ilios-remove-color;
+      }
     }
   }
 


### PR DESCRIPTION
Does the same thing as clicking the LM title, but might be a little bit
more obvious for users who don't want to unintentionally download the
LM file itself.

Fixes #1374