### PR TITLE
Add URL to offerings

### DIFF
--- a/addon-test-support/ilios-common/page-objects/components/offering-form.js
+++ b/addon-test-support/ilios-common/page-objects/components/offering-form.js
@@ -54,6 +54,12 @@ const definition = {
     value: value('input'),
     hasError: isVisible('.validation-error-message')
   },
+  url: {
+    scope: '[data-test-url]',
+    set: fillable('input'),
+    value: value('input'),
+    hasError: isVisible('.validation-error-message')
+  },
   recurring: {
     scope: '.make-recurring',
     toggle: clickable('[data-test-toggle-yesno] [data-test-handle]'),

--- a/addon-test-support/ilios-common/page-objects/components/week-glance-event.js
+++ b/addon-test-support/ilios-common/page-objects/components/week-glance-event.js
@@ -4,6 +4,7 @@ import {
   create,
   hasClass,
   isPresent,
+  property,
   text
 } from 'ember-cli-page-object';
 
@@ -13,6 +14,8 @@ const definition = {
   date: text('[data-test-date]'),
   sessionType: text('[data-test-session-type]'),
   location: text('[data-test-location]'),
+  link: text('[data-test-url]'),
+  url: property('href', '[data-test-url] a'),
   hasDescription: isPresent('[data-test-description]'),
   description: text('[data-test-description]'),
   sessionAttributes: collection('[data-test-session-attributes] svg', {

--- a/addon-test-support/ilios-common/page-objects/session.js
+++ b/addon-test-support/ilios-common/page-objects/session.js
@@ -176,7 +176,8 @@ export default create({
         learnerGroups: collection('.offering-manager-learner-groups li', {
           title: text()
         }),
-        location: text('.offering-manager-location'),
+        location: text('[data-test-location]'),
+        url: property('href', '[data-test-url] a'),
         instructors: collection('.offering-manager-instructors [data-test-instructor]', {
           title: text()
         }),

--- a/addon/components/ilios-tooltip.js
+++ b/addon/components/ilios-tooltip.js
@@ -7,7 +7,7 @@ export default class TooltipComponent extends Component {
 
   @action
   setup(element) {
-    this._popper = createPopper(this.args.target, element);
+    this._popper = createPopper(this.args.target, element, this.args.options ?? {});
   }
 
   get applicationElement() {

--- a/addon/components/new-offering.js
+++ b/addon/components/new-offering.js
@@ -8,11 +8,12 @@ export default class NewObjectiveComponent extends Component {
   @tracked smallGroupMode = true;
 
   @action
-  async save(startDate, endDate, room, learnerGroups, learners, instructorGroups, instructors){
+  async save(startDate, endDate, room, url, learnerGroups, learners, instructorGroups, instructors){
     const offering = this.store.createRecord('offering', {
       startDate,
       endDate,
       room,
+      url,
       learnerGroups,
       learners,
       instructorGroups,

--- a/addon/components/offering-form.hbs
+++ b/addon/components/offering-form.hbs
@@ -202,6 +202,24 @@
             </span>
           {{/each}}
         </div>
+        <div class="item url" data-test-url>
+          <label>
+            {{t "general.url"}}:
+          </label>
+          {{! template-lint-disable no-bare-strings}}
+          <input
+            type="text"
+            placeholder="https://example.com"
+            value={{this.bestUrl}}
+            {{on "input" (pick "target.value" this.changeURL)}}
+            {{on "keyup" (fn this.addErrorDisplayFor "url")}}
+          >
+          {{#each (await (compute (fn this.getErrorsFor) "url")) as |message|}}
+            <span class="validation-error-message">
+              {{message}}
+            </span>
+          {{/each}}
+        </div>
       {{/if}}
       {{#if @showInstructors}}
         <div class="instructors item">

--- a/addon/components/offering-form.hbs
+++ b/addon/components/offering-form.hbs
@@ -211,8 +211,10 @@
             type="text"
             placeholder="https://example.com"
             value={{this.bestUrl}}
+            inputmode="url"
             {{on "input" (pick "target.value" this.changeURL)}}
             {{on "keyup" (fn this.addErrorDisplayFor "url")}}
+            {{on "focus" (fn this.selectAllText)}}
           >
           {{#each (await (compute (fn this.getErrorsFor) "url")) as |message|}}
             <span class="validation-error-message">

--- a/addon/components/offering-form.js
+++ b/addon/components/offering-form.js
@@ -12,6 +12,7 @@ import { ValidateIf } from "class-validator";
 import scrollIntoView from "scroll-into-view";
 
 const DEBOUNCE_DELAY = 600;
+const DEFAULT_URL_VALUE = 'https://';
 
 @validatable
 export default class OfferingForm extends Component {
@@ -122,7 +123,7 @@ export default class OfferingForm extends Component {
       return this.url;
     }
 
-    return 'https://';
+    return DEFAULT_URL_VALUE;
   }
 
   @restartableTask
@@ -245,8 +246,19 @@ export default class OfferingForm extends Component {
 
   @action
   changeURL(value) {
+    const regex = RegExp('https://http[s]?:');
+    if (regex.test(value)) {
+      value = value.substring(8);
+    }
     this.url = value;
     this.urlChanged = true;
+  }
+
+  @action
+  selectAllText({ target }) {
+    if (target.value === DEFAULT_URL_VALUE) {
+      target.select();
+    }
   }
 
   async loadAvailableInstructorGroups(cohorts) {

--- a/addon/components/offering-manager.hbs
+++ b/addon/components/offering-manager.hbs
@@ -51,24 +51,7 @@
     </div>
     <div class="offering-manager-location">
       <TruncateText @text={{@offering.room}} @length={{10}} data-test-location />
-      {{#if @offering.url}}
-        <span data-test-url>
-          <a href={{@offering.url}}>{{t "general.virtualSessionLink"}}</a>
-          <CopyButton
-            title={{@offering.url}}
-            @clipboardText={{@offering.url}}
-            @success={{perform this.textCopied}}
-            class={{if this.textCopied.isRunning "copying"}}
-            data-test-url
-          >
-            {{#if this.textCopied.isRunning}}
-              <FaIcon @icon="check" />
-            {{else}}
-              <FaIcon @icon="copy" />
-            {{/if}}
-          </CopyButton>
-        </span>
-      {{/if}}
+      <OfferingUrlDisplay @url={{@offering.url}} data-test-url />
     </div>
     <div class="offering-manager-instructors">
       <ul>

--- a/addon/components/offering-manager.hbs
+++ b/addon/components/offering-manager.hbs
@@ -50,7 +50,25 @@
       </ul>
     </div>
     <div class="offering-manager-location">
-      <TruncateText @text={{@offering.room}} @length={{10}} />
+      <TruncateText @text={{@offering.room}} @length={{10}} data-test-location />
+      {{#if @offering.url}}
+        <span data-test-url>
+          <a href={{@offering.url}}>{{t "general.virtualSessionLink"}}</a>
+          <CopyButton
+            title={{@offering.url}}
+            @clipboardText={{@offering.url}}
+            @success={{perform this.textCopied}}
+            class={{if this.textCopied.isRunning "copying"}}
+            data-test-url
+          >
+            {{#if this.textCopied.isRunning}}
+              <FaIcon @icon="check" />
+            {{else}}
+              <FaIcon @icon="copy" />
+            {{/if}}
+          </CopyButton>
+        </span>
+      {{/if}}
     </div>
     <div class="offering-manager-instructors">
       <ul>

--- a/addon/components/offering-manager.js
+++ b/addon/components/offering-manager.js
@@ -1,6 +1,8 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { timeout } from 'ember-concurrency';
+import { task } from 'ember-concurrency-decorators';
 
 export default class OfferingManagerComponent extends Component {
   @tracked isEditing =  false;
@@ -8,8 +10,8 @@ export default class OfferingManagerComponent extends Component {
   @tracked hoveredGroups = [];
 
   @action
-  save(startDate, endDate, room, learnerGroups, learners, instructorGroups, instructors){
-    this.args.offering.setProperties({startDate, endDate, room, learnerGroups, learners, instructorGroups, instructors});
+  save(startDate, endDate, room, url, learnerGroups, learners, instructorGroups, instructors){
+    this.args.offering.setProperties({startDate, endDate, room, url, learnerGroups, learners, instructorGroups, instructors});
 
     return this.args.offering.save();
   }
@@ -21,5 +23,10 @@ export default class OfferingManagerComponent extends Component {
     } else {
       this.hoveredGroups = [...this.hoveredGroups, id];
     }
+  }
+
+  @task
+  *textCopied(){
+    yield timeout(3000);
   }
 }

--- a/addon/components/offering-url-display.hbs
+++ b/addon/components/offering-url-display.hbs
@@ -1,0 +1,31 @@
+{{#if @url}}
+  <span
+    class="offering-url-display"
+    ...attributes
+  >
+    <a href={{@url}}>{{t "general.virtualSessionLink"}}</a>
+    <CopyButton
+      title={{@url}}
+      @clipboardText={{@url}}
+      @success={{perform this.copy}}
+      class={{if this.copy.isRunning "copying"}}
+      {{did-insert (set this.copyButton)}}
+      data-test-copy-url
+    >
+      {{#if this.copy.isRunning}}
+        <FaIcon @icon="check" />
+      {{else}}
+        <FaIcon @icon="copy" />
+      {{/if}}
+    </CopyButton>
+  </span>
+  {{#if (and this.copyButton this.copy.isRunning)}}
+    <IliosTooltip
+      @target={{this.copyButton}}
+      @options={{hash placement="right"}}
+      class="offering-url-display-success-message-tooltip"
+    >
+      {{t "general.copiedSuccessfully"}}
+    </IliosTooltip>
+  {{/if}}
+{{/if}}

--- a/addon/components/offering-url-display.hbs
+++ b/addon/components/offering-url-display.hbs
@@ -5,7 +5,7 @@
   >
     <a title={{@url}} href={{@url}}>{{t "general.virtualSessionLink"}}</a>
     <CopyButton
-      title={{@url}}
+      title={{t "general.copyLink"}}
       @clipboardText={{@url}}
       @success={{perform this.copy}}
       class={{if this.copy.isRunning "copying"}}

--- a/addon/components/offering-url-display.hbs
+++ b/addon/components/offering-url-display.hbs
@@ -3,7 +3,7 @@
     class="offering-url-display"
     ...attributes
   >
-    <a href={{@url}}>{{t "general.virtualSessionLink"}}</a>
+    <a title={{@url}} href={{@url}}>{{t "general.virtualSessionLink"}}</a>
     <CopyButton
       title={{@url}}
       @clipboardText={{@url}}

--- a/addon/components/offering-url-display.js
+++ b/addon/components/offering-url-display.js
@@ -1,0 +1,10 @@
+import Component from '@glimmer/component';
+import { restartableTask } from 'ember-concurrency-decorators';
+import { timeout } from 'ember-concurrency';
+
+export default class OfferingUrlDisplayComponent extends Component {
+  @restartableTask
+  *copy(){
+    yield timeout(1500);
+  }
+}

--- a/addon/components/sessions-grid-offering.js
+++ b/addon/components/sessions-grid-offering.js
@@ -37,8 +37,8 @@ export default class SessionsGridOffering extends Component {
   }
 
   @dropTask
-  *save(startDate, endDate, room, learnerGroups, learners, instructorGroups, instructors){
-    this.args.offering.setProperties({startDate, endDate, room, learnerGroups, learners, instructorGroups, instructors});
+  *save(startDate, endDate, room, url, learnerGroups, learners, instructorGroups, instructors){
+    this.args.offering.setProperties({startDate, endDate, room, url, learnerGroups, learners, instructorGroups, instructors});
     yield this.args.offering.save();
     this.updateUi.perform();
   }

--- a/addon/components/single-event.hbs
+++ b/addon/components/single-event.hbs
@@ -30,6 +30,7 @@
         {{/unless}}
       </div>
       <div class="single-event-location">
+        <OfferingUrlDisplay @url={{@event.url}} />
         {{@event.location}}
       </div>
       {{#if this.taughtBy}}

--- a/addon/components/week-glance-event.hbs
+++ b/addon/components/week-glance-event.hbs
@@ -48,6 +48,7 @@
         - {{@event.location}}
       </span>
     {{/if}}
+    <OfferingUrlDisplay @url={{@event.url}} class="url" data-test-url />
     <span class="session-attributes" data-test-session-attributes>
       {{#if @event.attireRequired}}
         <FaIcon

--- a/addon/decorators/validation.js
+++ b/addon/decorators/validation.js
@@ -8,6 +8,7 @@ import { Gt } from './validation/gt';
 import { Lte } from './validation/lte';
 import { IsInt } from './validation/is-int';
 import { IsTrue } from './validation/is-true';
+import { IsURL } from './validation/is-url';
 import { validatable } from './validation/validatable';
 import { ArrayNotEmpty } from './validation/array-not-empty';
 
@@ -18,6 +19,7 @@ export {
   Lte,
   IsInt,
   IsTrue,
+  IsURL,
   AfterDate,
   BeforeDate,
   Length,

--- a/addon/decorators/validation/is-url.js
+++ b/addon/decorators/validation/is-url.js
@@ -1,0 +1,29 @@
+import { registerDecorator } from "class-validator";
+import { getOwner } from '@ember/application';
+import testURL from "is-url";
+
+export function IsURL(validationOptions) {
+  return function (object, propertyName) {
+    registerDecorator({
+      name: 'IsURL',
+      target: object.constructor,
+      propertyName: propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value) {
+          if (!value) {
+            return true;
+          }
+          return testURL(value);
+        },
+        defaultMessage({ object: target }) {
+          const owner = getOwner(target);
+          const intl = owner.lookup('service:intl');
+          const description = intl.t('errors.description');
+
+          return intl.t('errors.url', { description });
+        }
+      },
+    });
+  };
+}

--- a/addon/models/offering.js
+++ b/addon/models/offering.js
@@ -10,6 +10,7 @@ const { all } = RSVP;
 export default Model.extend({
   room: attr('string'),
   site: attr('string'),
+  url: attr('string'),
   startDate: attr('date'),
   endDate: attr('date'),
   updatedAt: attr('date'),

--- a/app/components/offering-url-display.js
+++ b/app/components/offering-url-display.js
@@ -1,0 +1,1 @@
+export { default } from 'ilios-common/components/offering-url-display';

--- a/app/styles/ilios-common/components.scss
+++ b/app/styles/ilios-common/components.scss
@@ -76,6 +76,7 @@
 @import 'components/offering-calendar';
 @import 'components/offering-form';
 @import 'components/offering-manager';
+@import 'components/offering-url-display';
 @import 'components/print-course';
 @import 'components/progress-bar';
 @import 'components/publication-menu';

--- a/app/styles/ilios-common/components/offering-manager.scss
+++ b/app/styles/ilios-common/components/offering-manager.scss
@@ -14,8 +14,17 @@
   }
 
   .offering-manager-location {
+    display: flex;
+    flex-direction: column;
     grid-column-start: 3;
     overflow-wrap: anywhere;
+    .copy-btn {
+      @include ilios-link-button;
+
+      &.copying {
+        color: $ilios-green;
+      }
+    }
   }
 
   .offering-manager-instructors {

--- a/app/styles/ilios-common/components/offering-url-display.scss
+++ b/app/styles/ilios-common/components/offering-url-display.scss
@@ -1,6 +1,7 @@
 .offering-url-display {
   .copy-btn {
     @include ilios-link-button;
+    margin-left: .25em;
 
     &.copying {
       color: $ilios-green;

--- a/app/styles/ilios-common/components/offering-url-display.scss
+++ b/app/styles/ilios-common/components/offering-url-display.scss
@@ -1,0 +1,21 @@
+.offering-url-display {
+  .copy-btn {
+    @include ilios-link-button;
+
+    &.copying {
+      color: $ilios-green;
+    }
+  }
+}
+
+// tooltips are outside the document flow so have to be styled outside the component
+.offering-url-display-success-message-tooltip {
+  padding: 0;
+  .arrow {
+    display: none;
+  }
+  .content {
+    background-color: $ilios-green;
+    color: $white;
+  }
+}

--- a/app/styles/ilios-common/components/single-event.scss
+++ b/app/styles/ilios-common/components/single-event.scss
@@ -54,6 +54,14 @@
         color: $updated-color;
       }
     }
+
+    .single-event-location {
+      display: flex;
+
+      .offering-url-display {
+        margin-right: 1rem;
+      }
+    }
   }
 
   .single-event-offered-at {

--- a/app/styles/ilios-common/components/week-glance.scss
+++ b/app/styles/ilios-common/components/week-glance.scss
@@ -57,6 +57,11 @@
       font-style: italic;
     }
 
+    .url {
+      display: block;
+      margin-left: 1em;
+    }
+
     .learning-materials {
       margin-left: 2em;
 

--- a/config/api-version.js
+++ b/config/api-version.js
@@ -1,3 +1,3 @@
 /* eslint-env node */
 
-module.exports = 'v2.0';
+module.exports = 'v2.1';

--- a/package-lock.json
+++ b/package-lock.json
@@ -19730,6 +19730,16 @@
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         },
+        "isurl": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
+          "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+          "dev": true,
+          "requires": {
+            "has-to-string-tag-x": "^1.2.0",
+            "is-object": "^1.0.1"
+          }
+        },
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -20748,6 +20758,11 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
+    "is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
+    },
     "is-valid-glob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
@@ -20810,16 +20825,6 @@
         "binaryextensions": "1 || 2",
         "editions": "^1.1.1",
         "textextensions": "1 || 2"
-      }
-    },
-    "isurl": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
-      "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
-      "dev": true,
-      "requires": {
-        "has-to-string-tag-x": "^1.2.0",
-        "is-object": "^1.0.1"
       }
     },
     "jquery": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "ember-test-selectors": "^4.0.0",
     "ember-truth-helpers": "^2.0.0",
     "froala-editor": "^3.0.6",
+    "is-url": "^1.2.4",
     "normalize.css": "^8.0.1",
     "query-string": "^6.8.3",
     "scroll-into-view": "^1.9.3",

--- a/tests/acceptance/course/session/offerings-test.js
+++ b/tests/acceptance/course/session/offerings-test.js
@@ -56,6 +56,7 @@ module('Acceptance | Session - Offerings', function(hooks) {
       learnerGroups: [learnerGroup1, learnerGroup2],
       startDate: this.today.format(),
       endDate: this.today.clone().add(1, 'hour').format(),
+      url: 'https://ucsf.edu/',
     });
 
     this.offering2 = this.server.create('offering', {
@@ -73,6 +74,7 @@ module('Acceptance | Session - Offerings', function(hooks) {
       instructors: [],
       startDate: this.today.clone().add(2, 'days').format(),
       endDate: this.today.clone().add(3, 'days').add(1, 'hour').format(),
+      url: 'https://example.edu/',
     });
   });
 
@@ -127,6 +129,7 @@ module('Acceptance | Session - Offerings', function(hooks) {
     assert.equal(blocks[0].offerings[0].learnerGroups[0].title, 'learner group 0');
     assert.equal(blocks[0].offerings[0].learnerGroups[1].title, 'learner group 1');
     assert.equal(blocks[0].offerings[0].location, this.offering1.room);
+    assert.equal(blocks[0].offerings[0].url, this.offering1.url);
     assert.equal(blocks[0].offerings[0].instructors.length, 8);
     assert.equal(blocks[0].offerings[0].instructors[0].title, '1 guy M. Mc1son');
     assert.equal(blocks[0].offerings[0].instructors[1].title, '2 guy M. Mc2son');
@@ -149,6 +152,7 @@ module('Acceptance | Session - Offerings', function(hooks) {
     assert.equal(blocks[2].offerings[0].learnerGroups.length, 1);
     assert.equal(blocks[2].offerings[0].learnerGroups[0].title, 'learner group 1');
     assert.equal(blocks[2].offerings[0].location, this.offering3.room);
+    assert.equal(blocks[2].offerings[0].url, this.offering3.url);
     assert.equal(blocks[2].offerings[0].instructors.length, 2);
     assert.equal(blocks[2].offerings[0].instructors[0].title, '3 guy M. Mc3son');
     assert.equal(blocks[2].offerings[0].instructors[1].title, '4 guy M. Mc4son');
@@ -312,7 +316,7 @@ module('Acceptance | Session - Offerings', function(hooks) {
 
   test('users can edit existing offerings', async function(assert) {
     this.user.update({ administeredSchools: [this.school] });
-    assert.expect(17);
+    assert.expect(18);
 
     await page.visit({ courseId: 1, sessionId: 1 });
     await page.offerings.dateBlocks[0].offerings[0].edit();
@@ -326,6 +330,7 @@ module('Acceptance | Session - Offerings', function(hooks) {
     await form.duration.hours.set(6);
     await form.duration.minutes.set(10);
     await form.location.set('Rm. 111');
+    await form.url.set('https://example.org');
 
     await form.learnerGroups.manager.selectedGroups.list.trees[0].removeAllSubgroups();
     await form.instructors.manager.instructors[0].remove();
@@ -355,6 +360,7 @@ module('Acceptance | Session - Offerings', function(hooks) {
     assert.equal(offering.instructors[3].title, '7 guy M. Mc7son');
     assert.equal(offering.instructors[4].title, '8 guy M. Mc8son');
     assert.equal(offering.location, 'Rm. 111');
+    assert.equal(offering.url, 'https://example.org/');
   });
 
   test('users can create recurring small groups', async function(assert) {
@@ -414,7 +420,7 @@ module('Acceptance | Session - Offerings', function(hooks) {
 
   test('users can create recurring single offerings', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
-    assert.expect(53);
+    assert.expect(57);
 
     await page.visit({ courseId: 1, sessionId: 1 });
     await page.offerings.header.createNew();
@@ -427,6 +433,7 @@ module('Acceptance | Session - Offerings', function(hooks) {
     await form.duration.hours.set(13);
     await form.duration.minutes.set(8);
     await form.location.set('Scottsdale Stadium');
+    await form.url.set('https://zoom.example.edu');
 
     await form.recurring.toggle();
     await form.recurring.setWeeks(4);
@@ -453,6 +460,7 @@ module('Acceptance | Session - Offerings', function(hooks) {
       assert.equal(block.offerings.length, 1);
       assert.equal(block.offerings[0].learnerGroups.length, 2);
       assert.equal(block.offerings[0].location, 'Scottsdale Stadium');
+      assert.equal(block.offerings[0].url, 'https://zoom.example.edu/');
       assert.equal(block.offerings[0].learnerGroups[0].title, 'learner group 0');
       assert.equal(block.offerings[0].learnerGroups[1].title, 'learner group 1');
 

--- a/tests/acceptance/course/sessionlist-test.js
+++ b/tests/acceptance/course/sessionlist-test.js
@@ -365,4 +365,19 @@ module('Acceptance | Course - Session List', function(hooks) {
     }
 
   });
+
+  test('edit offering URL', async function (assert) {
+    await page.visit({ courseId: 1, details: true });
+    const { sessions } = page.sessionsList;
+    const { offerings } = sessions[0].offerings;
+
+    assert.equal(sessions.length, 4);
+    assert.equal(sessions[0].firstOffering, today.format('L LT'));
+    await sessions[0].expandCollapse();
+    await offerings[0].edit();
+    const { offeringForm: form } = offerings[0];
+    await form.url.set('https://zoom.example.edu');
+    await form.save();
+    assert.equal(this.server.schema.offerings.find(1).url, 'https://zoom.example.edu');
+  });
 });

--- a/tests/integration/components/offering-form-test.js
+++ b/tests/integration/components/offering-form-test.js
@@ -428,4 +428,12 @@ module('Integration | Component | offering form', function(hooks) {
     assert.equal(component.currentTimezone.text, timezoneService.formatTimezone(newTimezone));
     await component.save();
   });
+
+  test('removes double https from start of URL when input', async function(assert) {
+    await render(hbs`<OfferingForm @close={{noop}} @showRoom={{true}} />`);
+    await component.url.set('https://http://example.com');
+    assert.equal('http://example.com', component.url.value);
+    await component.url.set('https://https://example.edu');
+    assert.equal('https://example.edu', component.url.value);
+  });
 });

--- a/tests/integration/components/offering-form-test.js
+++ b/tests/integration/components/offering-form-test.js
@@ -11,14 +11,16 @@ module('Integration | Component | offering form', function(hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
 
-  test('room input does not show by default', async function(assert) {
+  test('room and url input do not show by default', async function(assert) {
     await render(hbs`<OfferingForm @close={{noop}} />`);
     assert.notOk(component.location.isPresent);
+    assert.notOk(component.url.isPresent);
   });
 
-  test('room input shows up when requested', async function(assert) {
+  test('room and url input shows up when requested', async function(assert) {
     await render(hbs`<OfferingForm @close={{noop}} @showRoom={{true}} />`);
     assert.ok(component.location.isPresent);
+    assert.ok(component.url.isPresent);
   });
 
   test('room validation errors do not show up initially', async function(assert) {
@@ -31,6 +33,18 @@ module('Integration | Component | offering form', function(hooks) {
     await component.location.set(padStart('a', 300, 'a'));
     await component.save();
     assert.ok(component.location.hasError);
+  });
+
+  test('url validation errors do not show up initially', async function(assert) {
+    await render(hbs`<OfferingForm @close={{noop}} @showRoom={{true}} />`);
+    assert.notOk(component.url.hasError);
+  });
+
+  test('url validation errors show up when typing', async function(assert) {
+    await render(hbs`<OfferingForm @close={{noop}} @showRoom={{true}} />`);
+    await component.url.set('not a url');
+    await component.save();
+    assert.ok(component.url.hasError);
   });
 
   test('recurring options does not show by default', async function(assert) {
@@ -182,11 +196,12 @@ module('Integration | Component | offering form', function(hooks) {
   });
 
   test('save not recurring', async function(assert) {
-    assert.expect(7);
-    this.set('save', async (startDate, endDate, room, learners, learnerGroups, instructorGroups, instructors) => {
+    assert.expect(8);
+    this.set('save', async (startDate, endDate, room, url, learners, learnerGroups, instructorGroups, instructors) => {
       assert.equal(moment(startDate).format('YYYY-MM-DD'), moment().format('YYYY-MM-DD'));
       assert.equal(moment(endDate).format('YYYY-MM-DD'), moment().format('YYYY-MM-DD'));
       assert.equal(room, 'TBD');
+      assert.equal(url, null);
       assert.equal(learnerGroups.length, 0);
       assert.equal(learners.length, 0);
       assert.equal(instructorGroups.length, 0);

--- a/tests/integration/components/offering-url-display-test.js
+++ b/tests/integration/components/offering-url-display-test.js
@@ -1,0 +1,21 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | offering-url-display', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders URL', async function(assert) {
+    await render(hbs`<OfferingUrlDisplay @url="https://example.edu" />`);
+
+    assert.equal(this.element.textContent.trim(), 'Virtual Session Link');
+    assert.dom('a').hasAttribute('href', 'https://example.edu');
+  });
+
+  test('it renders nothing when no URL sent', async function(assert) {
+    await render(hbs`<OfferingUrlDisplay />`);
+
+    assert.equal(this.element.textContent, '');
+  });
+});

--- a/tests/integration/components/offering-url-display-test.js
+++ b/tests/integration/components/offering-url-display-test.js
@@ -12,6 +12,7 @@ module('Integration | Component | offering-url-display', function(hooks) {
     assert.equal(this.element.textContent.trim(), 'Virtual Session Link');
     assert.dom('a').hasAttribute('href', 'https://example.edu');
     assert.dom('a').hasAttribute('title', 'https://example.edu');
+    assert.dom('button').hasAttribute('title', 'Copy link');
   });
 
   test('it renders nothing when no URL sent', async function(assert) {

--- a/tests/integration/components/offering-url-display-test.js
+++ b/tests/integration/components/offering-url-display-test.js
@@ -11,6 +11,7 @@ module('Integration | Component | offering-url-display', function(hooks) {
 
     assert.equal(this.element.textContent.trim(), 'Virtual Session Link');
     assert.dom('a').hasAttribute('href', 'https://example.edu');
+    assert.dom('a').hasAttribute('title', 'https://example.edu');
   });
 
   test('it renders nothing when no URL sent', async function(assert) {

--- a/tests/integration/components/single-event-test.js
+++ b/tests/integration/components/single-event-test.js
@@ -16,7 +16,7 @@ module('Integration | Component | ilios calendar single event', function(hooks) 
   });
 
   test('it renders', async function(assert) {
-    assert.expect(23);
+    assert.expect(24);
 
     const now = moment().hour(8).minute(0).second(0);
     const course = this.server.create('course', {
@@ -59,6 +59,7 @@ module('Integration | Component | ilios calendar single event', function(hooks) 
       startDate: now,
       endDate: now.clone().add(1, 'hour'),
       location: 'here',
+      url: 'https://example.edu',
       instructors: ['Great Teacher'],
       session: 1,
       learningMaterials,
@@ -126,7 +127,8 @@ module('Integration | Component | ilios calendar single event', function(hooks) 
 
     assert.dom('.single-event-summary').containsText('test course', 'course title is displayed');
     assert.dom('.single-event-summary').containsText('test session', 'session title is displayed');
-    assert.dom('.single-event-location').containsText('here', 'location is displayed');
+    assert.dom('.single-event-location').containsText('Session Link here', 'location is displayed');
+    assert.dom('.single-event-location a').hasProperty('href', 'https://example.edu/');
     assert.dom('.single-event-instructors').containsText('Taught By Great Teacher', 'instructors are displayed');
     assert.dom('.single-event-session-is').containsText('Session Type: test type', 'session type is displayed');
     assert.dom('.single-event-summary').containsText('test description', 'session description is displayed');

--- a/tests/integration/components/week-glance-event-test.js
+++ b/tests/integration/components/week-glance-event-test.js
@@ -17,6 +17,7 @@ module('Integration | Component | week-glance-event', function(hooks) {
       name: 'Learn to Learn',
       startDate: today.format(),
       location: 'Room 123',
+      url: 'https://zoom.example.com/123?p=456',
       sessionTypeTitle: 'Lecture',
       courseExternalId: 'C1',
       sessionDescription: 'Best <strong>Session</strong> For Sure' + 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur',
@@ -59,6 +60,8 @@ module('Integration | Component | week-glance-event', function(hooks) {
     assert.equal(component.title, 'Learn to Learn');
     assert.equal(component.sessionType, 'Lecture');
     assert.equal(component.location, '- Room 123');
+    assert.equal(component.link, 'Virtual Session Link');
+    assert.equal(component.url, 'https://zoom.example.com/123?p=456');
     assert.ok(component.hasDescription);
     assert.equal(component.description, 'Best Session For SureLorem ipsum dolor sit amet, c');
     assert.equal(component.learningMaterials.length, 3);

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -320,6 +320,7 @@ general:
   url: URL
   userRole: "User Role"
   view: View
+  virtualSessionLink: Virtual Session Link
   visibleToStudents: "Visible to Students"
   vocabularies: Vocabularies
   vocabulary: Vocabulary

--- a/translations/es.yaml
+++ b/translations/es.yaml
@@ -320,6 +320,7 @@ general:
   url: URL
   userRole: "Función de Usuario"
   view: Vista
+  virtualSessionLink: Enlace de Sesión Virtual
   visibleToStudents: "visible para los estudiantes"
   vocabularies: Vocabularios
   vocabulary: Vocabulario

--- a/translations/fr.yaml
+++ b/translations/fr.yaml
@@ -320,6 +320,7 @@ general:
   url: URL
   userRole: "Rôle d'utilisateur"
   view: Vue
+  virtualSessionLink: Lien de Séance Virtuelle
   visibleToStudents: "Visible pour les étudiants"
   vocabularies: Vocabulaires
   vocabulary: Vocabulaire


### PR DESCRIPTION
Adds the ability to manage URL for individual offerings and displays it on the grid of offerings as well as on the single event and week at a glance view for students. The offering displays as `Virtual Session Link` and is clickable as well as having a copy button next to it. 

Fixes ilios/frontend#5271

Changes requested from functional review:
- [x] When hovering over the `Virtual Session Link` text the URL should display as a tooltip
- [x] When hovering over the copy icon a tooltip should indicate that clicking will copy
- [x] Add a blank space between text and copy button
- [x] when clicking into the URL field in the offering form it should highlight the `https` so a click + copy will result in `https://` getting remove and not double added. 
