### PR TITLE
Sort mesh decriptors by name

### DIFF
--- a/addon/components/detail-mesh.hbs
+++ b/addon/components/detail-mesh.hbs
@@ -40,7 +40,7 @@
         />
       {{else}}
         <ul class="selected-mesh-terms">
-          {{#each (sort-by "title" this.meshDescriptors) as |term|}}
+          {{#each (sort-by "name" this.meshDescriptors) as |term|}}
             <li>
               <span class="term-title">
                 {{term.name}}


### PR DESCRIPTION
They don't have a title, so that doesn't really work!