### PR TITLE
Track the count of learners and groups

### DIFF
--- a/addon/components/detail-learner-list.hbs
+++ b/addon/components/detail-learner-list.hbs
@@ -1,5 +1,5 @@
 <ul class="detail-learner-list" data-test-detail-learner-list>
-  {{#each (sort-by "fullName" (await @learners)) as |user|}}
+  {{#each (sort-by "fullName" @learners) as |user|}}
     {{#if @isManaging}}
       <li role="button" {{on "click" (fn @remove user)}}>
         <span data-test-user-name>{{user.fullName}}</span>

--- a/addon/components/detail-learners-and-learner-groups.js
+++ b/addon/components/detail-learners-and-learner-groups.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
+import { action, computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { dropTask } from 'ember-concurrency-decorators';
 import { hash } from 'rsvp';
@@ -35,12 +35,14 @@ export default class DetailLearnersAndLearnerGroupsComponent extends Component {
     this.isManaging = false;
   }
 
+  @computed('args.ilmSession.learners.length')
   get learnerCount() {
     if (! this.args.ilmSession) {
       return 0;
     }
     return this.args.ilmSession.hasMany('learners').ids().length;
   }
+  @computed('args.ilmSession.learnerGroups.length')
   get learnerGroupCount() {
     if (! this.args.ilmSession) {
       return 0;

--- a/tests/integration/components/detail-learners-and-learnergroups-test.js
+++ b/tests/integration/components/detail-learners-and-learnergroups-test.js
@@ -267,4 +267,22 @@ module('Integration | Component | detail-learners-and-learner-groups', function(
     assert.equal(component.detailLearnerList.learners.length, 2);
     assert.equal(component.detailLearnergroupsList.trees.length, 3);
   });
+
+  test('it updates when relationships change #1550', async function(assert) {
+    this.set('ilmSession', this.ilmSession);
+    await render(hbs`<DetailLearnersAndLearnerGroups
+      @editable={{true}}
+      @ilmSession={{this.ilmSession}}
+      @cohorts={{array}}
+    />`);
+    assert.equal(component.title, 'Learners and Learner Groups (3/3)');
+    assert.equal(component.detailLearnerList.learners.length, 3);
+    assert.equal(component.detailLearnergroupsList.trees.length, 2);
+    this.ilmSession.set('learners', []);
+    this.ilmSession.set('learnerGroups', []);
+    await this.ilmSession.save();
+    assert.equal(component.title, 'Learners and Learner Groups (0/0)');
+    assert.equal(component.detailLearnerList.learners.length, 0);
+    assert.equal(component.detailLearnergroupsList.trees.length, 0);
+  });
 });


### PR DESCRIPTION
The metadata hasMany property we're reading from the model isn't
autotracked so we have to add a computed tag to ensure this recomputes
when the values change. For some reason this only presents itself in a production build, but I was able to create a test that duplicates the issue within the single component so I believe this fixes #1550