### PR TITLE
Add Student Advisor manager to course and sessions

### DIFF
--- a/addon-test-support/ilios-common/page-objects/components/leadership-list.js
+++ b/addon-test-support/ilios-common/page-objects/components/leadership-list.js
@@ -6,4 +6,5 @@ export default {
   scope: '[data-test-leadership-list]',
   directors: collection('[data-test-directors] ul li', {}),
   administrators: collection('[data-test-administrators] ul li', {}),
+  studentAdvisors: collection('[data-test-student-advisors] ul li', {}),
 };

--- a/addon-test-support/ilios-common/page-objects/components/leadership-manager.js
+++ b/addon-test-support/ilios-common/page-objects/components/leadership-manager.js
@@ -32,4 +32,16 @@ export default {
   selectedAdministrators: collection('[data-test-administrators] ul li', {
     remove: clickable('.remove'),
   }),
+  studentAdvisorSearch: {
+    scope: '[data-test-student-advisor-search] [data-test-leadership-search]',
+    search: fillable('input[type=search]'),
+    results: collection('.results [data-test-result]', {
+      add: clickable(),
+      isSelectable: hasClass('clickable'),
+      isSelected: notHasClass('clickable'),
+    }),
+  },
+  selectedStudentAdvisors: collection('[data-test-student-advisors] ul li', {
+    remove: clickable('.remove'),
+  }),
 };

--- a/addon-test-support/ilios-common/page-objects/components/session-leadership-expanded.js
+++ b/addon-test-support/ilios-common/page-objects/components/session-leadership-expanded.js
@@ -1,0 +1,21 @@
+import {
+  create,
+  clickable,
+  text
+} from 'ember-cli-page-object';
+import leadershipList from './leadership-list';
+import leadershipManager from './leadership-manager';
+
+const definition = {
+  scope: '[data-test-session-leadership-expanded]',
+  title: text('[data-test-title]'),
+  collapse: clickable('[data-test-title]'),
+  manage: clickable('[data-test-manage]'),
+  save: clickable('[data-test-save]'),
+  cancel: clickable('[data-test-cancel]'),
+  leadershipList,
+  leadershipManager,
+};
+
+export default definition;
+export const component = create(definition);

--- a/addon-test-support/ilios-common/page-objects/session.js
+++ b/addon-test-support/ilios-common/page-objects/session.js
@@ -19,8 +19,7 @@ import instructorSelectionManager from './components/instructor-selection-manage
 import offeringForm from './components/offering-form';
 import { flatpickrDatePicker, pageObjectFillInFroalaEditor } from 'ilios-common';
 import leadershipCollapsed from './components/leadership-collapsed';
-import leadershipList from './components/leadership-list';
-import leadershipManager from './components/leadership-manager';
+import leadershipExpanded from './components/session-leadership-expanded';
 import postrequisiteEditor from './components/session/postrequisite-editor';
 import detailLearnersAndLearnerGroups from './components/detail-learners-and-learner-groups';
 
@@ -120,15 +119,7 @@ export default create({
   },
 
   leadershipCollapsed,
-  leadershipExpanded: {
-    scope: '[data-test-session-leadership-expanded]',
-    title: text('.title'),
-    manage: clickable('.actions button'),
-    save: clickable('.actions button.bigadd'),
-    cancel: clickable('.actions button.bigcancel'),
-    leadershipList,
-    leadershipManager,
-  },
+  leadershipExpanded,
 
   objectives,
   learningMaterials,

--- a/addon/components/course-editing.hbs
+++ b/addon/components/course-editing.hbs
@@ -18,9 +18,11 @@
       @title={{t "general.courseLeadership"}}
       @directorsCount={{has-many-length @course "directors"}}
       @administratorsCount={{has-many-length @course "administrators"}}
+      @studentAdvisorsCount={{has-many-length @course "studentAdvisors"}}
       @expand={{fn @setCourseLeadershipDetails true}}
       @showAdministrators={{true}}
       @showDirectors={{true}}
+      @showStudentAdvisors={{true}}
     />
   {{/if}}
   {{#if (or (not (has-many-length @course "courseObjectives")) @courseObjectiveDetails)}}

--- a/addon/components/course-leadership-expanded.hbs
+++ b/addon/components/course-leadership-expanded.hbs
@@ -30,30 +30,36 @@
     </div>
   </div>
   <div class="course-leadership-expanded-content">
-    {{#if (and (is-fulfilled @course.directors) (is-fulfilled @course.administrators))}}
+    {{#if (and (is-fulfilled @course.directors) (is-fulfilled @course.administrators) (is-fulfilled @course.studentAdvisors))}}
       {{#if @isManaging}}
         {{#unless this.manage.isRunning}}
           <LeadershipManager
             @directors={{this.directors}}
-            @administrators={{this.administrators}}
-            @showAdministrators={{true}}
             @showDirectors={{true}}
             @removeDirector={{this.removeDirector}}
             @addDirector={{this.addDirector}}
+            @administrators={{this.administrators}}
+            @showAdministrators={{true}}
             @removeAdministrator={{this.removeAdministrator}}
             @addAdministrator={{this.addAdministrator}}
+            @studentAdvisors={{this.studentAdvisors}}
+            @showStudentAdvisors={{true}}
+            @removeStudentAdvisor={{this.removeStudentAdvisor}}
+            @addStudentAdvisor={{this.addStudentAdvisor}}
           />
         {{/unless}}
       {{else}}
         <LeadershipList
           @directors={{await @course.directors}}
           @administrators={{await @course.administrators}}
+          @studentAdvisors={{await @course.studentAdvisors}}
           @showAdministrators={{true}}
           @showDirectors={{true}}
+          @showStudentAdvisors={{true}}
         />
       {{/if}}
     {{else}}
-      <LoadingSpinner @tagName="h3" />
+      <LoadingSpinner />
     {{/if}}
   </div>
 </div>

--- a/addon/components/course-leadership-expanded.js
+++ b/addon/components/course-leadership-expanded.js
@@ -3,15 +3,18 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { timeout } from 'ember-concurrency';
 import { dropTask } from 'ember-concurrency-decorators';
+import { hash } from 'rsvp';
 
 export default class CourseLeadershipExpandedComponent extends Component {
   @tracked directors = [];
   @tracked administrators = [];
+  @tracked studentAdvisors = [];
   get isCollapsible() {
     const administratorIds = this.args.course.hasMany('administrators').ids();
     const directorIds = this.args.course.hasMany('directors').ids();
+    const studentAdvisorIds = this.args.course.hasMany('studentAdvisors').ids();
 
-    return (administratorIds.length > 0 || directorIds.length > 0) && !this.args.isManaging;
+    return (administratorIds.length > 0 || directorIds.length > 0 || studentAdvisorIds.length > 0) && !this.args.isManaging;
   }
   @action
   addDirector(user) {
@@ -29,12 +32,24 @@ export default class CourseLeadershipExpandedComponent extends Component {
   removeAdministrator(user){
     this.administrators = this.administrators.filter(obj => obj !== user);
   }
+  @action
+  addStudentAdvisor(user) {
+    this.studentAdvisors = [...this.studentAdvisors, user];
+  }
+  @action
+  removeStudentAdvisor(user){
+    this.studentAdvisors = this.studentAdvisors.filter(obj => obj !== user);
+  }
   @dropTask
   *manage() {
-    const administrators = yield this.args.course.administrators;
-    const directors = yield this.args.course.directors;
-    this.administrators = administrators.toArray();
-    this.directors = directors.toArray();
+    const obj = yield hash({
+      administrators: this.args.course.administrators,
+      directors: this.args.course.directors,
+      studentAdvisors: this.args.course.studentAdvisors
+    });
+    this.administrators = obj.administrators.toArray();
+    this.directors = obj.directors.toArray();
+    this.studentAdvisors = obj.studentAdvisors.toArray();
     this.args.setIsManaging(true);
   }
   @dropTask
@@ -42,7 +57,8 @@ export default class CourseLeadershipExpandedComponent extends Component {
     yield timeout(10);
     this.args.course.setProperties({
       directors: this.directors,
-      administrators: this.administrators
+      administrators: this.administrators,
+      studentAdvisors: this.studentAdvisors,
     });
     this.args.expand();
     yield this.args.course.save();

--- a/addon/components/leadership-collapsed.hbs
+++ b/addon/components/leadership-collapsed.hbs
@@ -32,6 +32,16 @@
             </td>
           </tr>
         {{/if}}
+        {{#if @showStudentAdvisors}}
+          <tr>
+            <td>
+              {{t "general.studentAdvisors"}}
+            </td>
+            <td>
+              {{t "general.studentAdvisorCount" count=@studentAdvisorsCount}}
+            </td>
+          </tr>
+        {{/if}}
       </tbody>
     </table>
   </div>

--- a/addon/components/leadership-list.hbs
+++ b/addon/components/leadership-list.hbs
@@ -12,6 +12,11 @@
             {{t "general.administrators"}}
           </th>
         {{/if}}
+        {{#if @showStudentAdvisors}}
+          <th>
+            {{t "general.studentAdvisors"}}
+          </th>
+        {{/if}}
       </tr>
     </thead>
     <tbody>
@@ -49,6 +54,35 @@
             <ul>
               {{#if (is-array @administrators)}}
                 {{#each (sort-by "lastName" "firstName" @administrators) as |user|
+                }}
+                  <li>
+                    {{#unless user.enabled}}
+                      <FaIcon
+                        @icon="user-times"
+                        @title={{t "general.disabled"}}
+                        class="error"
+                      />
+                    {{/unless}}
+                    <span data-test-name>
+                      {{user.fullName}}
+                    </span>
+                  </li>
+                {{else}}
+                  <li>
+                    {{t "general.none"}}
+                  </li>
+                {{/each}}
+              {{else}}
+                <LoadingSpinner />
+              {{/if}}
+            </ul>
+          </td>
+        {{/if}}
+        {{#if @showStudentAdvisors}}
+          <td class="text-top" data-test-student-advisors>
+            <ul>
+              {{#if (is-array @studentAdvisors)}}
+                {{#each (sort-by "lastName" "firstName" @studentAdvisors) as |user|
                 }}
                   <li>
                     {{#unless user.enabled}}

--- a/addon/components/leadership-manager.hbs
+++ b/addon/components/leadership-manager.hbs
@@ -12,6 +12,11 @@
             {{t "general.administrators"}}
           </th>
         {{/if}}
+        {{#if @showStudentAdvisors}}
+          <th>
+            {{t "general.studentAdvisors"}}
+          </th>
+        {{/if}}
       </tr>
     </thead>
     <tbody>
@@ -70,6 +75,33 @@
             </ul>
           </td>
         {{/if}}
+        {{#if @showStudentAdvisors}}
+          <td class="text-top" data-test-student-advisors>
+            <ul>
+              {{#each (sort-by "lastName" "firstName" @studentAdvisors) as |user|}}
+                <li>
+                  <FaIcon
+                    @icon="times"
+                    class="clickable remove"
+                    @click={{fn @removeStudentAdvisor user}}
+                  />
+                  {{#unless user.enabled}}
+                    <FaIcon
+                      @icon="user-times"
+                      @title={{t "general.disabled"}}
+                      class="disabled-user"
+                    />
+                  {{/unless}}
+                  <span data-test-name>
+                    {{user.fullName}}
+                  </span>
+                </li>
+              {{else}}
+                {{t "general.none"}}
+              {{/each}}
+            </ul>
+          </td>
+        {{/if}}
       </tr>
       <tr>
         {{#if @showDirectors}}
@@ -85,6 +117,14 @@
             <LeadershipSearch
               @existingUsers={{@administrators}}
               @selectUser={{@addAdministrator}}
+            />
+          </td>
+        {{/if}}
+        {{#if @showStudentAdvisors}}
+          <td data-test-student-advisor-search>
+            <LeadershipSearch
+              @existingUsers={{@studentAdvisors}}
+              @selectUser={{@addStudentAdvisor}}
             />
           </td>
         {{/if}}

--- a/addon/components/session-details.hbs
+++ b/addon/components/session-details.hbs
@@ -21,7 +21,9 @@
       @title={{t "general.sessionAdministration"}}
       @showDirectors={{false}}
       @showAdministrators={{true}}
+      @showStudentAdvisors={{true}}
       @administratorsCount={{has-many-length @session "administrators"}}
+      @studentAdvisorsCount={{has-many-length @session "studentAdvisors"}}
       @expand={{fn @setSessionLeadershipDetails true}}
     />
   {{/if}}

--- a/addon/components/session-leadership-expanded.hbs
+++ b/addon/components/session-leadership-expanded.hbs
@@ -1,46 +1,57 @@
 <div
- class="session-leadership-expanded"
- {{did-insert (perform this.load) @session @session.administrators}}
- {{did-update (perform this.load) @session @session.administrators}}
- data-test-session-leadership-expanded
+  class="session-leadership-expanded"
+  data-test-session-leadership-expanded
 >
   <div class="session-leadership-expanded-header">
-    <div class="title collapsible clickable" role="button" {{on "click" @collapse}}>
+    <h3
+      class="title {{if this.isCollapsible "collapsible clickable"}}"
+      role="button"
+      {{on "click" (if this.isCollapsible @collapse (noop))}}
+      data-test-title
+    >
       {{t "general.sessionAdministration"}}
-    </div>
+    </h3>
     <div class="actions">
       {{#if @isManaging}}
-        <button class="bigadd" type="button" {{on "click" (perform this.save)}}>
+        <button class="bigadd" type="button" {{on "click" (perform this.save)}} data-test-save>
           <FaIcon
             @icon={{if this.save.isRunning "spinner" "check"}}
-            @spin={{if this.isSaving true false}}
+            @spin={{this.save.isRunning}}
           />
         </button>
-        <button class="bigcancel" type="button" {{on "click" this.cancel}}>
+        <button class="bigcancel" type="button" {{on "click" (fn @setIsManaging false)}} data-test-cancel>
           <FaIcon @icon="undo" />
         </button>
       {{else if @canUpdate}}
-        <button type="button" {{on "click" (perform this.manage)}}>
+        <button type="button" {{on "click" (perform this.manage)}} data-test-manage>
           {{t "general.manageLeadership"}}
         </button>
       {{/if}}
     </div>
   </div>
   <div class="session-leadership-expanded-content">
-    {{#if (is-array this.administrators)}}
+    {{#if (and (is-fulfilled @session.administrators) (is-fulfilled @session.studentAdvisors) )}}
       {{#if @isManaging}}
-        <LeadershipManager
-          @showAdministrators={{true}}
-          @showDirectors={{false}}
-          @administrators={{this.administratorBuffer}}
-          @removeAdministrator={{this.removeAdministrator}}
-          @addAdministrator={{this.addAdministrator}}
-        />
+        {{#unless this.manage.isRunning}}
+          <LeadershipManager
+            @showDirectors={{false}}
+            @administrators={{this.administrators}}
+            @showAdministrators={{true}}
+            @removeAdministrator={{this.removeAdministrator}}
+            @addAdministrator={{this.addAdministrator}}
+            @studentAdvisors={{this.studentAdvisors}}
+            @showStudentAdvisors={{true}}
+            @removeStudentAdvisor={{this.removeStudentAdvisor}}
+            @addStudentAdvisor={{this.addStudentAdvisor}}
+          />
+        {{/unless}}
       {{else}}
         <LeadershipList
+          @administrators={{await @session.administrators}}
+          @studentAdvisors={{await @session.studentAdvisors}}
           @showAdministrators={{true}}
           @showDirectors={{false}}
-          @administrators={{this.administrators}}
+          @showStudentAdvisors={{true}}
         />
       {{/if}}
     {{else}}

--- a/addon/components/session-leadership-expanded.js
+++ b/addon/components/session-leadership-expanded.js
@@ -1,46 +1,54 @@
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { timeout } from 'ember-concurrency';
 import { dropTask } from 'ember-concurrency-decorators';
-import { tracked } from '@glimmer/tracking';
+import { hash } from 'rsvp';
 
-export default class SessionLeadershipExpandedComponent extends Component {
-  @tracked administrators;
-  @tracked administratorBuffer;
+export default class CourseLeadershipExpandedComponent extends Component {
+  @tracked administrators = [];
+  @tracked studentAdvisors = [];
+  get isCollapsible() {
+    const administratorIds = this.args.session.hasMany('administrators').ids();
+    const studentAdvisorIds = this.args.session.hasMany('studentAdvisors').ids();
 
-  @dropTask
-  *load(element, [session]) {
-    if (session) {
-      this.administrators = (yield session.administrators).toArray();
-    }
+    return (administratorIds.length > 0 || studentAdvisorIds.length > 0) && !this.args.isManaging;
   }
-
-  @dropTask
-  *manage() {
-    this.administratorBuffer = (yield this.args.session.administrators).toArray();
-    this.args.setIsManaging(true);
-  }
-
-  @dropTask
-  *save(){
-    yield timeout(10);
-    this.args.session.set('administrators', this.administratorBuffer);
-    this.args.expand();
-    yield this.args.session.save();
-    this.args.setIsManaging(false);
-  }
-
   @action
   addAdministrator(user) {
-    this.administratorBuffer = [...this.administratorBuffer, user];
+    this.administrators = [...this.administrators, user];
   }
   @action
   removeAdministrator(user){
-    this.administratorBuffer = this.administratorBuffer.filter(obj => obj !== user);
+    this.administrators = this.administrators.filter(obj => obj !== user);
   }
   @action
-  cancel() {
-    this.administratorBuffer = null;
+  addStudentAdvisor(user) {
+    this.studentAdvisors = [...this.studentAdvisors, user];
+  }
+  @action
+  removeStudentAdvisor(user){
+    this.studentAdvisors = this.studentAdvisors.filter(obj => obj !== user);
+  }
+  @dropTask
+  *manage() {
+    const obj = yield hash({
+      administrators: this.args.session.administrators,
+      studentAdvisors: this.args.session.studentAdvisors
+    });
+    this.administrators = obj.administrators.toArray();
+    this.studentAdvisors = obj.studentAdvisors.toArray();
+    this.args.setIsManaging(true);
+  }
+  @dropTask
+  *save(){
+    yield timeout(10);
+    this.args.session.setProperties({
+      administrators: this.administrators,
+      studentAdvisors: this.studentAdvisors,
+    });
+    this.args.expand();
+    yield this.args.session.save();
     this.args.setIsManaging(false);
   }
 }

--- a/addon/models/course.js
+++ b/addon/models/course.js
@@ -29,6 +29,10 @@ export default Model.extend({
     async: true,
     inverse: 'administeredCourses'
   }),
+  studentAdvisors: hasMany('user', {
+    async: true,
+    inverse: 'studentAdvisedCourses'
+  }),
   cohorts: hasMany('cohort', {async: true}),
   courseObjectives: hasMany('course-objective', {async: true}),
   meshDescriptors: hasMany('mesh-descriptor', {async: true}),

--- a/addon/models/session.js
+++ b/addon/models/session.js
@@ -29,6 +29,10 @@ export default Model.extend({
     async: true,
     inverse: 'administeredSessions'
   }),
+  studentAdvisors: hasMany('user', {
+    async: true,
+    inverse: 'studentAdvisedSessions'
+  }),
   postrequisite: belongsTo('session', {
     inverse: 'prerequisites',
     async: true

--- a/addon/models/user.js
+++ b/addon/models/user.js
@@ -34,6 +34,14 @@ export default Model.extend({
     async: true,
     inverse: 'administrators'
   }),
+  studentAdvisedCourses: hasMany('course', {
+    async: true,
+    inverse: 'studentAdvisors'
+  }),
+  studentAdvisedSessions: hasMany('session', {
+    async: true,
+    inverse: 'studentAdvisors'
+  }),
   learnerGroups: hasMany('learner-group', {
     async: true,
     inverse: 'users'

--- a/tests/acceptance/course/leadership-test.js
+++ b/tests/acceptance/course/leadership-test.js
@@ -15,36 +15,39 @@ module('Acceptance | Course - Leadership', function(hooks) {
     this.user = await setupAuthentication({ school: this.school, administeredSchools: [this.school] });
     this.server.create('academicYear', {id: 2013});
 
-    const users = this.server.createList('user', 4);
+    const users = this.server.createList('user', 6);
     this.course = this.server.create('course', {
       year: 2013,
       school: this.school,
       directors: [users[0], users[1]],
       administrators: [users[2], users[3]],
+      studentAdvisors: [users[4], users[5]],
     });
   });
 
   test('collapsed leadership', async function (assert) {
-    assert.expect(8);
+    assert.expect(10);
     await page.visit({ courseId: 1, details: true });
 
     assert.equal(page.leadershipCollapsed.title, 'Course Leadership');
     assert.equal(page.leadershipCollapsed.headers.length, 1);
     assert.equal(page.leadershipCollapsed.headers[0].title, 'Summary');
 
-    assert.equal(page.leadershipCollapsed.summary.length, 2);
+    assert.equal(page.leadershipCollapsed.summary.length, 3);
     assert.equal(page.leadershipCollapsed.summary[0].name, 'Directors');
     assert.equal(page.leadershipCollapsed.summary[0].value, 'There are 2 directors');
     assert.equal(page.leadershipCollapsed.summary[1].name, 'Administrators');
     assert.equal(page.leadershipCollapsed.summary[1].value, 'There are 2 administrators');
+    assert.equal(page.leadershipCollapsed.summary[2].name, 'Student Advisors');
+    assert.equal(page.leadershipCollapsed.summary[2].value, 'There are 2 student advisors');
   });
 
   test('list leadership', async function (assert) {
-    assert.expect(7);
+    assert.expect(10);
     await page.visit({ courseId: 1, details: true, courseLeadershipDetails: true });
 
     assert.equal(page.leadershipExpanded.title, 'Course Leadership');
-    const { directors, administrators } = page.leadershipExpanded.leadershipList;
+    const { directors, administrators, studentAdvisors } = page.leadershipExpanded.leadershipList;
     assert.equal(directors.length, 2);
     assert.equal(directors[0].text, '1 guy M. Mc1son');
     assert.equal(directors[1].text, '2 guy M. Mc2son');
@@ -52,15 +55,19 @@ module('Acceptance | Course - Leadership', function(hooks) {
     assert.equal(administrators.length, 2);
     assert.equal(administrators[0].text, '3 guy M. Mc3son');
     assert.equal(administrators[1].text, '4 guy M. Mc4son');
+
+    assert.equal(studentAdvisors.length, 2);
+    assert.equal(studentAdvisors[0].text, '5 guy M. Mc5son');
+    assert.equal(studentAdvisors[1].text, '6 guy M. Mc6son');
   });
 
   test('search administrators', async function (assert) {
-    assert.expect(11);
+    assert.expect(15);
     await page.visit({ courseId: 1, details: true, courseLeadershipDetails: true });
     await page.leadershipExpanded.manage();
     const manager = page.leadershipExpanded.leadershipManager;
     await manager.administratorSearch.search('guy');
-    assert.equal(manager.administratorSearch.results.length, 5);
+    assert.equal(manager.administratorSearch.results.length, 7);
     assert.equal(manager.administratorSearch.results[0].text, '0 guy M. Mc0son user@example.edu');
     assert.ok(manager.administratorSearch.results[0].isSelectable);
     assert.equal(manager.administratorSearch.results[1].text, '1 guy M. Mc1son user@example.edu');
@@ -71,15 +78,19 @@ module('Acceptance | Course - Leadership', function(hooks) {
     assert.ok(manager.administratorSearch.results[3].isSelected);
     assert.equal(manager.administratorSearch.results[4].text, '4 guy M. Mc4son user@example.edu');
     assert.ok(manager.administratorSearch.results[4].isSelected);
+    assert.equal(manager.administratorSearch.results[5].text, '5 guy M. Mc5son user@example.edu');
+    assert.ok(manager.administratorSearch.results[5].isSelectable);
+    assert.equal(manager.administratorSearch.results[6].text, '6 guy M. Mc6son user@example.edu');
+    assert.ok(manager.administratorSearch.results[6].isSelectable);
   });
 
   test('search directors', async function (assert) {
-    assert.expect(11);
+    assert.expect(15);
     await page.visit({ courseId: 1, details: true, courseLeadershipDetails: true });
     await page.leadershipExpanded.manage();
     const manager = page.leadershipExpanded.leadershipManager;
     await manager.directorSearch.search('guy');
-    assert.equal(manager.directorSearch.results.length, 5);
+    assert.equal(manager.directorSearch.results.length, 7);
     assert.equal(manager.directorSearch.results[0].text, '0 guy M. Mc0son user@example.edu');
     assert.ok(manager.directorSearch.results[0].isSelectable);
     assert.equal(manager.directorSearch.results[1].text, '1 guy M. Mc1son user@example.edu');
@@ -90,15 +101,42 @@ module('Acceptance | Course - Leadership', function(hooks) {
     assert.ok(manager.directorSearch.results[3].isSelectable);
     assert.equal(manager.directorSearch.results[4].text, '4 guy M. Mc4son user@example.edu');
     assert.ok(manager.directorSearch.results[4].isSelectable);
+    assert.equal(manager.directorSearch.results[5].text, '5 guy M. Mc5son user@example.edu');
+    assert.ok(manager.directorSearch.results[5].isSelectable);
+    assert.equal(manager.directorSearch.results[6].text, '6 guy M. Mc6son user@example.edu');
+    assert.ok(manager.directorSearch.results[6].isSelectable);
+  });
+
+  test('search student advisors', async function (assert) {
+    assert.expect(15);
+    await page.visit({ courseId: 1, details: true, courseLeadershipDetails: true });
+    await page.leadershipExpanded.manage();
+    const manager = page.leadershipExpanded.leadershipManager;
+    await manager.studentAdvisorSearch.search('guy');
+    assert.equal(manager.studentAdvisorSearch.results.length, 7);
+    assert.equal(manager.studentAdvisorSearch.results[0].text, '0 guy M. Mc0son user@example.edu');
+    assert.ok(manager.studentAdvisorSearch.results[0].isSelectable);
+    assert.equal(manager.studentAdvisorSearch.results[1].text, '1 guy M. Mc1son user@example.edu');
+    assert.ok(manager.studentAdvisorSearch.results[1].isSelectable);
+    assert.equal(manager.studentAdvisorSearch.results[2].text, '2 guy M. Mc2son user@example.edu');
+    assert.ok(manager.studentAdvisorSearch.results[2].isSelectable);
+    assert.equal(manager.studentAdvisorSearch.results[3].text, '3 guy M. Mc3son user@example.edu');
+    assert.ok(manager.studentAdvisorSearch.results[3].isSelectable);
+    assert.equal(manager.studentAdvisorSearch.results[4].text, '4 guy M. Mc4son user@example.edu');
+    assert.ok(manager.studentAdvisorSearch.results[4].isSelectable);
+    assert.equal(manager.studentAdvisorSearch.results[5].text, '5 guy M. Mc5son user@example.edu');
+    assert.ok(manager.studentAdvisorSearch.results[5].isSelected);
+    assert.equal(manager.studentAdvisorSearch.results[6].text, '6 guy M. Mc6son user@example.edu');
+    assert.ok(manager.studentAdvisorSearch.results[6].isSelected);
   });
 
   test('manage leadership', async function (assert) {
-    assert.expect(12);
+    assert.expect(18);
     await page.visit({ courseId: 1, details: true, courseLeadershipDetails: true });
     await page.leadershipExpanded.manage();
     const manager = page.leadershipExpanded.leadershipManager;
 
-    const { selectedDirectors, selectedAdministrators } = manager;
+    const { selectedDirectors, selectedAdministrators, selectedStudentAdvisors } = manager;
     assert.equal(selectedDirectors.length, 2);
     assert.equal(selectedDirectors[0].text, '1 guy M. Mc1son');
     assert.equal(selectedDirectors[1].text, '2 guy M. Mc2son');
@@ -107,13 +145,21 @@ module('Acceptance | Course - Leadership', function(hooks) {
     assert.equal(selectedAdministrators[0].text, '3 guy M. Mc3son');
     assert.equal(selectedAdministrators[1].text, '4 guy M. Mc4son');
 
+    assert.equal(selectedStudentAdvisors.length, 2);
+    assert.equal(selectedStudentAdvisors[0].text, '5 guy M. Mc5son');
+    assert.equal(selectedStudentAdvisors[1].text, '6 guy M. Mc6son');
+
     await selectedDirectors[0].remove();
     await selectedAdministrators[1].remove();
+    await selectedStudentAdvisors[1].remove();
     await manager.directorSearch.search('guy');
     await manager.directorSearch.results[0].add();
 
     await manager.administratorSearch.search('guy');
     await manager.administratorSearch.results[0].add();
+
+    await manager.studentAdvisorSearch.search('guy');
+    await manager.studentAdvisorSearch.results[0].add();
 
     assert.equal(selectedDirectors.length, 2);
     assert.equal(selectedDirectors[0].text, '0 guy M. Mc0son');
@@ -122,24 +168,33 @@ module('Acceptance | Course - Leadership', function(hooks) {
     assert.equal(selectedAdministrators.length, 2);
     assert.equal(selectedAdministrators[0].text, '0 guy M. Mc0son');
     assert.equal(selectedAdministrators[1].text, '3 guy M. Mc3son');
+
+    assert.equal(selectedStudentAdvisors.length, 2);
+    assert.equal(selectedStudentAdvisors[0].text, '0 guy M. Mc0son');
+    assert.equal(selectedStudentAdvisors[1].text, '5 guy M. Mc5son');
   });
 
   test('cancel leadership changes', async function (assert) {
-    assert.expect(6);
+    assert.expect(9);
     await page.visit({ courseId: 1, details: true, courseLeadershipDetails: true });
     await page.leadershipExpanded.manage();
     const manager = page.leadershipExpanded.leadershipManager;
-    const { selectedDirectors, selectedAdministrators } = manager;
+    const { selectedDirectors, selectedAdministrators, selectedStudentAdvisors } = manager;
     await selectedDirectors[0].remove();
     await selectedAdministrators[1].remove();
+    await selectedStudentAdvisors[1].remove();
+
     await manager.directorSearch.search('guy');
     await manager.directorSearch.results[3].add();
 
     await manager.administratorSearch.search('guy');
     await manager.administratorSearch.results[1].add();
 
+    await manager.studentAdvisorSearch.search('guy');
+    await manager.studentAdvisorSearch.results[1].add();
+
     await page.leadershipExpanded.cancel();
-    const { directors, administrators } = page.leadershipExpanded.leadershipList;
+    const { directors, administrators, studentAdvisors } = page.leadershipExpanded.leadershipList;
     assert.equal(directors.length, 2);
     assert.equal(directors[0].text, '1 guy M. Mc1son');
     assert.equal(directors[1].text, '2 guy M. Mc2son');
@@ -147,23 +202,33 @@ module('Acceptance | Course - Leadership', function(hooks) {
     assert.equal(administrators.length, 2);
     assert.equal(administrators[0].text, '3 guy M. Mc3son');
     assert.equal(administrators[1].text, '4 guy M. Mc4son');
+
+    assert.equal(studentAdvisors.length, 2);
+    assert.equal(studentAdvisors[0].text, '5 guy M. Mc5son');
+    assert.equal(studentAdvisors[1].text, '6 guy M. Mc6son');
   });
 
   test('save leadership changes', async function (assert) {
-    assert.expect(6);
+    assert.expect(9);
     await page.visit({ courseId: 1, details: true, courseLeadershipDetails: true });
     await page.leadershipExpanded.manage();
     const manager = page.leadershipExpanded.leadershipManager;
-    const { selectedDirectors, selectedAdministrators } = manager;
+    const { selectedDirectors, selectedAdministrators, selectedStudentAdvisors } = manager;
     await selectedDirectors[0].remove();
     await selectedAdministrators[1].remove();
+    await selectedStudentAdvisors[1].remove();
+
     await manager.directorSearch.search('guy');
     await manager.directorSearch.results[3].add();
 
     await manager.administratorSearch.search('guy');
     await manager.administratorSearch.results[1].add();
+
+    await manager.studentAdvisorSearch.search('guy');
+    await manager.studentAdvisorSearch.results[0].add();
+
     await page.leadershipExpanded.save();
-    const { directors, administrators } = page.leadershipExpanded.leadershipList;
+    const { directors, administrators, studentAdvisors } = page.leadershipExpanded.leadershipList;
     assert.equal(directors.length, 2);
     assert.equal(directors[0].text, '2 guy M. Mc2son');
     assert.equal(directors[1].text, '3 guy M. Mc3son');
@@ -171,5 +236,9 @@ module('Acceptance | Course - Leadership', function(hooks) {
     assert.equal(administrators.length, 2);
     assert.equal(administrators[0].text, '1 guy M. Mc1son');
     assert.equal(administrators[1].text, '3 guy M. Mc3son');
+
+    assert.equal(studentAdvisors.length, 2);
+    assert.equal(studentAdvisors[0].text, '0 guy M. Mc0son');
+    assert.equal(studentAdvisors[1].text, '5 guy M. Mc5son');
   });
 });

--- a/tests/acceptance/course/session/leadership-test.js
+++ b/tests/acceptance/course/session/leadership-test.js
@@ -15,7 +15,7 @@ module('Acceptance | Session - Leadership', function(hooks) {
     this.user = await setupAuthentication({ school: this.school, administeredSchools: [this.school] });
     this.server.create('academicYear', {id: 2013});
 
-    const users = this.server.createList('user', 4);
+    const users = this.server.createList('user', 5);
     const course = this.server.create('course', {
       year: 2013,
       school: this.school,
@@ -25,41 +25,46 @@ module('Acceptance | Session - Leadership', function(hooks) {
     this.session = this.server.create('session', {
       course,
       administrators: [users[2], users[3]],
+      studentAdvisors: [users[4]],
     });
   });
 
   test('collapsed leadership', async function (assert) {
-    assert.expect(6);
+    assert.expect(8);
     await page.visit({ courseId: 1, sessionId: 1 });
 
     assert.equal(page.leadershipCollapsed.title, 'Session Administration');
     assert.equal(page.leadershipCollapsed.headers.length, 1);
     assert.equal(page.leadershipCollapsed.headers[0].title, 'Summary');
 
-    assert.equal(page.leadershipCollapsed.summary.length, 1);
+    assert.equal(page.leadershipCollapsed.summary.length, 2);
     assert.equal(page.leadershipCollapsed.summary[0].name, 'Administrators');
     assert.equal(page.leadershipCollapsed.summary[0].value, 'There are 2 administrators');
+    assert.equal(page.leadershipCollapsed.summary[1].name, 'Student Advisors');
+    assert.equal(page.leadershipCollapsed.summary[1].value, 'There is 1 student advisor');
   });
 
   test('list leadership', async function (assert) {
-    assert.expect(4);
+    assert.expect(6);
     await page.visit({ courseId: 1, sessionId: 1, sessionLeadershipDetails: true });
 
     assert.equal(page.leadershipExpanded.title, 'Session Administration');
-    const { administrators } = page.leadershipExpanded.leadershipList;
+    const { administrators, studentAdvisors } = page.leadershipExpanded.leadershipList;
 
     assert.equal(administrators.length, 2);
     assert.equal(administrators[0].text, '3 guy M. Mc3son');
     assert.equal(administrators[1].text, '4 guy M. Mc4son');
+    assert.equal(studentAdvisors.length, 1);
+    assert.equal(studentAdvisors[0].text, '5 guy M. Mc5son');
   });
 
   test('search administrators', async function (assert) {
-    assert.expect(11);
+    assert.expect(13);
     await page.visit({ courseId: 1, sessionId: 1, sessionLeadershipDetails: true });
     await page.leadershipExpanded.manage();
     const manager = page.leadershipExpanded.leadershipManager;
     await manager.administratorSearch.search('guy');
-    assert.equal(manager.administratorSearch.results.length, 5);
+    assert.equal(manager.administratorSearch.results.length, 6);
     assert.equal(manager.administratorSearch.results[0].text, '0 guy M. Mc0son user@example.edu');
     assert.ok(manager.administratorSearch.results[0].isSelectable);
     assert.equal(manager.administratorSearch.results[1].text, '1 guy M. Mc1son user@example.edu');
@@ -70,64 +75,109 @@ module('Acceptance | Session - Leadership', function(hooks) {
     assert.ok(manager.administratorSearch.results[3].isSelected);
     assert.equal(manager.administratorSearch.results[4].text, '4 guy M. Mc4son user@example.edu');
     assert.ok(manager.administratorSearch.results[4].isSelected);
+    assert.equal(manager.administratorSearch.results[5].text, '5 guy M. Mc5son user@example.edu');
+    assert.ok(manager.administratorSearch.results[5].isSelectable);
+  });
+
+  test('search student advisors', async function (assert) {
+    assert.expect(13);
+    await page.visit({ courseId: 1, sessionId: 1, sessionLeadershipDetails: true });
+    await page.leadershipExpanded.manage();
+    const manager = page.leadershipExpanded.leadershipManager;
+    await manager.studentAdvisorSearch.search('guy');
+    assert.equal(manager.studentAdvisorSearch.results.length, 6);
+    assert.equal(manager.studentAdvisorSearch.results[0].text, '0 guy M. Mc0son user@example.edu');
+    assert.ok(manager.studentAdvisorSearch.results[0].isSelectable);
+    assert.equal(manager.studentAdvisorSearch.results[1].text, '1 guy M. Mc1son user@example.edu');
+    assert.ok(manager.studentAdvisorSearch.results[1].isSelectable);
+    assert.equal(manager.studentAdvisorSearch.results[2].text, '2 guy M. Mc2son user@example.edu');
+    assert.ok(manager.studentAdvisorSearch.results[2].isSelectable);
+    assert.equal(manager.studentAdvisorSearch.results[3].text, '3 guy M. Mc3son user@example.edu');
+    assert.ok(manager.studentAdvisorSearch.results[3].isSelectable);
+    assert.equal(manager.studentAdvisorSearch.results[4].text, '4 guy M. Mc4son user@example.edu');
+    assert.ok(manager.studentAdvisorSearch.results[4].isSelectable);
+    assert.equal(manager.studentAdvisorSearch.results[5].text, '5 guy M. Mc5son user@example.edu');
+    assert.ok(manager.studentAdvisorSearch.results[5].isSelected);
   });
 
   test('manage leadership', async function (assert) {
-    assert.expect(6);
+    assert.expect(10);
     await page.visit({ courseId: 1, sessionId: 1, sessionLeadershipDetails: true });
     await page.leadershipExpanded.manage();
     const manager = page.leadershipExpanded.leadershipManager;
 
-    const { selectedAdministrators } = manager;
+    const { selectedAdministrators, selectedStudentAdvisors } = manager;
 
     assert.equal(selectedAdministrators.length, 2);
     assert.equal(selectedAdministrators[0].text, '3 guy M. Mc3son');
     assert.equal(selectedAdministrators[1].text, '4 guy M. Mc4son');
+    assert.equal(selectedStudentAdvisors.length, 1);
+    assert.equal(selectedStudentAdvisors[0].text, '5 guy M. Mc5son');
 
     await selectedAdministrators[1].remove();
+    await selectedStudentAdvisors[0].remove();
 
     await manager.administratorSearch.search('guy');
     await manager.administratorSearch.results[0].add();
+    await manager.studentAdvisorSearch.search('guy');
+    await manager.studentAdvisorSearch.results[0].add();
 
     assert.equal(selectedAdministrators.length, 2);
     assert.equal(selectedAdministrators[0].text, '0 guy M. Mc0son');
     assert.equal(selectedAdministrators[1].text, '3 guy M. Mc3son');
+
+    assert.equal(selectedStudentAdvisors.length, 1);
+    assert.equal(selectedStudentAdvisors[0].text, '0 guy M. Mc0son');
   });
 
   test('cancel leadership changes', async function (assert) {
-    assert.expect(3);
+    assert.expect(5);
     await page.visit({ courseId: 1, sessionId: 1, sessionLeadershipDetails: true });
     await page.leadershipExpanded.manage();
     const manager = page.leadershipExpanded.leadershipManager;
-    const { selectedAdministrators } = manager;
+    const { selectedAdministrators, selectedStudentAdvisors } = manager;
     await selectedAdministrators[1].remove();
+    await selectedStudentAdvisors[0].remove();
 
     await manager.administratorSearch.search('guy');
     await manager.administratorSearch.results[1].add();
 
+    await manager.studentAdvisorSearch.search('guy');
+    await manager.studentAdvisorSearch.results[1].add();
+
     await page.leadershipExpanded.cancel();
-    const { administrators } = page.leadershipExpanded.leadershipList;
+    const { administrators, studentAdvisors } = page.leadershipExpanded.leadershipList;
 
     assert.equal(administrators.length, 2);
     assert.equal(administrators[0].text, '3 guy M. Mc3son');
     assert.equal(administrators[1].text, '4 guy M. Mc4son');
+
+    assert.equal(studentAdvisors.length, 1);
+    assert.equal(studentAdvisors[0].text, '5 guy M. Mc5son');
   });
 
   test('save leadership changes', async function (assert) {
-    assert.expect(3);
+    assert.expect(5);
     await page.visit({ courseId: 1, sessionId: 1, sessionLeadershipDetails: true });
     await page.leadershipExpanded.manage();
     const manager = page.leadershipExpanded.leadershipManager;
-    const { selectedAdministrators } = manager;
+    const { selectedAdministrators, selectedStudentAdvisors } = manager;
     await selectedAdministrators[1].remove();
+    await selectedStudentAdvisors[0].remove();
 
     await manager.administratorSearch.search('guy');
     await manager.administratorSearch.results[1].add();
+    await manager.studentAdvisorSearch.search('guy');
+    await manager.studentAdvisorSearch.results[1].add();
+
     await page.leadershipExpanded.save();
-    const { administrators } = page.leadershipExpanded.leadershipList;
+    const { administrators, studentAdvisors } = page.leadershipExpanded.leadershipList;
 
     assert.equal(administrators.length, 2);
     assert.equal(administrators[0].text, '1 guy M. Mc1son');
     assert.equal(administrators[1].text, '3 guy M. Mc3son');
+
+    assert.equal(studentAdvisors.length, 1);
+    assert.equal(studentAdvisors[0].text, '1 guy M. Mc1son');
   });
 });

--- a/tests/integration/components/course-leadership-expanded-test.js
+++ b/tests/integration/components/course-leadership-expanded-test.js
@@ -10,22 +10,22 @@ module('Integration | Component | course leadership expanded', function(hooks) {
   setupMirage(hooks);
 
   test('it renders', async function(assert) {
-    assert.expect(6);
+    assert.expect(8);
     const users = this.server.createList('user', 2);
     const course = this.server.create('course', {
       directors: [users[0]],
       administrators: users,
+      studentAdvisors: [users[0]],
     });
     const courseModel = await this.owner.lookup('service:store').find('course', course.id);
     this.set('course', courseModel);
-    this.set('nothing', () => {});
     await render(hbs`<CourseLeadershipExpanded
-      @course={{course}}
+      @course={{this.course}}
       @editable={{true}}
-      @collapse={{this.nothing}}
-      @expand={{this.nothing}}
+      @collapse={{noop}}
+      @expand={{noop}}
       @isManaging={{false}}
-      @setIsManaging={{this.nothing}}
+      @setIsManaging={{noop}}
     />`);
 
     assert.equal(component.title, 'Course Leadership');
@@ -34,6 +34,8 @@ module('Integration | Component | course leadership expanded', function(hooks) {
     assert.equal(component.leadershipList.administrators.length, 2);
     assert.equal(component.leadershipList.administrators[0].text, '0 guy M. Mc0son');
     assert.equal(component.leadershipList.administrators[1].text, '1 guy M. Mc1son');
+    assert.equal(component.leadershipList.studentAdvisors.length, 1);
+    assert.equal(component.leadershipList.studentAdvisors[0].text, '0 guy M. Mc0son');
   });
 
   test('clicking the header collapses when there are administrators', async function(assert) {
@@ -47,14 +49,13 @@ module('Integration | Component | course leadership expanded', function(hooks) {
     this.set('click', () => {
       assert.ok(true, 'Action was fired');
     });
-    this.set('nothing', () => {});
     await render(hbs`<CourseLeadershipExpanded
-      @course={{course}}
+      @course={{this.course}}
       @editable={{true}}
-      @collapse={{action click}}
-      @expand={{this.nothing}}
+      @collapse={{this.click}}
+      @expand={{noop}}
       @isManaging={{false}}
-      @setIsManaging={{this.nothing}}
+      @setIsManaging={{noop}}
     />`);
     await component.collapse();
   });
@@ -70,14 +71,35 @@ module('Integration | Component | course leadership expanded', function(hooks) {
     this.set('click', () => {
       assert.ok(true, 'Action was fired');
     });
-    this.set('nothing', () => {});
     await render(hbs`<CourseLeadershipExpanded
-      @course={{course}}
+      @course={{this.course}}
       @editable={{true}}
-      @collapse={{action click}}
-      @expand={{this.nothing}}
+      @collapse={{this.click}}
+      @expand={{noop}}
       @isManaging={{false}}
-      @setIsManaging={{this.nothing}}
+      @setIsManaging={{noop}}
+    />`);
+    await component.collapse();
+  });
+
+  test('clicking the header collapses when there are student advisors', async function(assert) {
+    assert.expect(1);
+    const studentAdvisors = this.server.createList('user', 1);
+    const course = this.server.create('course', {
+      studentAdvisors
+    });
+    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    this.set('course', courseModel);
+    this.set('click', () => {
+      assert.ok(true, 'Action was fired');
+    });
+    await render(hbs`<CourseLeadershipExpanded
+      @course={{this.course}}
+      @editable={{true}}
+      @collapse={{this.click}}
+      @expand={{noop}}
+      @isManaging={{false}}
+      @setIsManaging={{noop}}
     />`);
     await component.collapse();
   });
@@ -90,14 +112,13 @@ module('Integration | Component | course leadership expanded', function(hooks) {
     this.set('click', () => {
       assert.ok(false);
     });
-    this.set('nothing', () => {});
     await render(hbs`<CourseLeadershipExpanded
-      @course={{course}}
+      @course={{this.course}}
       @editable={{true}}
-      @collapse={{action click}}
-      @expand={{this.nothing}}
+      @collapse={{this.click}}
+      @expand={{noop}}
       @isManaging={{false}}
-      @setIsManaging={{this.nothing}}
+      @setIsManaging={{noop}}
     />`);
     await component.collapse();
   });
@@ -110,14 +131,13 @@ module('Integration | Component | course leadership expanded', function(hooks) {
     this.set('click', () => {
       assert.ok(true, 'Action was fired');
     });
-    this.set('nothing', () => {});
     await render(hbs`<CourseLeadershipExpanded
-      @course={{course}}
+      @course={{this.course}}
       @editable={{true}}
       @collapse={{this.nothing}}
       @expand={{this.nothing}}
       @isManaging={{false}}
-      @setIsManaging={{action click}}
+      @setIsManaging={{this.click}}
     />`);
     await component.manage();
   });

--- a/tests/integration/components/leadership-list-test.js
+++ b/tests/integration/components/leadership-list-test.js
@@ -10,7 +10,7 @@ module('Integration | Component | leadership list', function(hooks) {
 
 
   test('it renders with data', async function(assert) {
-    assert.expect(5);
+    assert.expect(7);
     const user1 = EmberObject.create({
       firstName: 'a',
       lastName: 'person',
@@ -23,85 +23,135 @@ module('Integration | Component | leadership list', function(hooks) {
     });
     this.set('directors', [user1]);
     this.set('administrators', [user2, user1]);
+    this.set('studentAdvisors', [user2]);
 
     await render(hbs`<LeadershipList
       @directors={{this.directors}}
       @administrators={{this.administrators}}
+      @studentAdvisors={{this.studentAdvisors}}
       @showAdministrators={{true}}
       @showDirectors={{true}}
+      @showStudentAdvisors={{true}}
     />`);
     const directors = 'table tbody tr:nth-of-type(1) td:nth-of-type(1) li [data-test-name]';
     const administrators = 'table tbody tr:nth-of-type(1) td:nth-of-type(2) li [data-test-name]';
+    const studentAdvisors = 'table tbody tr:nth-of-type(1) td:nth-of-type(3) li [data-test-name]';
 
     assert.dom(directors).exists({ count: 1 });
     assert.dom(findAll(directors)[0]).hasText('a b person');
     assert.dom(administrators).exists({ count: 2 });
     assert.dom(findAll(administrators)[0]).hasText('a b person');
     assert.dom(findAll(administrators)[1]).hasText('b a person');
+    assert.dom(studentAdvisors).exists({ count: 1 });
+    assert.dom(findAll(studentAdvisors)[0]).hasText('b a person');
   });
 
   test('it renders without directors', async function(assert) {
-    assert.expect(2);
+    assert.expect(4);
     const user1 = EmberObject.create({
       firstName: 'a',
       lastName: 'person',
       fullName: 'a b person',
     });
     this.set('administrators', [user1]);
+    this.set('studentAdvisors', [user1]);
 
     await render(hbs`<LeadershipList
       @showDirectors={{false}}
       @showAdministrators={{true}}
       @administrators={{this.administrators}}
+      @showStudentAdvisors={{true}}
+      @studentAdvisors={{this.studentAdvisors}}
     />`);
     const administrators = 'table tbody tr:nth-of-type(1) td:nth-of-type(1) li [data-test-name]';
+    const studentAdvisors = 'table tbody tr:nth-of-type(1) td:nth-of-type(2) li [data-test-name]';
 
     assert.dom(administrators).exists({ count: 1 });
     assert.dom(findAll(administrators)[0]).hasText('a b person');
+    assert.dom(studentAdvisors).exists({ count: 1 });
+    assert.dom(findAll(studentAdvisors)[0]).hasText('a b person');
   });
 
   test('it renders without administrators', async function(assert) {
-    assert.expect(2);
+    assert.expect(4);
     const user1 = EmberObject.create({
       firstName: 'a',
       lastName: 'person',
       fullName: 'a b person',
     });
     this.set('directors', [user1]);
+    this.set('studentAdvisors', [user1]);
 
     await render(hbs`<LeadershipList
       @showAdministrators={{false}}
       @showDirectors={{true}}
       @directors={{this.directors}}
+      @showStudentAdvisors={{true}}
+      @studentAdvisors={{this.studentAdvisors}}
     />`);
     const directors = 'table tbody tr:nth-of-type(1) td:nth-of-type(1) li [data-test-name]';
+    const studentAdvisors = 'table tbody tr:nth-of-type(1) td:nth-of-type(2) li [data-test-name]';
 
     assert.dom(directors).exists({ count: 1 });
     assert.dom(findAll(directors)[0]).hasText('a b person');
+    assert.dom(studentAdvisors).exists({ count: 1 });
+    assert.dom(findAll(studentAdvisors)[0]).hasText('a b person');
+  });
+
+  test('it renders without student advisors', async function(assert) {
+    assert.expect(4);
+    const user1 = EmberObject.create({
+      firstName: 'a',
+      lastName: 'person',
+      fullName: 'a b person',
+    });
+    this.set('directors', [user1]);
+    this.set('administrators', [user1]);
+
+    await render(hbs`<LeadershipList
+      @showDirectors={{true}}
+      @directors={{this.directors}}
+      @showAdministrators={{true}}
+      @administrators={{this.administrators}}
+      @showStudentAdvisors={{false}}
+    />`);
+    const directors = 'table tbody tr:nth-of-type(1) td:nth-of-type(1) li [data-test-name]';
+    const administrators = 'table tbody tr:nth-of-type(1) td:nth-of-type(2) li [data-test-name]';
+
+    assert.dom(directors).exists({ count: 1 });
+    assert.dom(findAll(directors)[0]).hasText('a b person');
+    assert.dom(administrators).exists({ count: 1 });
+    assert.dom(findAll(administrators)[0]).hasText('a b person');
   });
 
   test('it renders without data', async function(assert) {
-    assert.expect(4);
+    assert.expect(6);
     this.set('directors', []);
     this.set('administrators', []);
+    this.set('studentAdvisors', []);
 
     await render(hbs`<LeadershipList
       @directors={{this.directors}}
       @administrators={{this.administrators}}
+      @studentAdvisors={{this.studentAdvisors}}
       @showAdministrators={{true}}
       @showDirectors={{true}}
+      @showStudentAdvisors={{true}}
       />`);
     const directors = 'table tbody tr:nth-of-type(1) td:nth-of-type(1) li';
     const administrators = 'table tbody tr:nth-of-type(1) td:nth-of-type(2) li';
+    const studentAdvisors = 'table tbody tr:nth-of-type(1) td:nth-of-type(3) li';
 
     assert.dom(directors).exists({ count: 1 });
     assert.dom(findAll(directors)[0]).hasText('None');
     assert.dom(administrators).exists({ count: 1 });
     assert.dom(findAll(administrators)[0]).hasText('None');
+    assert.dom(studentAdvisors).exists({ count: 1 });
+    assert.dom(findAll(studentAdvisors)[0]).hasText('None');
   });
 
   test('disabled users are indicated with an icon', async function(assert) {
-    assert.expect(7);
+    assert.expect(10);
     const user1 = EmberObject.create({
       enabled: true,
       firstName: 'a',
@@ -116,19 +166,25 @@ module('Integration | Component | leadership list', function(hooks) {
     });
     this.set('directors', [user1]);
     this.set('administrators', [user2, user1]);
+    this.set('studentAdvisors', [user2]);
 
     await render(hbs`<LeadershipList
       @directors={{this.directors}}
       @administrators={{this.administrators}}
+      @studentAdvisors={{this.studentAdvisors}}
       @showAdministrators={{true}}
       @showDirectors={{true}}
+      @showStudentAdvisors={{true}}
     />`);
     const directors = 'table tbody tr:nth-of-type(1) td:nth-of-type(1) li';
     const administrators = 'table tbody tr:nth-of-type(1) td:nth-of-type(2) li';
+    const studentAdvisors = 'table tbody tr:nth-of-type(1) td:nth-of-type(3) li';
     const directorNames = `${directors} [data-test-name]`;
     const disabledDirectors = `${directors} .fa-user-times`;
     const administratorNames = `${administrators} [data-test-name]`;
     const disabledAdministrators = `${administrators} .fa-user-times`;
+    const studentAdvisorNames = `${studentAdvisors} [data-test-name]`;
+    const disabledStudentAdvisors = `${studentAdvisors} .fa-user-times`;
 
     assert.dom(directors).exists({ count: 1 });
     assert.dom(disabledDirectors).doesNotExist();
@@ -137,5 +193,8 @@ module('Integration | Component | leadership list', function(hooks) {
     assert.dom(disabledAdministrators).exists({ count: 1 });
     assert.dom(findAll(administratorNames)[0]).hasText('a b person');
     assert.dom(findAll(administratorNames)[1]).hasText('b a person');
+    assert.dom(studentAdvisors).exists({ count: 1 });
+    assert.dom(disabledStudentAdvisors).exists({ count: 1 });
+    assert.dom(findAll(studentAdvisorNames)[0]).hasText('b a person');
   });
 });

--- a/tests/integration/components/leadership-manager-test.js
+++ b/tests/integration/components/leadership-manager-test.js
@@ -15,52 +15,67 @@ module('Integration | Component | leadership manager', function(hooks) {
   setupMirage(hooks);
 
   test('it renders with data', async function(assert) {
-    assert.expect(5);
+    assert.expect(7);
     this.server.createList('user', 2);
     const users = await this.owner.lookup('service:store').findAll('user');
     this.set('directors', [users.firstObject]);
     this.set('administrators', users);
+    this.set('studentAdvisors', [users.objectAt(1)]);
 
     await render(hbs`<LeadershipManager
       @showAdministrators={{true}}
       @showDirectors={{true}}
+      @showStudentAdvisors={{true}}
       @directors={{this.directors}}
       @administrators={{this.administrators}}
+      @studentAdvisors={{this.studentAdvisors}}
       @removeDirector={{noop}}
       @addDirector={{noop}}
       @removeAdministrator={{noop}}
       @addAdministrator={{noop}}
+      @removeStudentAdvisor={{noop}}
+      @addStudentAdvisor={{noop}}
     />`);
     const directors = 'table tbody tr:nth-of-type(1) td:nth-of-type(1) li';
     const administrators = 'table tbody tr:nth-of-type(1) td:nth-of-type(2) li';
+    const studentAdvisors = 'table tbody tr:nth-of-type(1) td:nth-of-type(3) li';
 
     assert.dom(directors).exists({ count: 1 });
     assert.dom(findAll(directors)[0]).hasText('0 guy M. Mc0son');
     assert.dom(administrators).exists({ count: 2 });
     assert.dom(findAll(administrators)[0]).hasText('0 guy M. Mc0son');
     assert.dom(findAll(administrators)[1]).hasText('1 guy M. Mc1son');
+    assert.dom(studentAdvisors).exists({ count: 1 });
+    assert.dom(findAll(studentAdvisors)[0]).hasText('1 guy M. Mc1son');
   });
 
   test('it renders without data', async function(assert) {
-    assert.expect(2);
+    assert.expect(3);
     this.set('directors', []);
     this.set('administrators', []);
+    this.set('studentAdvisors', []);
 
     await render(hbs`<LeadershipManager
       @showAdministrators={{true}}
       @showDirectors={{true}}
+      @showStudentAdvisors={{true}}
       @directors={{this.directors}}
       @administrators={{this.administrators}}
+      @studentAdvisors={{this.studentAdvisors}}
       @removeDirector={{noop}}
       @addDirector={{noop}}
       @removeAdministrator={{noop}}
       @addAdministrator={{noop}}
+      @removeStudentAdvisor={{noop}}
+      @addStudentAdvisor={{noop}}
     />`);
     const directors = 'table tbody tr:nth-of-type(1) td:nth-of-type(1) li';
     const administrators = 'table tbody tr:nth-of-type(1) td:nth-of-type(2) li';
+    const studentAdvisors = 'table tbody tr:nth-of-type(1) td:nth-of-type(3) li';
 
     assert.dom(directors).doesNotExist();
     assert.dom(administrators).doesNotExist();
+    assert.dom(studentAdvisors).doesNotExist();
   });
 
   test('remove director', async function(assert) {
@@ -69,6 +84,7 @@ module('Integration | Component | leadership manager', function(hooks) {
     const user = await this.owner.lookup('service:store').find('user', 1);
     this.set('directors', [user]);
     this.set('administrators', []);
+    this.set('studentAdvisors', []);
     this.set('remove', (who) => {
       assert.equal(who, user);
     });
@@ -76,12 +92,16 @@ module('Integration | Component | leadership manager', function(hooks) {
     await render(hbs`<LeadershipManager
       @showAdministrators={{true}}
       @showDirectors={{true}}
+      @showStudentAdvisors={{true}}
       @directors={{this.directors}}
       @administrators={{this.administrators}}
-      @removeDirector={{action remove}}
+      @studentAdvisors={{this.studentAdvisors}}
+      @removeDirector={{this.remove}}
       @addDirector={{noop}}
       @removeAdministrator={{noop}}
       @addAdministrator={{noop}}
+      @removeStudentAdvisor={{noop}}
+      @addStudentAdvisor={{noop}}
     />`);
     const list = 'table tbody tr:nth-of-type(1) td:nth-of-type(1) li';
     const icon = `${list}:nth-of-type(1) svg`;
@@ -97,6 +117,7 @@ module('Integration | Component | leadership manager', function(hooks) {
     const user = await this.owner.lookup('service:store').find('user', 1);
     this.set('directors', []);
     this.set('administrators', [user]);
+    this.set('studentAdvisors', []);
     this.set('remove', (who) => {
       assert.equal(who, user);
     });
@@ -104,12 +125,16 @@ module('Integration | Component | leadership manager', function(hooks) {
     await render(hbs`<LeadershipManager
       @showAdministrators={{true}}
       @showDirectors={{true}}
+      @showStudentAdvisors={{true}}
       @directors={{this.directors}}
       @administrators={{this.administrators}}
+      @studentAdvisors={{this.studentAdvisors}}
       @removeDirector={{noop}}
       @addDirector={{noop}}
-      @removeAdministrator={{action remove}}
+      @removeAdministrator={{this.remove}}
       @addAdministrator={{noop}}
+      @removeStudentAdvisor={{noop}}
+      @addStudentAdvisor={{noop}}
     />`);
     const list = 'table tbody tr:nth-of-type(1) td:nth-of-type(2) li';
     const icon = `${list}:nth-of-type(1) svg`;
@@ -119,12 +144,46 @@ module('Integration | Component | leadership manager', function(hooks) {
     await click(icon);
   });
 
+  test('remove student advisor', async function(assert) {
+    assert.expect(3);
+    this.server.createList('user', 1);
+    const user = await this.owner.lookup('service:store').find('user', 1);
+    this.set('directors', []);
+    this.set('administrators', []);
+    this.set('studentAdvisors', [user]);
+    this.set('remove', (who) => {
+      assert.equal(who, user);
+    });
+
+    await render(hbs`<LeadershipManager
+      @showAdministrators={{true}}
+      @showDirectors={{true}}
+      @showStudentAdvisors={{true}}
+      @directors={{this.directors}}
+      @administrators={{this.administrators}}
+      @studentAdvisors={{this.studentAdvisors}}
+      @removeDirector={{noop}}
+      @addDirector={{noop}}
+      @removeAdministrator={{noop}}
+      @addAdministrator={{noop}}
+      @removeStudentAdvisor={{this.remove}}
+      @addStudentAdvisor={{noop}}
+    />`);
+    const list = 'table tbody tr:nth-of-type(1) td:nth-of-type(3) li';
+    const icon = `${list}:nth-of-type(1) svg`;
+
+    assert.dom(list).exists({ count: 1 });
+    assert.dom(findAll(list)[0]).hasText('0 guy M. Mc0son');
+    await click(icon);
+  });
+
   test('add director', async function(assert) {
-    assert.expect(6);
+    assert.expect(8);
     this.server.createList('user', 1);
     const user = await this.owner.lookup('service:store').find('user', 1);
     this.set('directors', []);
     this.set('administrators', [user]);
+    this.set('studentAdvisors', [user]);
     this.set('add', (who) => {
       assert.equal(who, user, 'user passed correctly from action');
       this.set('directors', [who]);
@@ -133,34 +192,42 @@ module('Integration | Component | leadership manager', function(hooks) {
     await render(hbs`<LeadershipManager
       @showAdministrators={{true}}
       @showDirectors={{true}}
+      @showStudentAdvisors={{true}}
       @directors={{this.directors}}
       @administrators={{this.administrators}}
+      @studentAdvisors={{this.studentAdvisors}}
       @removeDirector={{noop}}
-      @addDirector={{action add}}
+      @addDirector={{this.add}}
       @removeAdministrator={{noop}}
       @addAdministrator={{noop}}
+      @removeStudentAdvisor={{noop}}
+      @addStudentAdvisor={{noop}}
     />`);
     const directorsList = 'table tbody tr:nth-of-type(1) td:nth-of-type(1) li';
     const administratorsList = 'table tbody tr:nth-of-type(1) td:nth-of-type(2) li';
+    const studentAdvisorsList = 'table tbody tr:nth-of-type(1) td:nth-of-type(3) li';
     const directorSearch = '[data-test-director-search] input';
     const firstResult = '[data-test-result-index="1"]';
 
     assert.dom(directorsList).doesNotExist();
     assert.dom(administratorsList).exists({ count: 1 });
+    assert.dom(studentAdvisorsList).exists({ count: 1 });
     await fillIn(directorSearch, 'user');
 
     assert.ok(find(firstResult).textContent.includes('0 guy'));
     await click(firstResult);
     assert.dom(directorsList).exists({ count: 1 });
     assert.dom(administratorsList).exists({ count: 1 });
+    assert.dom(studentAdvisorsList).exists({ count: 1 });
   });
 
   test('add administrator', async function(assert) {
-    assert.expect(6);
+    assert.expect(8);
     this.server.createList('user', 1);
     const user = await this.owner.lookup('service:store').find('user', 1);
     this.set('directors', [user]);
     this.set('administrators', []);
+    this.set('studentAdvisors', [user]);
     this.set('add', (who) => {
       assert.equal(who, user, 'user passed correctly from action');
       this.set('administrators', [who]);
@@ -169,20 +236,26 @@ module('Integration | Component | leadership manager', function(hooks) {
     await render(hbs`<LeadershipManager
       @showAdministrators={{true}}
       @showDirectors={{true}}
+      @showStudentAdvisors={{true}}
       @directors={{this.directors}}
       @administrators={{this.administrators}}
+      @studentAdvisors={{this.studentAdvisors}}
       @removeDirector={{noop}}
       @addDirector={{noop}}
       @removeAdministrator={{noop}}
-      @addAdministrator={{action add}}
+      @addAdministrator={{this.add}}
+      @removeStudentAdvisor={{noop}}
+      @addStudentAdvisor={{noop}}
     />`);
     const directorsList = 'table tbody tr:nth-of-type(1) td:nth-of-type(1) li';
     const administratorsList = 'table tbody tr:nth-of-type(1) td:nth-of-type(2) li';
+    const studentAdvisorsList = 'table tbody tr:nth-of-type(1) td:nth-of-type(3) li';
     const administratorSearch = '[data-test-administrator-search] input';
     const firstResult = '[data-test-result-index="1"]';
 
     assert.dom(directorsList).exists({ count: 1 });
     assert.dom(administratorsList).doesNotExist();
+    assert.dom(studentAdvisorsList).exists({ count: 1 });
 
     await fillIn(administratorSearch, 'user');
 
@@ -190,6 +263,52 @@ module('Integration | Component | leadership manager', function(hooks) {
     await click(firstResult);
     assert.dom(directorsList).exists({ count: 1 });
     assert.dom(administratorsList).exists({ count: 1 });
+    assert.dom(studentAdvisorsList).exists({ count: 1 });
+  });
+
+  test('add student advisor', async function(assert) {
+    assert.expect(8);
+    this.server.createList('user', 1);
+    const user = await this.owner.lookup('service:store').find('user', 1);
+    this.set('directors', [user]);
+    this.set('administrators', [user]);
+    this.set('studentAdvisors', []);
+    this.set('add', (who) => {
+      assert.equal(who, user, 'user passed correctly from action');
+      this.set('studentAdvisors', [who]);
+    });
+
+    await render(hbs`<LeadershipManager
+      @showAdministrators={{true}}
+      @showDirectors={{true}}
+      @showStudentAdvisors={{true}}
+      @directors={{this.directors}}
+      @administrators={{this.administrators}}
+      @studentAdvisors={{this.studentAdvisors}}
+      @removeDirector={{noop}}
+      @addDirector={{noop}}
+      @removeAdministrator={{noop}}
+      @addAdministrator={{noop}}
+      @removeStudentAdvisor={{noop}}
+      @addStudentAdvisor={{this.add}}
+    />`);
+    const directorsList = 'table tbody tr:nth-of-type(1) td:nth-of-type(1) li';
+    const administratorsList = 'table tbody tr:nth-of-type(1) td:nth-of-type(2) li';
+    const studentAdvisorsList = 'table tbody tr:nth-of-type(1) td:nth-of-type(3) li';
+    const studentAdvisorSearch = '[data-test-student-advisor-search] input';
+    const firstResult = '[data-test-result-index="1"]';
+
+    assert.dom(directorsList).exists({ count: 1 });
+    assert.dom(administratorsList).exists({ count: 1 });
+    assert.dom(studentAdvisorsList).doesNotExist();
+
+    await fillIn(studentAdvisorSearch, 'user');
+
+    assert.ok(find(firstResult).textContent.includes('0 guy'));
+    await click(firstResult);
+    assert.dom(directorsList).exists({ count: 1 });
+    assert.dom(administratorsList).exists({ count: 1 });
+    assert.dom(studentAdvisorsList).exists({ count: 1 });
   });
 
   test('disabled users are indicated with an icon', async function(assert) {

--- a/tests/integration/components/session-leadership-expanded-test.js
+++ b/tests/integration/components/session-leadership-expanded-test.js
@@ -1,129 +1,125 @@
-import EmberObject from '@ember/object';
-import RSVP from 'rsvp';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-const { resolve } = RSVP;
+import { component } from 'ilios-common/page-objects/components/session-leadership-expanded';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | session leadership expanded', function(hooks) {
   setupRenderingTest(hooks);
-
+  setupMirage(hooks);
 
   test('it renders', async function(assert) {
-    assert.expect(4);
-
-    const user1 = EmberObject.create({
-      firstName: 'a',
-      lastName: 'person',
-      fullName: 'a b person',
-      enabled: true,
+    assert.expect(6);
+    const users = this.server.createList('user', 2);
+    const course = this.server.create('course');
+    const session = this.server.create('session', {
+      course,
+      administrators: users,
+      studentAdvisors: [users[0]],
     });
-    const user2 = EmberObject.create({
-      firstName: 'b',
-      lastName: 'person',
-      fullName: 'b a person',
-      enabled: true,
-    });
-    const session = EmberObject.create({
-      administrators: resolve([user1, user2]),
-      hasMany(what){
-        if (what === 'administrators') {
-          return {
-            ids(){
-              return [1, 2];
-            }
-          };
-        }
-        assert.ok(false);
-      }
-    });
-
-    this.set('session', session);
-    this.set('nothing', parseInt);
+    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    this.set('session', sessionModel);
     await render(hbs`<SessionLeadershipExpanded
-      @session={{session}}
+      @session={{this.session}}
       @canUpdate={{true}}
-      @collapse={{action nothing}}
-      @expand={{action nothing}}
+      @collapse={{noop}}
+      @expand={{noop}}
       @isManaging={{false}}
-      @setIsManaging={{action nothing}}
+      @setIsManaging={{noop}}
     />`);
-    const title = '.title';
-    const table = 'table';
-    const administrators = `${table} tbody tr:nth-of-type(1) td:nth-of-type(1) li`;
-    const firstAdministrator = `${administrators}:nth-of-type(1)`;
-    const secondAdministrator = `${administrators}:nth-of-type(2)`;
 
-    assert.dom(title).hasText('Session Administration');
-    assert.dom(administrators).exists({ count: 2 });
-    assert.dom(firstAdministrator).hasText('a b person');
-    assert.dom(secondAdministrator).hasText('b a person');
+    assert.equal(component.title, 'Session Administration');
+    assert.equal(component.leadershipList.administrators.length, 2);
+    assert.equal(component.leadershipList.administrators[0].text, '0 guy M. Mc0son');
+    assert.equal(component.leadershipList.administrators[1].text, '1 guy M. Mc1son');
+    assert.equal(component.leadershipList.studentAdvisors.length, 1);
+    assert.equal(component.leadershipList.studentAdvisors[0].text, '0 guy M. Mc0son');
   });
 
-  test('clicking the header collapses', async function(assert) {
+  test('clicking the header collapses when there are administrators', async function(assert) {
     assert.expect(1);
-    const session = EmberObject.create({
-      administrators: resolve([]),
-      hasMany(what){
-        if (what === 'administrators') {
-          return {
-            ids(){
-              return [];
-            }
-          };
-        }
-      }
+    const administrators = this.server.createList('user', 1);
+    const course = this.server.create('course');
+    const session = this.server.create('session', {
+      course,
+      administrators
     });
-
-    this.set('session', session);
+    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    this.set('session', sessionModel);
     this.set('click', () => {
       assert.ok(true, 'Action was fired');
     });
-    this.set('nothing', parseInt);
     await render(hbs`<SessionLeadershipExpanded
-      @session={{session}}
+      @session={{this.session}}
       @canUpdate={{true}}
-      @collapse={{action click}}
-      @expand={{action nothing}}
+      @collapse={{this.click}}
+      @expand={{noop}}
       @isManaging={{false}}
-      @setIsManaging={{action nothing}}
+      @setIsManaging={{noop}}
     />`);
-    const title = '.title';
+    await component.collapse();
+  });
 
-    await click(title);
+  test('clicking the header collapses when there are student advisors', async function(assert) {
+    assert.expect(1);
+    const studentAdvisors = this.server.createList('user', 1);
+    const course = this.server.create('course');
+    const session = this.server.create('session', {
+      course,
+      studentAdvisors
+    });
+    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    this.set('session', sessionModel);
+    this.set('click', () => {
+      assert.ok(true, 'Action was fired');
+    });
+    await render(hbs`<SessionLeadershipExpanded
+      @session={{this.session}}
+      @canUpdate={{true}}
+      @collapse={{this.click}}
+      @expand={{noop}}
+      @isManaging={{false}}
+      @setIsManaging={{noop}}
+    />`);
+    await component.collapse();
+  });
+
+  test('clicking the header does not collapse where there are no linked leaders', async function(assert) {
+    assert.expect(0);
+    const session = this.server.create('session');
+    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    this.set('session', sessionModel);
+    this.set('click', () => {
+      assert.ok(false);
+    });
+    await render(hbs`<SessionLeadershipExpanded
+      @session={{this.session}}
+      @canUpdate={{true}}
+      @collapse={{this.click}}
+      @expand={{noop}}
+      @isManaging={{false}}
+      @setIsManaging={{noop}}
+    />`);
+    await component.collapse();
   });
 
   test('clicking manage fires action', async function(assert) {
     assert.expect(1);
-    const session = EmberObject.create({
-      administrators: resolve([]),
-      hasMany(what){
-        if (what === 'administrators') {
-          return {
-            ids(){
-              return [];
-            }
-          };
-        }
-      }
-    });
-
-    this.set('session', session);
+    const session = this.server.create('session');
+    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    this.set('session', sessionModel);
     this.set('click', () => {
       assert.ok(true, 'Action was fired');
     });
-    this.set('nothing', parseInt);
     await render(hbs`<SessionLeadershipExpanded
-      @session={{session}}
+      @session={{this.session}}
       @canUpdate={{true}}
-      @collapse={{action nothing}}
-      @expand={{action nothing}}
+      @collapse={{this.nothing}}
+      @expand={{this.nothing}}
       @isManaging={{false}}
-      @setIsManaging={{action click}}
+      @setIsManaging={{this.click}}
     />`);
-    const manage = '.actions button';
-
-    await click(manage);
+    await component.manage();
   });
 });

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -281,6 +281,8 @@ general:
   starts: Starts
   startTime: "Start Time"
   status: Status
+  studentAdvisorCount: "There {count, plural, =1 {is 1 student advisor} other {are # student advisors}}"
+  studentAdvisors: Student Advisors
   summary: Summary
   sunday: Sunday
   supplementalCurriculum: "Supplemental Curriculum"

--- a/translations/es.yaml
+++ b/translations/es.yaml
@@ -281,6 +281,8 @@ general:
   starts: Empieza
   startTime: "Hora de Iniciar"
   status: Estado
+  studentAdvisorCount: "Hay {count, plural, =1 {1 consejero estudiantil} other {# consejeros estudiantiles}}"
+  studentAdvisors: Consejeros Estudiantiles
   summary: Resumen
   sunday: Domingo
   supplementalCurriculum: "Plan de Estudios No Requerido"

--- a/translations/fr.yaml
+++ b/translations/fr.yaml
@@ -281,6 +281,8 @@ general:
   starts: Commencer
   startTime: "Heure Commencer"
   status: Statut
+  studentAdvisorCount: "Il y a {count, plural, =1 {une camarade-conseil} other {# camarades-conseil}}"
+  studentAdvisors: Camarades-Conseil
   summary: "Résumé"
   sunday: Dimanche
   supplementalCurriculum: "Supplemental Curriculum"


### PR DESCRIPTION
This new leadership role will have expanded privileges in the course and
session and will be able to see events and materials as if they were a
student in the course.

Requires https://github.com/ilios/ilios/pull/2978