### PR TITLE
[breaking] Improve Scroll Position Handling

### DIFF
--- a/addon/components/sessions-grid.hbs
+++ b/addon/components/sessions-grid.hbs
@@ -1,4 +1,3 @@
-{{on-window "scroll" this.setScroll passive=true}}
 <div
   class="sessions-grid"
   data-test-sessions-grid

--- a/addon/components/sessions-grid.js
+++ b/addon/components/sessions-grid.js
@@ -54,16 +54,6 @@ export default class SessionsGrid extends Component {
   }
 
   @action
-  setScroll() {
-    if (!this.isDestroying && !this.isDestroyed) {
-      const isCourseRoute = this.router.currentRouteName === 'course.index';
-      if (isCourseRoute) {
-        this.preserveScroll.savePosition('session-list', window.scrollY);
-      }
-    }
-  }
-
-  @action
   scrollDown() {
     const position = this.preserveScroll.getPosition('session-list');
     next(() => {

--- a/addon/components/sessions-grid.js
+++ b/addon/components/sessions-grid.js
@@ -58,19 +58,17 @@ export default class SessionsGrid extends Component {
     if (!this.isDestroying && !this.isDestroyed) {
       const isCourseRoute = this.router.currentRouteName === 'course.index';
       if (isCourseRoute) {
-        const yPos = window.scrollY;
-        this.preserveScroll.set('yPos', yPos === 0 ? null : yPos);
+        this.preserveScroll.savePosition('session-list', window.scrollY);
       }
     }
   }
 
   @action
   scrollDown() {
-    const preserveScroll = this.preserveScroll;
-    const { shouldScrollDown, yPos } = preserveScroll;
+    const position = this.preserveScroll.getPosition('session-list');
     next(() => {
-      if (shouldScrollDown && yPos) {
-        window.scroll(0, yPos);
+      if (position) {
+        window.scroll(0, position);
       }
     });
   }

--- a/addon/routes/course/index.js
+++ b/addon/routes/course/index.js
@@ -47,9 +47,8 @@ export default class CourseIndexRoute extends Route.extend(AuthenticatedRouteMix
 
   @action
   willTransition(transition) {
-    this.preserveScroll.set('isListenerOn', false);
     if (transition.targetName !== 'session.index') {
-      this.preserveScroll.set('yPos', null);
+      this.preserveScroll.clearPosition('session-list');
     }
   }
 }

--- a/addon/routes/course/index.js
+++ b/addon/routes/course/index.js
@@ -1,7 +1,7 @@
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
-import { get, action } from '@ember/object';
+import { action } from '@ember/object';
 import preloadCourse from 'ilios-common/utils/preload-course';
 
 export default class CourseIndexRoute extends Route.extend(AuthenticatedRouteMixin) {
@@ -11,11 +11,6 @@ export default class CourseIndexRoute extends Route.extend(AuthenticatedRouteMix
 
   canCreateSession = false;
   canUpdateCourse = false;
-
-  beforeModel(transition) {
-    const isFromSessionIndex = get(transition, 'from.name') === 'session.index';
-    this.preserveScroll.set('shouldScrollDown', isFromSessionIndex);
-  }
 
   /**
    * Prefetch related data to limit network requests
@@ -43,11 +38,13 @@ export default class CourseIndexRoute extends Route.extend(AuthenticatedRouteMix
     filterSessionsBy: {
       replace: true
     },
-  };
+  }
 
   @action
   willTransition(transition) {
-    if (transition.targetName !== 'session.index') {
+    if (transition.targetName === 'session.index') {
+      this.preserveScroll.savePosition('session-list', window.scrollY);
+    } else {
       this.preserveScroll.clearPosition('session-list');
     }
   }

--- a/addon/services/preserve-scroll.js
+++ b/addon/services/preserve-scroll.js
@@ -1,7 +1,15 @@
 import Service from '@ember/service';
 
-export default Service.extend({
-  shouldScrollDown: false,
-  xPos: null,
-  yPos: null
-});
+export default class PreserveScrollService extends Service {
+  #positions = {};
+
+  savePosition(key, position) {
+    this.#positions[key] = position;
+  }
+  getPosition(key) {
+    return this.#positions[key] ?? 0;
+  }
+  clearPosition(key) {
+    delete this.#positions[key];
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15065,14 +15065,6 @@
         }
       }
     },
-    "ember-on-helper": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/ember-on-helper/-/ember-on-helper-0.1.0.tgz",
-      "integrity": "sha512-jjafBnWfoA4VSSje476ft5G+urlvvuSDddwAJjKDCjKY9mbe3hAEsJiMBAaPObJRMm1FOglCuKjQZfwDDls6MQ==",
-      "requires": {
-        "ember-cli-babel": "^7.7.3"
-      }
-    },
     "ember-pad": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/ember-pad/-/ember-pad-1.2.3.tgz",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "ember-modal-dialog": "3.0.0-beta.4",
     "ember-modifier": "^1.0.2",
     "ember-moment": "^8.0.0",
-    "ember-on-helper": "^0.1.0",
     "ember-pad": "^1.2.3",
     "ember-page-title": "^5.0.1",
     "ember-pikaday": "^3.0.0",

--- a/tests/unit/services/preserve-scroll-test.js
+++ b/tests/unit/services/preserve-scroll-test.js
@@ -1,0 +1,18 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Service | preserve-scroll', function(hooks) {
+  setupTest(hooks);
+
+  test('it works', function(assert) {
+    const service = this.owner.lookup('service:preserve-scroll');
+    assert.ok(service);
+    service.savePosition('foo', 93);
+    assert.equal(service.getPosition('foo'), 93);
+    service.clearPosition('foo');
+    assert.equal(service.getPosition('foo'), 0);
+    service.clearPosition('foo');
+    service.clearPosition('foo');
+    assert.equal(service.getPosition('foo'), 0);
+  });
+});


### PR DESCRIPTION
The preserveScroll service is used here and on the DashboardMyReports component on the frontend, but in a confusing way. I touched up the API and also yanked the scroll event binding as it wasn't needed to record the position when a session is clicked. 

Refs ilios/frontend#2977