### PR TITLE
Allow course object to have multiple parents when configured

### DIFF
--- a/addon/components/course/manage-objective-parents.hbs
+++ b/addon/components/course/manage-objective-parents.hbs
@@ -47,11 +47,10 @@
                       @title={{objective.title}}
                       @allowMultipleParents={{this.selectedCohort.allowMultipleParents}}
                       @isSelected={{contains objective @selected}}
-                      @add={{
-                        pipe
-                          (unless this.selectedCohort.allowMultipleParents (fn @removeFromCohort this.selectedCohort))
-                          (fn @add objective)
-                        }}
+                      @add={{pipe
+                        (if this.selectedCohort.allowMultipleParents (noop) (fn @removeFromCohort this.selectedCohort))
+                        (fn @add objective)
+                      }}
                       @remove={{fn @remove objective}}
                     />
                   </li>

--- a/addon/components/course/objective-list.js
+++ b/addon/components/course/objective-list.js
@@ -43,6 +43,8 @@ export default class CourseObjectiveListComponent extends Component {
     return await map(cohorts, async cohort => {
       const programYear = await cohort.programYear;
       const program = await programYear.program;
+      const school = await program.school;
+      const allowMultipleCourseObjectiveParents = await school.getConfigValue('allowMultipleCourseObjectiveParents');
       const objectives = await programYear.objectives;
       const objectiveObjects = await map(objectives, async objective => {
         let competencyId = 0;
@@ -78,6 +80,7 @@ export default class CourseObjectiveListComponent extends Component {
       return {
         title: `${program.title} ${cohort.title}`,
         id: cohort.id,
+        allowMultipleParents: allowMultipleCourseObjectiveParents,
         competencies,
       };
     });


### PR DESCRIPTION
This configuration option wasn't being passed through correctly after
the refactor to Octane objectives. Fixed and added a test.

Fixes #1392