### PR TITLE
Pin @formatjs intl libraries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3944,9 +3944,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.0.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.9.tgz",
-      "integrity": "sha512-0sCTiXKXELOBxvZLN4krQ0FPOAA7ij+6WwvD0k/PHd9/KAkr4dXel5J9fh6F4x1FwAQILqAWkmpeuS6mjf1iKA=="
+      "version": "14.0.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.10.tgz",
+      "integrity": "sha512-Bz23oN/5bi0rniKT24ExLf4cK0JdvN3dH/3k0whYkdN4eI4vS2ZW/2ENNn2uxHCzWcbdHIa/GRuWQytfzCjRYw=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -9007,9 +9007,9 @@
       },
       "dependencies": {
         "entities": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.2.tgz",
-          "integrity": "sha512-dmD3AvJQBUjKpcNkoqr+x+IF0SdRtPz9Vk0uTy4yWqga9ibB6s4v++QFWNohjiUGoMlF552ZvNyXDxz5iW0qmw==",
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+          "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
           "dev": true
         }
       }
@@ -9173,9 +9173,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.458",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.458.tgz",
-      "integrity": "sha512-OjRkb0igW0oKE2QbzS7vBYrm7xjW/KRTtIj0OGGx57jr/YhBiKb7oZvdbaojqjfCb/7LbnwsbMbdsYjthdJbAw=="
+      "version": "1.3.459",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.459.tgz",
+      "integrity": "sha512-aN3Z89qEYIwVjzGi9SrcTjjopRZ3STUA6xTufS0fxZy8xOO2iqVw8rYKdT32CHgOKHOYj5KGmz3n6xUKE4QJiQ=="
     },
     "element-resize-detector": {
       "version": "1.2.1",
@@ -16389,9 +16389,9 @@
           }
         },
         "eslint-scope": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
-          "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
+          "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
           "requires": {
             "esrecurse": "^4.1.0",
             "estraverse": "^4.1.1"
@@ -17768,9 +17768,9 @@
       }
     },
     "engine.io": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.4.1.tgz",
-      "integrity": "sha512-8MfIfF1/IIfxuc2gv5K+XlFZczw/BpTvqBdl0E2fBLkYQp4miv4LuDTVtYt4yMyaIFLEr4vtaSgV4mjvll8Crw==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.4.2.tgz",
+      "integrity": "sha512-b4Q85dFkGw+TqgytGPrGgACRUhsdKc9S9ErRAXpPGy/CXKs4tYoHDkvIRdsseAF7NjfVwjRFIn6KTnbw7LwJZg==",
       "dev": true,
       "requires": {
         "accepts": "~1.3.4",
@@ -17796,9 +17796,9 @@
       }
     },
     "engine.io-client": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.2.tgz",
-      "integrity": "sha512-AWjc1Xg06a6UPFOBAzJf48W1UR/qKYmv/ubgSCumo9GXgvL/xGIvo05dXoBL+2NTLMipDI7in8xK61C17L25xg==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.3.tgz",
+      "integrity": "sha512-0NGY+9hioejTEJCaSJZfWZLk4FPI9dN+1H1C4+wj2iuFba47UgZbJzfWs4aNFajnX/qAaYKbe2lLTfEEWzCmcw==",
       "dev": true,
       "requires": {
         "component-emitter": "~1.3.0",
@@ -18031,9 +18031,9 @@
           "dev": true
         },
         "eslint-scope": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
-          "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
+          "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
           "dev": true,
           "requires": {
             "esrecurse": "^4.1.0",
@@ -18050,14 +18050,14 @@
           }
         },
         "espree": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-7.0.0.tgz",
-          "integrity": "sha512-/r2XEx5Mw4pgKdyb7GNLQNsu++asx/dltf/CI8RFi9oGHxmQFgvLbc5Op4U6i8Oaj+kdslhJtVlEZeAqH5qOTw==",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-7.1.0.tgz",
+          "integrity": "sha512-dcorZSyfmm4WTuTnE5Y7MEN1DyoPYy1ZR783QW1FJoenn7RailyWFsq/UL6ZAAA7uXurN9FIpYyUs3OfiIW+Qw==",
           "dev": true,
           "requires": {
-            "acorn": "^7.1.1",
+            "acorn": "^7.2.0",
             "acorn-jsx": "^5.2.0",
-            "eslint-visitor-keys": "^1.1.0"
+            "eslint-visitor-keys": "^1.2.0"
           }
         },
         "globals": {
@@ -18221,9 +18221,9 @@
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.2.0.tgz",
+      "integrity": "sha512-WFb4ihckKil6hu3Dp798xdzSfddwKKU3+nGniKF6HfeW6OLd2OUDEPP7TcHtB5+QXOKg2s6B2DaMPE1Nn/kxKQ=="
     },
     "esm": {
       "version": "3.2.25",
@@ -20075,9 +20075,9 @@
       },
       "dependencies": {
         "entities": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.2.tgz",
-          "integrity": "sha512-dmD3AvJQBUjKpcNkoqr+x+IF0SdRtPz9Vk0uTy4yWqga9ibB6s4v++QFWNohjiUGoMlF552ZvNyXDxz5iW0qmw==",
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+          "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
           "dev": true
         }
       }
@@ -20386,25 +20386,43 @@
       "integrity": "sha512-97+A29MV0kp6Xzkb4CxBNxxDU4qldyVFNzvZIiLMYqIZFutT2DJCzE1TEv0hXdmFQfAIY4KhNhL6L1BEEU0J8w=="
     },
     "intl-format-cache": {
-      "version": "4.2.34",
-      "resolved": "https://registry.npmjs.org/intl-format-cache/-/intl-format-cache-4.2.34.tgz",
-      "integrity": "sha512-WNqj3hLG1Z9mpJPGLajslBDGYkinxNcyChHbIgGoDexrN2841d7gpinpsI5UzvH+qzV++NgnEaDNTdrRLcDnTw=="
+      "version": "4.2.35",
+      "resolved": "https://registry.npmjs.org/intl-format-cache/-/intl-format-cache-4.2.35.tgz",
+      "integrity": "sha512-ZNmFKRL+nONhiK11oe5F+fdsMwWX+PELD2cLraXVkEgI34Zb8ElAXzIhjcVijwrRocRZfSBuC6WStzW9+/VLcQ=="
     },
     "intl-messageformat": {
-      "version": "8.3.19",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-8.3.19.tgz",
-      "integrity": "sha512-43kN5K5Eg1X2gcGgvGtImroGsO4aozFaUKv0/JedTfwNYfCSBG5mhGCe3aaVbJoVc/lEDgb7PzOrRSrBulAWMQ==",
+      "version": "8.3.20",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-8.3.20.tgz",
+      "integrity": "sha512-FlwX5xvSubFWPHfdxMO2fsAqirjXe+n+AAFq2qjdC/yeXRXrJGq17S7626BeQWE/GYmSpvYAxDqH/WCGBPmm4Q==",
       "requires": {
-        "intl-format-cache": "^4.2.34",
-        "intl-messageformat-parser": "^5.0.12"
+        "intl-format-cache": "^4.2.35",
+        "intl-messageformat-parser": "^5.1.0"
       }
     },
     "intl-messageformat-parser": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-5.0.12.tgz",
-      "integrity": "sha512-jWsfY8Bq1rPoR/gHcpkC3quJFmR6Gp7Iq80+pIuaWyPOgXrpCw7rVPG0wowP8Mw0Qd9/MIsm0FEpSqS7d2dtWA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-5.1.0.tgz",
+      "integrity": "sha512-Qs5l8FNggCNTbDvIqUWOee6lx+iTHuYPOfugiScsAEV8VD2+rO/RtjQ0v+mCMqywMOBoVJM54zVTQ/MAw5dwyA==",
       "requires": {
-        "@formatjs/intl-numberformat": "^4.2.2"
+        "@formatjs/intl-numberformat": "^4.2.3"
+      },
+      "dependencies": {
+        "@formatjs/intl-numberformat": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@formatjs/intl-numberformat/-/intl-numberformat-4.2.3.tgz",
+          "integrity": "sha512-5QNxfAxHOOp0aET+Pok/mfAjjB0Gyd7rMi1ZtGQGVYdwZ9WmDxwJ159JROf0rEkyaytcai6wdSdlo/Qrj4aHZg==",
+          "requires": {
+            "@formatjs/intl-utils": "^3.3.0"
+          }
+        },
+        "@formatjs/intl-utils": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-3.3.0.tgz",
+          "integrity": "sha512-gEP8ay58r0bEXTo5ZFRIUIG16Ausyue4wWWWnvz+fFHORXSOXJTHef0itW/l7gfTxhqVqF7Zw/YZKMqCQZQJ4Q==",
+          "requires": {
+            "emojis-list": "^3.0.0"
+          }
+        }
       }
     },
     "into-stream": {
@@ -20653,12 +20671,12 @@
       }
     },
     "is-regex": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
+      "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
       "dev": true,
       "requires": {
-        "has": "^1.0.3"
+        "has-symbols": "^1.0.1"
       }
     },
     "is-regexp": {
@@ -21542,9 +21560,9 @@
       },
       "dependencies": {
         "entities": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.2.tgz",
-          "integrity": "sha512-dmD3AvJQBUjKpcNkoqr+x+IF0SdRtPz9Vk0uTy4yWqga9ibB6s4v++QFWNohjiUGoMlF552ZvNyXDxz5iW0qmw==",
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+          "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
           "dev": true
         }
       }
@@ -23016,9 +23034,9 @@
       "dev": true
     },
     "pbkdf2": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.0.tgz",
-      "integrity": "sha512-wHMFZ6HTLGlB9f/WsQBs5OwMQJoLXYuJUzbA+j+hRBf7+Y8KcXpatzIviIcTy1OAyhWQp08nyiPO8Dnv0z4Sww==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
+      "integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
       "requires": {
         "create-hash": "^1.1.2",
         "create-hmac": "^1.1.4",
@@ -25532,14 +25550,14 @@
       "dev": true
     },
     "stylelint": {
-      "version": "13.5.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.5.0.tgz",
-      "integrity": "sha512-+Jy7ieKAWKTf2tmcAE7jgScxH39Urb87i0bjK/enScFaGWWaFn4kAPwepGOSk2b7CLUDVt/O6kwA0x0p/V7moQ==",
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.6.0.tgz",
+      "integrity": "sha512-55gG2pNjVr183JJM/tlr3KAua6vTVX7Ho/lgKKuCIWszTZ1gmrXjX4Wok53SI8wRYFPbwKAcJGULQ77OJxTcNw==",
       "dev": true,
       "requires": {
         "@stylelint/postcss-css-in-js": "^0.37.1",
         "@stylelint/postcss-markdown": "^0.36.1",
-        "autoprefixer": "^9.7.6",
+        "autoprefixer": "^9.8.0",
         "balanced-match": "^1.0.0",
         "chalk": "^4.0.0",
         "cosmiconfig": "^6.0.0",
@@ -25548,10 +25566,10 @@
         "file-entry-cache": "^5.0.1",
         "get-stdin": "^8.0.0",
         "global-modules": "^2.0.0",
-        "globby": "^11.0.0",
+        "globby": "^11.0.1",
         "globjoin": "^0.1.4",
         "html-tags": "^3.1.0",
-        "ignore": "^5.1.4",
+        "ignore": "^5.1.8",
         "import-lazy": "^4.0.0",
         "imurmurhash": "^0.1.4",
         "known-css-properties": "^0.19.0",
@@ -25562,7 +25580,7 @@
         "meow": "^7.0.1",
         "micromatch": "^4.0.2",
         "normalize-selector": "^0.2.0",
-        "postcss": "^7.0.30",
+        "postcss": "^7.0.32",
         "postcss-html": "^0.36.0",
         "postcss-less": "^3.1.4",
         "postcss-media-query-parser": "^0.2.3",
@@ -25570,7 +25588,7 @@
         "postcss-resolve-nested-selector": "^0.1.1",
         "postcss-safe-parser": "^4.0.2",
         "postcss-sass": "^0.4.4",
-        "postcss-scss": "^2.0.0",
+        "postcss-scss": "^2.1.1",
         "postcss-selector-parser": "^6.0.2",
         "postcss-syntax": "^0.36.2",
         "postcss-value-parser": "^4.1.0",
@@ -25583,7 +25601,7 @@
         "sugarss": "^2.0.0",
         "svg-tags": "^1.0.0",
         "table": "^5.4.6",
-        "v8-compile-cache": "^2.1.0",
+        "v8-compile-cache": "^2.1.1",
         "write-file-atomic": "^3.0.3"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,10 @@
   },
   "dependencies": {
     "@ember/render-modifiers": "^1.0.2",
-    "@formatjs/intl-pluralrules": "^2.2.1",
-    "@formatjs/intl-relativetimeformat": "^5.2.1",
+    "@formatjs/intl-numberformat": "4.2.2",
+    "@formatjs/intl-pluralrules": "2.2.2",
+    "@formatjs/intl-relativetimeformat": "5.2.2",
+    "@formatjs/intl-utils": "3.2.0",
     "@fortawesome/ember-fontawesome": "^0.2.0",
     "@fortawesome/free-brands-svg-icons": "^5.6.1",
     "@fortawesome/free-regular-svg-icons": "^5.6.1",


### PR DESCRIPTION
intl-utils 3.3.0 doesn't work in browsers (only in node). In order to
avoid that release in our code I had to pin all of this stuff
temporarily.