### PR TITLE
Add polyfill for safari 12

### DIFF
--- a/addon/utils/load-polyfills.js
+++ b/addon/utils/load-polyfills.js
@@ -1,6 +1,8 @@
 export async function loadPolyfills() {
-  await intlPluralRules();
-  await intlRelativeTimeFormat();
+  await Promise.all([
+    intlPluralRules(),
+    intlRelativeTimeFormat(),
+  ]);
 }
 
 async function intlPluralRules() {
@@ -9,17 +11,22 @@ async function intlPluralRules() {
   }
 
   await import('@formatjs/intl-pluralrules/polyfill');
-  await import('@formatjs/intl-pluralrules/dist/locale-data/en');
-  await import('@formatjs/intl-pluralrules/dist/locale-data/es');
-  await import('@formatjs/intl-pluralrules/dist/locale-data/fr');
+  await Promise.all([
+    import('@formatjs/intl-pluralrules/dist/locale-data/en'),
+    import('@formatjs/intl-pluralrules/dist/locale-data/es'),
+    import('@formatjs/intl-pluralrules/dist/locale-data/fr'),
+  ]);
 }
 
 async function intlRelativeTimeFormat() {
   if ('Intl' in window && 'RelativeTimeFormat' in Intl) {
     return;
   }
-  import('@formatjs/intl-relativetimeformat/polyfill');
-  import('@formatjs/intl-relativetimeformat/dist/locale-data/en');
-  import('@formatjs/intl-relativetimeformat/dist/locale-data/es');
-  import('@formatjs/intl-relativetimeformat/dist/locale-data/fr');
+
+  await import('@formatjs/intl-relativetimeformat/polyfill');
+  await Promise.all([
+    import('@formatjs/intl-relativetimeformat/dist/locale-data/en'),
+    import('@formatjs/intl-relativetimeformat/dist/locale-data/es'),
+    import('@formatjs/intl-relativetimeformat/dist/locale-data/fr'),
+  ]);
 }

--- a/addon/utils/load-polyfills.js
+++ b/addon/utils/load-polyfills.js
@@ -1,0 +1,25 @@
+export async function loadPolyfills() {
+  await intlPluralRules();
+  await intlRelativeTimeFormat();
+}
+
+async function intlPluralRules() {
+  if ('Intl' in window && 'PluralRules' in Intl) {
+    return;
+  }
+
+  await import('@formatjs/intl-pluralrules/polyfill');
+  await import('@formatjs/intl-pluralrules/dist/locale-data/en');
+  await import('@formatjs/intl-pluralrules/dist/locale-data/es');
+  await import('@formatjs/intl-pluralrules/dist/locale-data/fr');
+}
+
+async function intlRelativeTimeFormat() {
+  if ('Intl' in window && 'RelativeTimeFormat' in Intl) {
+    return;
+  }
+  import('@formatjs/intl-relativetimeformat/polyfill');
+  import('@formatjs/intl-relativetimeformat/dist/locale-data/en');
+  import('@formatjs/intl-relativetimeformat/dist/locale-data/es');
+  import('@formatjs/intl-relativetimeformat/dist/locale-data/fr');
+}

--- a/index.js
+++ b/index.js
@@ -104,9 +104,16 @@ module.exports = {
         return `<link rel="preload" href="${rootUrl}/assets/fonts/${font}" as="font" type="font/woff2" crossorigin="anonymous">`;
       });
       const linkText = links.join("\n");
+      let polyfillIoScript = '';
+
+      if (env.environment === "production") {
+        //provides polyfills based on the users browser, Safari 12 requires Intl.PluralRules and Intl.RelativeTimeFormat for each locale we support
+        polyfillIoScript = '<script src="https://polyfill.io/v3/polyfill.min.js?version=3.52.1&features=Intl.PluralRules%252CIntl.PluralRules.%257Elocale.en%252CIntl.PluralRules.%257Elocale.es%252CIntl.PluralRules.%257Elocale.fr%252CIntl.RelativeTimeFormat%252CIntl.RelativeTimeFormat.%257Elocale.en%252CIntl.RelativeTimeFormat.%257Elocale.fr%252CIntl.RelativeTimeFormat.%257Elocale.es"></script>';
+      }
 
       return `
         <title>Ilios</title>
+        ${polyfillIoScript}
         ${linkText}
       `;
     }

--- a/index.js
+++ b/index.js
@@ -104,16 +104,9 @@ module.exports = {
         return `<link rel="preload" href="${rootUrl}/assets/fonts/${font}" as="font" type="font/woff2" crossorigin="anonymous">`;
       });
       const linkText = links.join("\n");
-      let polyfillIoScript = '';
-
-      if (env.environment === "production") {
-        //provides polyfills based on the users browser, Safari 12 requires Intl.PluralRules and Intl.RelativeTimeFormat for each locale we support
-        polyfillIoScript = '<script src="https://polyfill.io/v3/polyfill.min.js?version=3.52.1&features=Intl.PluralRules%252CIntl.PluralRules.%257Elocale.en%252CIntl.PluralRules.%257Elocale.es%252CIntl.PluralRules.%257Elocale.fr%252CIntl.RelativeTimeFormat%252CIntl.RelativeTimeFormat.%257Elocale.en%252CIntl.RelativeTimeFormat.%257Elocale.fr%252CIntl.RelativeTimeFormat.%257Elocale.es"></script>';
-      }
 
       return `
         <title>Ilios</title>
-        ${polyfillIoScript}
         ${linkText}
       `;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3418,6 +3418,22 @@
         "@formatjs/intl-utils": "^3.1.0"
       }
     },
+    "@formatjs/intl-pluralrules": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-pluralrules/-/intl-pluralrules-2.2.1.tgz",
+      "integrity": "sha512-2iKcf/t9UtpGPUADdv5QV/nMmb+BKse7Jph/OV7nOyypqESebdYQQsRHg+zs+9ug1BkcNJutOdp6mSnOPJf0Mw==",
+      "requires": {
+        "@formatjs/intl-utils": "^3.1.0"
+      }
+    },
+    "@formatjs/intl-relativetimeformat": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-5.2.1.tgz",
+      "integrity": "sha512-OKUdYNtWIpfwPGqadbRnD3Y2mgyEL6GwPyvcLjpfAk5Sd63q4D4FLAwdMdOCGDR+13yQDGRaT/fUKSJxYdgmCQ==",
+      "requires": {
+        "@formatjs/intl-utils": "^3.1.0"
+      }
+    },
     "@formatjs/intl-utils": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-3.1.0.tgz",
@@ -5617,6 +5633,15 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.3.0.tgz",
       "integrity": "sha512-nAihlQsYGyc5Bwq6+EsubvANYGExeJKHDO3RjnvwU042fawQTQfM3Kxn7IHUXQOz4bzfwsGYYHGSvXyW4zOGLg=="
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "blank-object": {
       "version": "1.0.2",
@@ -18731,6 +18756,12 @@
         "flat-cache": "^2.0.1"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "filesize": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-4.2.1.tgz",
@@ -22017,6 +22048,12 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+    },
+    "nan": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -27106,7 +27143,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
   },
   "dependencies": {
     "@ember/render-modifiers": "^1.0.2",
+    "@formatjs/intl-pluralrules": "^2.2.1",
+    "@formatjs/intl-relativetimeformat": "^5.2.1",
     "@fortawesome/ember-fontawesome": "^0.2.0",
     "@fortawesome/free-brands-svg-icons": "^5.6.1",
     "@fortawesome/free-regular-svg-icons": "^5.6.1",

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -1,11 +1,13 @@
 import Route from '@ember/routing/route';
 import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mixin';
 import { inject as service } from '@ember/service';
+import { loadPolyfills } from 'ilios-common/utils/load-polyfills';
 
 export default Route.extend(ApplicationRouteMixin, {
   intl: service(),
   moment: service(),
-  beforeModel() {
+  async beforeModel() {
+    await loadPolyfills();
     this.intl.setLocale('en-us');
     this.moment.setLocale('en');
   }

--- a/tests/dummy/config/targets.js
+++ b/tests/dummy/config/targets.js
@@ -12,7 +12,8 @@ const isProduction = process.env.EMBER_ENV === 'production';
 if (isCI || isProduction) {
   browsers.push('last 1 edge versions');
   browsers.push('firefox esr'); //sometimes points to the last 2 ESR releases when they overlap
-  browsers.push('last 1 ios versions');
+  browsers.push('last 4 ios versions');
+  browsers.push('last 3 safari versions');
 }
 
 module.exports = {

--- a/tests/unit/utils/load-polyfills-test.js
+++ b/tests/unit/utils/load-polyfills-test.js
@@ -1,0 +1,10 @@
+import { loadPolyfills } from 'ilios-common/utils/load-polyfills';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | loadPolyfills', function() {
+
+  test('it works', async function(assert) {
+    await loadPolyfills();
+    assert.ok(true);
+  });
+});


### PR DESCRIPTION
This version, which is still in active use, doesn't have the Intl libs
we need. ~Using the polyfill.io service creates a script that uses the
browser agent to decide what data to send so users of more modern
browsers won't need to download and execute this.~

Instead of relying on a third party service which may block loading
indefinitely if it is down and which we'll need to remember to keep
updated this loads the polyfills we need for Safari 12 by doing feature
detection and then async loading each script.

Fixes #1412