### PR TITLE
Replace our URL validation library

### DIFF
--- a/addon/decorators/validation/is-url.js
+++ b/addon/decorators/validation/is-url.js
@@ -1,6 +1,6 @@
 import { registerDecorator } from "class-validator";
 import { getOwner } from '@ember/application';
-import testURL from "is-url";
+import URLValidator from 'validator/es/lib/isURL';
 
 export function IsURL(validationOptions) {
   return function (object, propertyName) {
@@ -14,7 +14,10 @@ export function IsURL(validationOptions) {
           if (!value) {
             return true;
           }
-          return testURL(value);
+          return URLValidator(value, {
+            // eslint-disable-next-line camelcase
+            require_protocol: true,
+          });
         },
         defaultMessage({ object: target }) {
           const owner = getOwner(target);

--- a/package-lock.json
+++ b/package-lock.json
@@ -7989,6 +7989,13 @@
         "google-libphonenumber": "^3.2.8",
         "tslib": ">=1.9.0",
         "validator": "13.0.0"
+      },
+      "dependencies": {
+        "validator": {
+          "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/validator/-/validator-13.0.0.tgz",
+          "integrity": "sha512-anYx5fURbgF04lQV18nEQWZ/3wHGnxiKdG4aL8J+jEDsm98n/sU/bey+tYk6tnGJzm7ioh5FoqrAiQ6m03IgaA=="
+        }
       }
     },
     "cldr-core": {
@@ -21956,11 +21963,6 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
-    "is-url": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
-      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
-    },
     "is-valid-glob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
@@ -28179,9 +28181,9 @@
       }
     },
     "validator": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.0.0.tgz",
-      "integrity": "sha512-anYx5fURbgF04lQV18nEQWZ/3wHGnxiKdG4aL8J+jEDsm98n/sU/bey+tYk6tnGJzm7ioh5FoqrAiQ6m03IgaA=="
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.1.1.tgz",
+      "integrity": "sha512-8GfPiwzzRoWTg7OV1zva1KvrSemuMkv07MA9TTl91hfhe+wKrsrgVN4H2QSFd/U/FhiU3iWPYVgvbsOGwhyFWw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -76,13 +76,13 @@
     "ember-truth-helpers": "^2.0.0",
     "flatpickr": "^4.6.3",
     "froala-editor": "^3.0.6",
-    "is-url": "^1.2.4",
     "normalize.css": "^8.0.1",
     "query-string": "^6.8.3",
     "scroll-into-view": "^1.9.3",
     "striptags": "^3.1.1",
     "typeface-nunito": "1.1.3",
-    "typeface-nunito-sans": "0.0.72"
+    "typeface-nunito-sans": "0.0.72",
+    "validator": "^13.1.1"
   },
   "devDependencies": {
     "@ember/edition-utils": "^1.1.1",

--- a/tests/integration/components/offering-form-test.js
+++ b/tests/integration/components/offering-form-test.js
@@ -1,4 +1,4 @@
-import { module, test } from 'qunit';
+import { module, test, todo } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { render } from '@ember/test-helpers';
@@ -441,5 +441,12 @@ module('Integration | Component | offering form', function(hooks) {
     await render(hbs`<OfferingForm @close={{noop}} @showRoom={{true}} />`);
     await component.url.set('  http://example.com  ');
     assert.equal('http://example.com', component.url.value);
+  });
+
+  todo('rejects query param with trailing slash ilios/ilios#3050', async function(assert) {
+    await render(hbs`<OfferingForm @close={{noop}} @showRoom={{true}} />`);
+    assert.notOk(component.url.hasError);
+    await component.url.set('http://example.com?jayden=awesome/');
+    assert.ok(component.url.hasError);
   });
 });


### PR DESCRIPTION
This is a more maintained validation system (and we're already using it
on the frontend). Unfortunately it still doesn't catch a bad slash in the
query param so I've added a test that is allowed to fail and will
attempt a PR upstream to fix.

Refs ilios/ilios#3050
