### PR TITLE
prevents double-listing of ILM-based events if they are already shown as post-reqs

### DIFF
--- a/addon/components/dashboard-agenda.js
+++ b/addon/components/dashboard-agenda.js
@@ -49,12 +49,12 @@ export default class DashboardAgendaComponent extends Component {
     return this.weeksEvents.filter(ev => {
       // ACHTUNG MINEN!
       // do a reverse lookup here against pre-work events.
-      // if the current event has pre-requisites, and if any of
-      // those pre-requisites has been identified as pre-work event
+      // if the current event is derived from an ILM and it has pre-requisites,
+      // and if any of those pre-requisites has been identified as pre-work event
       // then do not list this event again, as it will be displayed
       // as post-requisite elsewhere in this agenda view already.
       // [ST 2020/08/04]
-      if (ev.prerequisites.length) {
+      if (ev.ilmSession && ev.prerequisites.length) {
         const prerequisiteHashes = ev.prerequisites.map(ev => {
           return this.hashEvent(ev);
         });

--- a/addon/components/dashboard-agenda.js
+++ b/addon/components/dashboard-agenda.js
@@ -21,6 +21,9 @@ export default class DashboardAgendaComponent extends Component {
   }
 
   get ilmPreWorkEvents() {
+    if (! this.weeksEvents) {
+      return [];
+    }
     const preWork = this.weeksEvents.reduce((arr, ev) => {
       if (!ev.isBlanked && ev.isPublished && !ev.isScheduled) {
         arr.pushObjects(ev.prerequisites);

--- a/tests/integration/components/dashboard-agenda-test.js
+++ b/tests/integration/components/dashboard-agenda-test.js
@@ -95,6 +95,19 @@ module('Integration | Component | dashboard agenda', function (hooks) {
         isScheduled: true,
         isBlanked: false,
       },
+      {
+        name: 'prework to an ILM',
+        startDate: today.format(),
+        endDate: tomorrow.format(),
+        location: "room 123",
+        ilmSession: true,
+        slug: 'whatever',
+        postrequisiteSlug: 'ilmpostreq',
+        postrequisiteName: 'ILM postreq',
+        isPublished: true,
+        isScheduled: false,
+        isBlanked: false,
+      },
     ];
 
     mockEvents = [
@@ -196,6 +209,23 @@ module('Integration | Component | dashboard agenda', function (hooks) {
         isScheduled: false,
         isBlanked: false,
       },
+      {
+        name: 'Ilm',
+        startDate: today.format(),
+        location: 123,
+        lastModified: today.format(),
+        attendanceRequired: true,
+        equipmentRequired: true,
+        attireRequired: true,
+        postrequisites: [],
+        prerequisites: [
+          preWork[6],
+        ],
+        isPublished: true,
+        isScheduled: false,
+        isBlanked: false,
+        ilmSession: 12345,
+      },
     ];
 
     preWork[0].postrequisites = [mockEvents[2]];
@@ -216,7 +246,7 @@ module('Integration | Component | dashboard agenda', function (hooks) {
   });
 
   test('it renders with events', async function (assert) {
-    assert.expect(17);
+    assert.expect(18);
     this.owner.register('service:user-events', userEventsMock);
     this.userEvents = this.owner.lookup('service:user-events');
 
@@ -231,7 +261,7 @@ module('Integration | Component | dashboard agenda', function (hooks) {
       assert.dom(tds[1]).hasText(mockEvents[i].name);
     }
     const preworkSelector = '[data-test-ilios-calendar-pre-work-event]';
-    assert.equal(this.element.querySelectorAll(preworkSelector).length, 2);
+    assert.equal(this.element.querySelectorAll(preworkSelector).length, 3);
     assert.dom(this.element.querySelector(`${preworkSelector}:nth-of-type(1)`))
       .hasText(
         'prework 2 Due Before first (' + moment(mockEvents[0].startDate).format('M/D/YYYY') + ')'
@@ -239,6 +269,10 @@ module('Integration | Component | dashboard agenda', function (hooks) {
     assert.dom(this.element.querySelector(`${preworkSelector}:nth-of-type(2)`))
       .hasText(
         'prework 1 Due Before third (' + moment(mockEvents[2].startDate).format('M/D/YYYY') + ')'
+      );
+    assert.dom(this.element.querySelector(`${preworkSelector}:nth-of-type(3)`))
+      .hasText(
+        'prework to an ILM Due Before ILM postreq (' + moment(mockEvents[3].startDate).format('M/D/YYYY') + ')'
       );
   });
 

--- a/tests/integration/components/dashboard-agenda-test.js
+++ b/tests/integration/components/dashboard-agenda-test.js
@@ -1,4 +1,3 @@
-import { resolve } from 'rsvp';
 import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
@@ -204,13 +203,13 @@ module('Integration | Component | dashboard agenda', function (hooks) {
     preWork[2].postrequisites = [mockEvents[0]];
 
     userEventsMock = Service.extend({
-      getEvents() {
-        return new resolve(mockEvents);
+      async getEvents() {
+        return mockEvents;
       },
     });
     blankEventsMock = Service.extend({
-      getEvents() {
-        return new resolve([]);
+      async getEvents() {
+        return [];
       },
     });
 

--- a/tests/integration/components/dashboard-agenda-test.js
+++ b/tests/integration/components/dashboard-agenda-test.js
@@ -128,6 +128,7 @@ module('Integration | Component | dashboard agenda', function (hooks) {
         equipmentRequired: false,
         attireRequired: false,
         postrequisites: [],
+        prerequisites: [],
         isPublished: true,
         isScheduled: false,
         isBlanked: false,


### PR DESCRIPTION
this filters out any ILMs-based events from the agenda if they are already listed as post-requisite in the "pre-work" section.

![Selection_073](https://user-images.githubusercontent.com/1410427/89438765-11639e80-d6fe-11ea-8648-39b5ab72ccd1.png)

fixes #1553 