### PR TITLE
Replace title with page-title

### DIFF
--- a/addon/templates/mymaterials.hbs
+++ b/addon/templates/mymaterials.hbs
@@ -1,4 +1,4 @@
-{{title (t "general.learningMaterials")}}
+{{page-title (t "general.learningMaterials")}}
 <MyMaterials
   @courseIdFilter={{this.course}}
   @filter={{this.filter}}


### PR DESCRIPTION
{{title}} has been deprecated by ember-page-title in favor of
{{page-title}}.