### PR TITLE
Improve screen position when visiting session

### DIFF
--- a/addon/components/session-details.hbs
+++ b/addon/components/session-details.hbs
@@ -1,6 +1,5 @@
 <section
   class="session-details"
-  {{scroll-into-view}}
   data-test-session-details
 >
   <SessionOverview

--- a/addon/modifiers/scroll-into-view.js
+++ b/addon/modifiers/scroll-into-view.js
@@ -1,5 +1,10 @@
 import { modifier } from 'ember-modifier';
+import { next } from '@ember/runloop';
 
 export default modifier(function scrollIntoView(element, [block = "start"]) {
-  element.scrollIntoView({ block });
+  next(() => {
+    if (element) {
+      element.scrollIntoView({ block });
+    }
+  });
 });

--- a/addon/templates/session/index.hbs
+++ b/addon/templates/session/index.hbs
@@ -1,4 +1,4 @@
-<div class="backtolink backtosessionlink" data-test-back-to-sessions>
+<div class="backtolink backtosessionlink" data-test-back-to-sessions {{scroll-into-view}}>
   {{! template-lint-disable no-implicit-this }}
   <LinkTo @route="course" @model={{await @model.course}} @query={{hash}}>
     {{t "general.backToSessionList"}}


### PR DESCRIPTION
When clicking on a session further down the list of sessions in a course
users were being left somewhere in the middle of the session instead of
at the top. This seems to be caused by the scroll working while the page
is still building. Waiting until the next tick of the runloop results in
the desired position of the screen.

I also moved this up a level because I think it gives a better user
experience to retain the return to session link.