### PR TITLE
remove timed release indicator from blanked LMs

### DIFF
--- a/addon/components/single-event-learningmaterial-list.hbs
+++ b/addon/components/single-event-learningmaterial-list.hbs
@@ -4,9 +4,6 @@
       {{#each @learningMaterials as |lm|}}
         <li class="single-event-learningmaterial-item">
           {{#if lm.isBlanked}}
-            <span class="lm-type-icon">
-              <FaIcon @icon="clock" @title={{t "general.timedRelease"}} />
-            </span>
             <div class="single-event-learningmaterial-item-title">
               {{lm.title}}
             </div>

--- a/tests/integration/components/single-event-learningmaterial-list-test.js
+++ b/tests/integration/components/single-event-learningmaterial-list-test.js
@@ -8,7 +8,7 @@ module('Integration | Component | ilios calendar single event learningmaterial l
   setupRenderingTest(hooks);
 
   test('it renders', async function(assert) {
-    assert.expect(11);
+    assert.expect(10);
 
     this.set('learningMaterials', [
       {title: 'first one', mimetype: 'application/pdf', absoluteFileUri: 'http://firstlink'},
@@ -26,7 +26,6 @@ module('Integration | Component | ilios calendar single event learningmaterial l
     assert.dom('li:nth-of-type(2) .fa-file-audio').exists('LM type icon is present.');
     assert.dom('li:nth-of-type(2) a').hasAttribute('href','http://secondlink');
     assert.dom('li:nth-of-type(3) .single-event-learningmaterial-item-title').hasText('third one');
-    assert.dom('li:nth-of-type(3) .fa-clock').exists('LM type icon is present.');
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
   });

--- a/tests/integration/components/single-event-test.js
+++ b/tests/integration/components/single-event-test.js
@@ -16,7 +16,7 @@ module('Integration | Component | ilios calendar single event', function(hooks) 
   });
 
   test('it renders', async function(assert) {
-    assert.expect(24);
+    assert.expect(23);
 
     const now = moment().hour(8).minute(0).second(0);
     const course = this.server.create('course', {
@@ -140,7 +140,6 @@ module('Integration | Component | ilios calendar single event', function(hooks) 
     assert.dom(`${firstSessionLm} .single-event-learningmaterial-item-title`).containsText(learningMaterials[0].title);
 
     const secondSessionLm = '.single-event-learningmaterial-list:nth-of-type(1) .single-event-learningmaterial-item:nth-of-type(2)';
-    assert.dom(`${secondSessionLm} .lm-type-icon .fa-clock`).exists('Timed release icon is visible');
     assert.dom(`${secondSessionLm} .single-event-learningmaterial-item-title`).containsText(learningMaterials[1].title);
 
     const sessionObjectivesSelector = '.single-event-objective-list > .single-event-objective-list:nth-of-type(1)';


### PR DESCRIPTION
no idea what we were originally thinking here, the commit logs are not clear on it.

btw, the timed release info (start/end date) is listed for un-blanked materials further down in this component's template, so removing this altogether seems like the best approach to me.

fixes #1589