### PR TITLE
show campus name of record where display name diverges.

### DIFF
--- a/addon-test-support/ilios-common/page-objects/components/detail-instructors-list.js
+++ b/addon-test-support/ilios-common/page-objects/components/detail-instructors-list.js
@@ -1,0 +1,18 @@
+import { collection, create, text } from 'ember-cli-page-object';
+import userNameInfo from './user-name-info';
+
+const definition = {
+  scope: '[data-test-instructors-list]',
+  instructors: collection('[data-test-instructor-group] li', {
+    userNameInfo
+  }),
+  instructorGroups: collection('[data-test-instructor-group]', {
+    title: text('[data-test-instructor-group-title]'),
+    members: collection('[data-test-instructor-group-members] li', {
+      userNameInfo
+    })
+  })
+};
+
+export default definition;
+export const component = create(definition);

--- a/addon-test-support/ilios-common/page-objects/components/detail-learner-list.js
+++ b/addon-test-support/ilios-common/page-objects/components/detail-learner-list.js
@@ -1,11 +1,12 @@
-import {clickable, collection, create, isPresent, text} from 'ember-cli-page-object';
+import { clickable, collection, create, isPresent } from 'ember-cli-page-object';
+import userNameInfo from './user-name-info';
 
 const definition = {
   scope: '[data-test-detail-learner-list]',
   learners: collection('li', {
-    userName: text('[data-test-user-name]'),
     remove: clickable('[data-icon="times"]'),
     isRemovable: isPresent('[data-icon="times"]'),
+    userNameInfo
   }),
 };
 

--- a/addon-test-support/ilios-common/page-objects/components/instructor-selection-manager.js
+++ b/addon-test-support/ilios-common/page-objects/components/instructor-selection-manager.js
@@ -1,12 +1,7 @@
-import {
-  clickable,
-  collection,
-  fillable,
-  hasClass,
-  text,
-} from 'ember-cli-page-object';
+import { clickable, collection, create, fillable, hasClass, text } from 'ember-cli-page-object';
+import userNameInfo from './user-name-info';
 
-export default {
+const definition = {
   scope: '[data-test-instructor-selection-manager]',
   search: fillable('.search-box input'),
   searchResults: collection('.results [data-test-result]', {
@@ -15,11 +10,17 @@ export default {
     inactive: hasClass('inactive'),
   }),
   instructors: collection('[data-test-instructors] li', {
-    remove: clickable()
+    userNameInfo,
+    remove: clickable('.remove')
   }),
   instructorGroups: collection('[data-test-instructor-group]', {
     title: text('[data-test-instructor-group-title]'),
-    members: collection('[data-test-instructor-group-members] li'),
+    members: collection('[data-test-instructor-group-members] li', {
+      userNameInfo
+    }),
     remove: clickable('[data-test-instructor-group-title]')
   }),
 };
+
+export default definition;
+export const component = create(definition);

--- a/addon-test-support/ilios-common/page-objects/components/learning-materials.js
+++ b/addon-test-support/ilios-common/page-objects/components/learning-materials.js
@@ -11,6 +11,8 @@ import {
 } from 'ember-cli-page-object';
 import meshManager from './mesh-manager';
 import search from './learningmaterial-search';
+import userNameInfo from './user-name-info';
+import newLearningMaterial from './new-learningmaterial';
 import {
   flatpickrDatePicker,
   pageObjectFillInFroalaEditor,
@@ -31,7 +33,10 @@ const definition = {
   current: collection('.detail-learningmaterials-content table tbody tr', {
     title: text('td [data-test-title]', { at: 0 }),
     type: text( 'td [data-test-lm-type-icon] title'),
-    owner: text('td', { at: 1 }),
+    owner: {
+      scope: 'td:nth-of-type(2)',
+      userNameInfo
+    },
     required: text('td', { at: 2 }),
     notes: text('td:eq(3) > span'),
     mesh: text('td', { at: 4 }),
@@ -40,22 +45,7 @@ const definition = {
     isTimedRelease: isVisible('.fa-clock'),
     details: clickable('.link', { at: 0 }),
   }),
-  newLearningMaterial: {
-    scope: '.new-learningmaterial',
-    name: fillable('input', { at: 0 }),
-    author: fillable('input', { at: 1 }),
-    url: fillable('input', { at: 2 }),
-    citation: fillable('textarea'),
-    userName: text('.owninguser'),
-    status: fillable('select', { at: 0 }),
-    role: fillable('select', { at: 1 }),
-    description: pageObjectFillInFroalaEditor('[data-test-html-editor]'),
-    rationale: fillable('[data-test-copyright-rationale]'),
-    agreement: clickable('[data-test-copyright-agreement]'),
-    save: clickable('.done'),
-    cancel: clickable('.cancel'),
-    hasAgreementValidationError: isVisible('[data-test-agreement-validation-error-message]'),
-  },
+  newLearningMaterial,
   manager: {
     scope: '.learningmaterial-manager',
     name: {

--- a/addon-test-support/ilios-common/page-objects/components/new-learningmaterial.js
+++ b/addon-test-support/ilios-common/page-objects/components/new-learningmaterial.js
@@ -1,0 +1,26 @@
+import { clickable, create, fillable, isVisible } from 'ember-cli-page-object';
+import { pageObjectFillInFroalaEditor } from 'ilios-common';
+import userNameInfo from './user-name-info';
+
+const definition = {
+  scope: '[data-test-new-learningmaterial]',
+  name: fillable('input', { at: 0 }),
+  author: fillable('input', { at: 1 }),
+  url: fillable('input', { at: 2 }),
+  citation: fillable('textarea'),
+  owningUser: {
+    scope: '[data-test-owninguser]',
+    userNameInfo
+  },
+  status: fillable('select', { at: 0 }),
+  role: fillable('select', { at: 1 }),
+  description: pageObjectFillInFroalaEditor('[data-test-html-editor]'),
+  rationale: fillable('[data-test-copyright-rationale]'),
+  agreement: clickable('[data-test-copyright-agreement]'),
+  save: clickable('.done'),
+  cancel: clickable('.cancel'),
+  hasAgreementValidationError: isVisible('[data-test-agreement-validation-error-message]'),
+};
+
+export default definition;
+export const component = create(definition);

--- a/addon-test-support/ilios-common/page-objects/components/user-name-info.js
+++ b/addon-test-support/ilios-common/page-objects/components/user-name-info.js
@@ -1,0 +1,19 @@
+import {
+  create,
+  isVisible,
+  text,
+  triggerable
+} from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-user-name-info]',
+  fullName: text('[data-test-fullname]'),
+  hasAdditionalInfo: isVisible('[data-test-info]'),
+  expandTooltip: triggerable('mouseover', '[data-test-info] .info'),
+  closeTooltip: triggerable('mouseout', '[data-test-info] .info'),
+  tooltipContents: text('.ilios-tooltip', { resetScope: true }),
+  isTooltipVisible: isVisible('.ilios-tooltip', { resetScope: true }),
+};
+
+export default definition;
+export const component = create(definition);

--- a/addon-test-support/ilios-common/page-objects/session.js
+++ b/addon-test-support/ilios-common/page-objects/session.js
@@ -22,6 +22,7 @@ import leadershipCollapsed from './components/leadership-collapsed';
 import leadershipExpanded from './components/session-leadership-expanded';
 import postrequisiteEditor from './components/session/postrequisite-editor';
 import detailLearnersAndLearnerGroups from './components/detail-learners-and-learner-groups';
+import userNameInfo from './components/user-name-info';
 
 export default create({
   scope: '[data-test-session-details]',
@@ -117,10 +118,8 @@ export default create({
     },
     lastUpdated: text('.last-update'),
   },
-
   leadershipCollapsed,
   leadershipExpanded,
-
   objectives,
   learningMaterials,
   meshTerms,
@@ -138,7 +137,7 @@ export default create({
     currentGroups: collection('[data-test-instructor-group]', {
       title: text('[data-test-instructor-group-title]'),
       members: collection('[data-test-instructor-group-members] li', {
-        text: text(),
+        userNameInfo
       }),
     }),
     currentInstructors: collection('[data-test-instructors] li', {
@@ -170,7 +169,7 @@ export default create({
         location: text('[data-test-location]'),
         url: property('href', '[data-test-url] a'),
         instructors: collection('.offering-manager-instructors [data-test-instructor]', {
-          title: text()
+          userNameInfo
         }),
         edit: clickable('.edit'),
         remove: clickable('.remove'),

--- a/addon/components/detail-instructors-list.hbs
+++ b/addon/components/detail-instructors-list.hbs
@@ -1,5 +1,6 @@
 <div
   class="detail-instructors-list"
+  data-test-instructors-list
 >
   {{#if @instructors.length}}
     <h4>
@@ -9,7 +10,7 @@
     <ul class="instructors-list" data-test-instructors>
       {{#each (sort-by "fullName" @instructors) as |user|}}
         <li>
-          {{user.fullName}}
+          <UserNameInfo @user={{user}} />
         </li>
       {{/each}}
     </ul>
@@ -29,9 +30,9 @@
           </span>
           <br>
           <ul class="instructorgroup-members-list" data-test-instructor-group-members>
-            {{#each (sort-by "fullName" (await instructorGroup.users)) as |instructorGroupMember|}}
+            {{#each (sort-by "fullName" (await instructorGroup.users)) as |user|}}
               <li>
-                {{instructorGroupMember.fullName}}
+                <UserNameInfo @user={{user}} />
               </li>
             {{/each}}
           </ul>

--- a/addon/components/detail-learner-list.hbs
+++ b/addon/components/detail-learner-list.hbs
@@ -2,12 +2,12 @@
   {{#each (sort-by "fullName" @learners) as |user|}}
     {{#if @isManaging}}
       <li role="button" {{on "click" (fn @remove user)}}>
-        <span data-test-user-name>{{user.fullName}}</span>
+        <UserNameInfo @user={{user}} />
         <FaIcon @icon="times" class="remove" />
       </li>
     {{else}}
       <li role="button">
-        <span data-test-user-name>{{user.fullName}}</span>
+        <UserNameInfo @user={{user}} />
       </li>
     {{/if}}
   {{/each}}

--- a/addon/components/detail-learning-materials.hbs
+++ b/addon/components/detail-learning-materials.hbs
@@ -114,7 +114,7 @@
                 </span>
               </td>
               <td class="text-center" colspan="2">
-                {{lmProxy.learningMaterial.owningUser.fullName}}
+                <UserNameInfo @user={{get (await lmProxy.learningMaterial) "owningUser"}} />
               </td>
               <td class="text-center" colspan="2">
                 {{#if lmProxy.required}}

--- a/addon/components/instructor-selection-manager.hbs
+++ b/addon/components/instructor-selection-manager.hbs
@@ -7,7 +7,7 @@
     <ul class="instructors-list" data-test-instructors>
       {{#each (sort-by "fullName" (await @instructors)) as |user|}}
         <li role="button" {{on "click" (fn @removeInstructor user)}}>
-          {{user.fullName}}
+          <UserNameInfo @user={{user}} />
           <FaIcon @icon="times" class="remove" />
         </li>
       {{/each}}
@@ -29,9 +29,9 @@
           </span>
           <br>
           <ul class="instructorgroup-members-list" data-test-instructor-group-members>
-            {{#each (sort-by "fullName" (await instructorGroup.users)) as |instructorGroupMember|}}
+            {{#each (sort-by "fullName" (await instructorGroup.users)) as |user|}}
               <li>
-                {{instructorGroupMember.fullName}}
+                <UserNameInfo @user={{user}} />
               </li>
             {{/each}}
           </ul>

--- a/addon/components/leadership-list.hbs
+++ b/addon/components/leadership-list.hbs
@@ -34,9 +34,7 @@
                         class="error"
                       />
                     {{/unless}}
-                    <span data-test-name>
-                      {{user.fullName}}
-                    </span>
+                    <UserNameInfo @user={{user}} />
                   </li>
                 {{else}}
                   <li>
@@ -63,9 +61,7 @@
                         class="error"
                       />
                     {{/unless}}
-                    <span data-test-name>
-                      {{user.fullName}}
-                    </span>
+                    <UserNameInfo @user={{user}} />
                   </li>
                 {{else}}
                   <li>
@@ -92,9 +88,7 @@
                         class="error"
                       />
                     {{/unless}}
-                    <span data-test-name>
-                      {{user.fullName}}
-                    </span>
+                    <UserNameInfo @user={{user}} />
                   </li>
                 {{else}}
                   <li>

--- a/addon/components/leadership-manager.hbs
+++ b/addon/components/leadership-manager.hbs
@@ -38,9 +38,7 @@
                       class="disabled-user"
                     />
                   {{/unless}}
-                  <span data-test-name>
-                    {{user.fullName}}
-                  </span>
+                  <UserNameInfo @user={{user}} />
                 </li>
               {{else}}
                 {{t "general.none"}}
@@ -65,9 +63,7 @@
                       class="disabled-user"
                     />
                   {{/unless}}
-                  <span data-test-name>
-                    {{user.fullName}}
-                  </span>
+                  <UserNameInfo @user={{user}} />
                 </li>
               {{else}}
                 {{t "general.none"}}
@@ -92,9 +88,7 @@
                       class="disabled-user"
                     />
                   {{/unless}}
-                  <span data-test-name>
-                    {{user.fullName}}
-                  </span>
+                  <UserNameInfo @user={{user}} />
                 </li>
               {{else}}
                 {{t "general.none"}}

--- a/addon/components/learningmaterial-manager.hbs
+++ b/addon/components/learningmaterial-manager.hbs
@@ -92,7 +92,7 @@
         {{t "general.owner"}}:
       </label>
       <span class="owninguser">
-        {{this.owningUserName}}
+        <UserNameInfo @user={{this.owningUser}} />
       </span>
     </div>
     <div class="item">

--- a/addon/components/learningmaterial-manager.js
+++ b/addon/components/learningmaterial-manager.js
@@ -17,7 +17,7 @@ export default class LearningMaterialManagerComponent extends Component {
   @AfterDate('startDate', { granularity: 'minute'}) @tracked endDate;
 
   @tracked type;
-  @tracked owningUserName;
+  @tracked owningUser;
   @tracked originalAuthor;
   @tracked description;
   @tracked copyrightPermission;
@@ -36,6 +36,7 @@ export default class LearningMaterialManagerComponent extends Component {
   @tracked userRoleTitle;
   @tracked publicNotes;
   @tracked required;
+
 
   get isFile() {
     return this.type === 'file';
@@ -150,8 +151,7 @@ export default class LearningMaterialManagerComponent extends Component {
 
     const status = yield parentMaterial.get('status');
     this.statusId = status.id;
-    const owningUser = yield parentMaterial.get('owningUser');
-    this.owningUserName = owningUser.fullName;
+    this.owningUser = yield parentMaterial.get('owningUser');
     const userRole = yield parentMaterial.get('userRole');
     this.userRoleTitle = userRole.title;
   }

--- a/addon/components/new-learningmaterial.hbs
+++ b/addon/components/new-learningmaterial.hbs
@@ -1,4 +1,4 @@
-<div class="new-learningmaterial">
+<div class="new-learningmaterial" data-test-new-learningmaterial>
   <div class="item">
     <label>
       {{t "general.displayName"}}:
@@ -34,12 +34,12 @@
       </select>
     </span>
   </div>
-  <div class="item">
+  <div class="item" data-test-owninguser>
     <label>
       {{t "general.owner"}}:
     </label>
     <span class="owninguser">
-      {{get (await this.currentUser.model) "fullName"}}
+      <UserNameInfo @user={{await this.currentUser.model}} />
     </span>
   </div>
   <div class="item">

--- a/addon/components/offering-manager.hbs
+++ b/addon/components/offering-manager.hbs
@@ -55,9 +55,9 @@
     </div>
     <div class="offering-manager-instructors">
       <ul>
-        {{#each (await @offering.allInstructors) as |instructor|}}
+        {{#each (await @offering.allInstructors) as |user|}}
           <li data-test-instructor>
-            {{instructor.fullName}}
+            <UserNameInfo @user={{user}} />
           </li>
         {{else}}
           <li>

--- a/addon/components/offering-manager.js
+++ b/addon/components/offering-manager.js
@@ -33,5 +33,4 @@ export default class OfferingManagerComponent extends Component {
   setLearnerGroupElement(element, [id]) {
     set(this, `learnerGroupElement${id}`, element);
   }
-
 }

--- a/addon/components/user-name-info.hbs
+++ b/addon/components/user-name-info.hbs
@@ -1,0 +1,26 @@
+<span
+  class="user-name-info"
+  data-test-user-name-info
+  {{did-insert this.load (await @user)}}
+  {{did-update this.load (await @user)}}
+>
+  <span data-test-fullname>{{this.fullName}}</span>
+  {{#if this.hasDifferentCampusNameOfRecord}}
+    <span
+      data-test-info
+      {{did-insert (set this.theElement)}}
+      {{mouse-hover-toggle (fn this.toggleUsernameInfoHover)}}
+    >
+      <FaIcon
+        @icon="info-circle"
+        @title={{t "general.campusNameOfRecord"}}
+        class="info"
+      />
+      {{#if this.isHoveringOverUsernameInfo}}
+        <IliosTooltip @target={{this.theElement}}>
+          {{this.campusNameOfRecord}}
+        </IliosTooltip>
+      {{/if}}
+    </span>
+  {{/if}}
+</span>

--- a/addon/components/user-name-info.js
+++ b/addon/components/user-name-info.js
@@ -1,0 +1,25 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class UserNameInfoComponent extends Component {
+  @tracked isHoveringOverUsernameInfo = false;
+  @tracked fullName;
+  @tracked campusNameOfRecord;
+  @tracked hasDifferentCampusNameOfRecord = false;
+
+  @action
+  load(element, [user]){
+    if (! user) {
+      return;
+    }
+    this.fullName = user.get('fullName');
+    this.hasDifferentCampusNameOfRecord = user.get('hasDifferentDisplayName');
+    this.campusNameOfRecord = user.get('fullNameFromFirstMiddleLastName');
+  }
+
+  @action
+  toggleUsernameInfoHover(isHovering) {
+    this.isHoveringOverUsernameInfo = isHovering;
+  }
+}

--- a/addon/models/user.js
+++ b/addon/models/user.js
@@ -164,16 +164,16 @@ export default Model.extend({
     }
   ),
 
-  fullName: computed('firstName', 'middleName', 'lastName', 'displayName', function() {
-    if (this.displayName) {
-      return this.displayName;
-    }
+  fullName: computed('fullNameFromFirstMiddleInitialLastName', 'displayName', function() {
+    return this.displayName ? this.displayName : this.get('fullNameFromFirstMiddleInitialLastName');
+  }),
 
+  fullNameFromFirstMiddleInitialLastName: computed('firstName', 'middleName', 'lastName', function() {
     if (!this.firstName || !this.lastName) {
       return '';
     }
 
-    const middleInitial = this.middleName?this.middleName.charAt(0):false;
+    const middleInitial = this.middleName ? this.middleName.charAt(0) : false;
 
     if (middleInitial) {
       return `${this.firstName} ${middleInitial}. ${this.lastName}`;
@@ -181,6 +181,43 @@ export default Model.extend({
       return `${this.firstName} ${this.lastName}`;
     }
   }),
+
+  fullNameFromFirstMiddleLastName: computed('firstName', 'middleName', 'lastName', function() {
+    if (!this.firstName || !this.lastName) {
+      return '';
+    }
+
+    if (this.middleName) {
+      return `${this.firstName} ${this.middleName} ${this.lastName}`;
+    } else {
+      return `${this.firstName} ${this.lastName}`;
+    }
+  }),
+
+  fullNameFromFirstLastName: computed('firstName', 'lastName', function() {
+    if (!this.firstName || !this.lastName) {
+      return '';
+    }
+    return `${this.firstName} ${this.lastName}`;
+  }),
+
+  hasDifferentDisplayName: computed(
+    'displayName',
+    'fullNameFromFirstMiddleInitialLastName',
+    'fullNameFromFirstMiddleLastName',
+    'fullNameFromFirstLastName',
+    function() {
+      const displayName = this.displayName?.trim().toLowerCase();
+      // no display name? nothing to compare then.
+      if (! displayName) {
+        return false;
+      }
+      // compare the display name to 'first last', then to 'first middle last' and 'first m. last' as a fallbacks.
+      return !(displayName === this.get('fullNameFromFirstLastName').trim().toLowerCase()
+        || displayName === this.get('fullNameFromFirstMiddleLastName').trim().toLowerCase()
+        || displayName === this.get('fullNameFromFirstMiddleInitialLastName').trim().toLowerCase());
+    }
+  ),
 
   /**
    * A list of all courses that this user is instructing in.

--- a/app/components/user-name-info.js
+++ b/app/components/user-name-info.js
@@ -1,0 +1,1 @@
+export { default } from 'ilios-common/components/user-name-info';

--- a/app/styles/ilios-common/mixins/ilios-list.scss
+++ b/app/styles/ilios-common/mixins/ilios-list.scss
@@ -107,7 +107,7 @@
     cursor: pointer;
     display: flex;
 
-    .remove {
+    .remove, .info {
       margin-left: .5em;
     }
   }

--- a/tests/acceptance/course/learningmaterials-test.js
+++ b/tests/acceptance/course/learningmaterials-test.js
@@ -18,6 +18,7 @@ module('Acceptance | Course - Learning Materials', function(hooks) {
   hooks.beforeEach(async function () {
     this.school = this.server.create('school');
     this.user = await setupAuthentication({ school: this.school });
+    this.user2 = this.server.create('user', { displayName: 'Clem Chowder' });
     this.server.create('academicYear');
     this.server.create('learningMaterialStatus', {
       learningMaterialIds: [1]
@@ -44,7 +45,7 @@ module('Acceptance | Course - Learning Materials', function(hooks) {
       });
       this.server.create('learningMaterial', {
         originalAuthor: 'Jennifer Johnson',
-        owningUserId: this.user.id,
+        owningUserId: this.user2.id,
         statusId: 1,
         userRoleId: 1,
         copyrightPermission: false,
@@ -115,7 +116,8 @@ module('Acceptance | Course - Learning Materials', function(hooks) {
       assert.equal(page.learningMaterials.current.length, 4);
 
       assert.equal(page.learningMaterials.current[0].title, 'learning material 0');
-      assert.equal(page.learningMaterials.current[0].owner, '0 guy M. Mc0son');
+      assert.equal(page.learningMaterials.current[0].owner.userNameInfo.fullName, '0 guy M. Mc0son');
+      assert.notOk(page.learningMaterials.current[0].owner.userNameInfo.hasAdditionalInfo);
       assert.equal(page.learningMaterials.current[0].required, 'No');
       assert.equal(page.learningMaterials.current[0].notes, 'No');
       assert.notOk(page.learningMaterials.current[0].isNotePublic);
@@ -123,7 +125,13 @@ module('Acceptance | Course - Learning Materials', function(hooks) {
       assert.equal(page.learningMaterials.current[0].status, 'status 0');
 
       assert.equal(page.learningMaterials.current[1].title, 'learning material 1');
-      assert.equal(page.learningMaterials.current[1].owner, '0 guy M. Mc0son');
+      assert.equal(page.learningMaterials.current[1].owner.userNameInfo.fullName, 'Clem Chowder');
+      assert.ok(page.learningMaterials.current[1].owner.userNameInfo.hasAdditionalInfo);
+      assert.notOk(page.learningMaterials.current[1].owner.userNameInfo.isTooltipVisible);
+      await page.learningMaterials.current[1].owner.userNameInfo.expandTooltip();
+      assert.equal(page.learningMaterials.current[1].owner.userNameInfo.tooltipContents, '1 guy M, Mc1son');
+      await page.learningMaterials.current[1].owner.userNameInfo.closeTooltip();
+      assert.notOk(page.learningMaterials.current[1].owner.userNameInfo.isTooltipVisible);
       assert.equal(page.learningMaterials.current[1].required, 'No');
       assert.equal(page.learningMaterials.current[1].notes, 'No');
       assert.notOk(page.learningMaterials.current[1].isNotePublic);
@@ -132,7 +140,8 @@ module('Acceptance | Course - Learning Materials', function(hooks) {
       assert.equal(page.learningMaterials.current[1].status, 'status 0');
 
       assert.equal(page.learningMaterials.current[2].title, 'learning material 2');
-      assert.equal(page.learningMaterials.current[2].owner, '0 guy M. Mc0son');
+      assert.equal(page.learningMaterials.current[2].owner.userNameInfo.fullName, '0 guy M. Mc0son');
+      assert.notOk(page.learningMaterials.current[2].owner.userNameInfo.hasAdditionalInfo);
       assert.equal(page.learningMaterials.current[2].required, 'Yes');
       assert.equal(page.learningMaterials.current[2].notes, 'No');
       assert.notOk(page.learningMaterials.current[2].isNotePublic);
@@ -141,7 +150,8 @@ module('Acceptance | Course - Learning Materials', function(hooks) {
       assert.equal(page.learningMaterials.current[2].status, 'status 0');
 
       assert.equal(page.learningMaterials.current[3].title, 'learning material 3');
-      assert.equal(page.learningMaterials.current[3].owner, '0 guy M. Mc0son');
+      assert.equal(page.learningMaterials.current[3].owner.userNameInfo.fullName, '0 guy M. Mc0son');
+      assert.notOk(page.learningMaterials.current[3].owner.userNameInfo.hasAdditionalInfo);
       assert.equal(page.learningMaterials.current[3].required, 'Yes');
       assert.equal(page.learningMaterials.current[3].notes, 'Yes');
       assert.ok(page.learningMaterials.current[3].isNotePublic);
@@ -165,7 +175,7 @@ module('Acceptance | Course - Learning Materials', function(hooks) {
       assert.notOk(page.learningMaterials.search.isVisible, 'search box is hidden while new group are being added');
 
       await page.learningMaterials.newLearningMaterial.name(testTitle);
-      assert.equal(page.learningMaterials.newLearningMaterial.userName, '0 guy M. Mc0son');
+      assert.equal(page.learningMaterials.newLearningMaterial.owningUser.userNameInfo.fullName, '0 guy M. Mc0son');
       await page.learningMaterials.newLearningMaterial.author(testAuthor);
       await page.learningMaterials.newLearningMaterial.url(testUrl);
       await page.learningMaterials.newLearningMaterial.status('2');
@@ -195,7 +205,7 @@ module('Acceptance | Course - Learning Materials', function(hooks) {
       assert.notOk(page.learningMaterials.search.isVisible, 'search box is hidden while new group are being added');
 
       await page.learningMaterials.newLearningMaterial.name(testTitle);
-      assert.equal(page.learningMaterials.newLearningMaterial.userName, '0 guy M. Mc0son');
+      assert.equal(page.learningMaterials.newLearningMaterial.owningUser.userNameInfo.fullName, '0 guy M. Mc0son');
       await page.learningMaterials.newLearningMaterial.author(testAuthor);
       await page.learningMaterials.newLearningMaterial.citation(testCitation);
       await page.learningMaterials.newLearningMaterial.status('2');
@@ -340,7 +350,7 @@ module('Acceptance | Course - Learning Materials', function(hooks) {
       await page.learningMaterials.manager.save();
 
       assert.equal(page.learningMaterials.current[0].title, 'learning material 0');
-      assert.equal(page.learningMaterials.current[0].owner, '0 guy M. Mc0son');
+      assert.equal(page.learningMaterials.current[0].owner.userNameInfo.fullName, '0 guy M. Mc0son');
       assert.equal(page.learningMaterials.current[0].required, 'Yes');
       assert.notOk(page.learningMaterials.current[0].isNotePublic);
       assert.equal(page.learningMaterials.current[0].notes, 'Yes');
@@ -383,7 +393,7 @@ module('Acceptance | Course - Learning Materials', function(hooks) {
       await page.learningMaterials.manager.cancel();
 
       assert.equal(page.learningMaterials.current[0].title, 'learning material 0');
-      assert.equal(page.learningMaterials.current[0].owner, '0 guy M. Mc0son');
+      assert.equal(page.learningMaterials.current[0].owner.userNameInfo.fullName, '0 guy M. Mc0son');
       assert.equal(page.learningMaterials.current[0].required, 'No');
       assert.equal(page.learningMaterials.current[0].notes, 'No');
       assert.notOk(page.learningMaterials.current[0].isNotePublic);
@@ -678,7 +688,8 @@ module('Acceptance | Course - Learning Materials', function(hooks) {
       assert.equal(page.learningMaterials.current.length, 1);
 
       assert.equal(page.learningMaterials.current[0].title, 'learning material 0');
-      assert.equal(page.learningMaterials.current[0].owner, '0 guy M. Mc0son');
+      assert.equal(page.learningMaterials.current[0].owner.userNameInfo.fullName, '0 guy M. Mc0son');
+      assert.notOk(page.learningMaterials.current[0].owner.userNameInfo.hasAdditionalInfo);
       assert.equal(page.learningMaterials.current[0].required, 'No');
       assert.equal(page.learningMaterials.current[0].notes, 'No');
       assert.notOk(page.learningMaterials.current[0].isNotePublic);

--- a/tests/acceptance/course/session/learner-groups-test.js
+++ b/tests/acceptance/course/session/learner-groups-test.js
@@ -60,8 +60,8 @@ module('Acceptance | Session - Learner Groups', function(hooks) {
 
       const { detailLearnerList, detailLearnergroupsList } = page.detailLearnersAndLearnerGroups;
       assert.equal(detailLearnerList.learners.length, 2);
-      assert.equal(detailLearnerList.learners[0].userName, '1 guy M. Mc1son');
-      assert.equal(detailLearnerList.learners[1].userName, '2 guy M. Mc2son');
+      assert.equal(detailLearnerList.learners[0].userNameInfo.fullName, '1 guy M. Mc1son');
+      assert.equal(detailLearnerList.learners[1].userNameInfo.fullName, '2 guy M. Mc2son');
       assert.equal(detailLearnergroupsList.trees.length, 3);
       assert.equal(detailLearnergroupsList.trees[0].title, 'learner group 0 (program 0 cohort 0)');
       assert.equal(detailLearnergroupsList.trees[1].title, 'learner group 1 (program 0 cohort 0)');
@@ -90,8 +90,14 @@ module('Acceptance | Session - Learner Groups', function(hooks) {
 
       const { learnerSelectionManager, learnergroupSelectionManager } = page.detailLearnersAndLearnerGroups;
       assert.equal(learnerSelectionManager.selectedLearners.detailLearnerList.learners.length, 2);
-      assert.equal(learnerSelectionManager.selectedLearners.detailLearnerList.learners[0].userName, '1 guy M. Mc1son');
-      assert.equal(learnerSelectionManager.selectedLearners.detailLearnerList.learners[1].userName, '2 guy M. Mc2son');
+      assert.equal(
+        learnerSelectionManager.selectedLearners.detailLearnerList.learners[0].userNameInfo.fullName,
+        '1 guy M. Mc1son'
+      );
+      assert.equal(
+        learnerSelectionManager.selectedLearners.detailLearnerList.learners[1].userNameInfo.fullName,
+        '2 guy M. Mc2son'
+      );
       assert.equal(learnergroupSelectionManager.selectedGroups.list.trees.length, 3);
       assert.equal(
         learnergroupSelectionManager.selectedGroups.list.trees[0].title,
@@ -537,9 +543,9 @@ module('Acceptance | Session - Learner Groups', function(hooks) {
       await page.detailLearnersAndLearnerGroups.save();
 
       assert.equal(page.detailLearnersAndLearnerGroups.detailLearnerList.learners.length, 3);
-      assert.equal(page.detailLearnersAndLearnerGroups.detailLearnerList.learners[0].userName, '1 guy M. Mc1son');
-      assert.equal(page.detailLearnersAndLearnerGroups.detailLearnerList.learners[1].userName, '2 guy M. Mc2son');
-      assert.equal(page.detailLearnersAndLearnerGroups.detailLearnerList.learners[2].userName, 'joe u. shmoe');
+      assert.equal(page.detailLearnersAndLearnerGroups.detailLearnerList.learners[0].userNameInfo.fullName, '1 guy M. Mc1son');
+      assert.equal(page.detailLearnersAndLearnerGroups.detailLearnerList.learners[1].userNameInfo.fullName, '2 guy M. Mc2son');
+      assert.equal(page.detailLearnersAndLearnerGroups.detailLearnerList.learners[2].userNameInfo.fullName, 'joe u. shmoe');
 
     });
 

--- a/tests/acceptance/course/session/learningmaterials-test.js
+++ b/tests/acceptance/course/session/learningmaterials-test.js
@@ -17,6 +17,7 @@ module('Acceptance | Session - Learning Materials', function(hooks) {
   hooks.beforeEach(async function () {
     this.school = this.server.create('school');
     this.user = await setupAuthentication({ school: this.school });
+    this.user2 = this.server.create('user', { displayName: 'Clem Chowder' });
     this.server.create('academicYear');
     this.server.create('learningMaterialStatus', {
       learningMaterialIds: [1]
@@ -39,7 +40,7 @@ module('Acceptance | Session - Learning Materials', function(hooks) {
       });
       this.server.create('learningMaterial', {
         originalAuthor: 'Jennifer Johnson',
-        owningUserId: this.user.id,
+        owningUserId: this.user2.id,
         statusId: 1,
         userRoleId: 1,
         copyrightPermission: false,
@@ -116,7 +117,8 @@ module('Acceptance | Session - Learning Materials', function(hooks) {
       assert.equal(page.learningMaterials.current.length, 4);
 
       assert.equal(page.learningMaterials.current[0].title, 'learning material 0');
-      assert.equal(page.learningMaterials.current[0].owner, '0 guy M. Mc0son');
+      assert.equal(page.learningMaterials.current[0].owner.userNameInfo.fullName, '0 guy M. Mc0son');
+      assert.notOk(page.learningMaterials.current[0].owner.userNameInfo.hasAdditionalInfo);
       assert.equal(page.learningMaterials.current[0].required, 'No');
       assert.equal(page.learningMaterials.current[0].notes, 'No');
       assert.notOk(page.learningMaterials.current[0].isNotePublic);
@@ -124,7 +126,13 @@ module('Acceptance | Session - Learning Materials', function(hooks) {
       assert.equal(page.learningMaterials.current[0].status, 'status 0');
 
       assert.equal(page.learningMaterials.current[1].title, 'learning material 1');
-      assert.equal(page.learningMaterials.current[1].owner, '0 guy M. Mc0son');
+      assert.equal(page.learningMaterials.current[1].owner.userNameInfo.fullName, 'Clem Chowder');
+      assert.ok(page.learningMaterials.current[1].owner.userNameInfo.hasAdditionalInfo);
+      assert.notOk(page.learningMaterials.current[1].owner.userNameInfo.isTooltipVisible);
+      await page.learningMaterials.current[1].owner.userNameInfo.expandTooltip();
+      assert.equal(page.learningMaterials.current[1].owner.userNameInfo.tooltipContents, '1 guy M, Mc1son');
+      await page.learningMaterials.current[1].owner.userNameInfo.closeTooltip();
+      assert.notOk(page.learningMaterials.current[1].owner.userNameInfo.isTooltipVisible);
       assert.equal(page.learningMaterials.current[1].required, 'No');
       assert.equal(page.learningMaterials.current[1].notes, 'No');
       assert.notOk(page.learningMaterials.current[1].isNotePublic);
@@ -133,7 +141,8 @@ module('Acceptance | Session - Learning Materials', function(hooks) {
       assert.equal(page.learningMaterials.current[1].status, 'status 0');
 
       assert.equal(page.learningMaterials.current[2].title, 'learning material 2');
-      assert.equal(page.learningMaterials.current[2].owner, '0 guy M. Mc0son');
+      assert.equal(page.learningMaterials.current[2].owner.userNameInfo.fullName, '0 guy M. Mc0son');
+      assert.notOk(page.learningMaterials.current[2].owner.userNameInfo.hasAdditionalInfo);
       assert.equal(page.learningMaterials.current[2].required, 'Yes');
       assert.equal(page.learningMaterials.current[2].notes, 'No');
       assert.notOk(page.learningMaterials.current[2].isNotePublic);
@@ -142,7 +151,8 @@ module('Acceptance | Session - Learning Materials', function(hooks) {
       assert.equal(page.learningMaterials.current[2].status, 'status 0');
 
       assert.equal(page.learningMaterials.current[3].title, 'learning material 3');
-      assert.equal(page.learningMaterials.current[3].owner, '0 guy M. Mc0son');
+      assert.equal(page.learningMaterials.current[3].owner.userNameInfo.fullName, '0 guy M. Mc0son');
+      assert.notOk(page.learningMaterials.current[3].owner.userNameInfo.hasAdditionalInfo);
       assert.equal(page.learningMaterials.current[3].required, 'Yes');
       assert.equal(page.learningMaterials.current[3].notes, 'Yes');
       assert.ok(page.learningMaterials.current[3].isNotePublic);
@@ -166,7 +176,7 @@ module('Acceptance | Session - Learning Materials', function(hooks) {
       assert.notOk(page.learningMaterials.search.isVisible, 'search box is hidden while new group are being added');
 
       await page.learningMaterials.newLearningMaterial.name(testTitle);
-      assert.equal(page.learningMaterials.newLearningMaterial.userName, '0 guy M. Mc0son');
+      assert.equal(page.learningMaterials.newLearningMaterial.owningUser.userNameInfo.fullName, '0 guy M. Mc0son');
       await page.learningMaterials.newLearningMaterial.author(testAuthor);
       await page.learningMaterials.newLearningMaterial.url(testUrl);
       await page.learningMaterials.newLearningMaterial.status('2');
@@ -196,7 +206,7 @@ module('Acceptance | Session - Learning Materials', function(hooks) {
       assert.notOk(page.learningMaterials.search.isVisible, 'search box is hidden while new group are being added');
 
       await page.learningMaterials.newLearningMaterial.name(testTitle);
-      assert.equal(page.learningMaterials.newLearningMaterial.userName, '0 guy M. Mc0son');
+      assert.equal(page.learningMaterials.newLearningMaterial.owningUser.userNameInfo.fullName, '0 guy M. Mc0son');
       await page.learningMaterials.newLearningMaterial.author(testAuthor);
       await page.learningMaterials.newLearningMaterial.citation(testCitation);
       await page.learningMaterials.newLearningMaterial.status('2');
@@ -337,7 +347,7 @@ module('Acceptance | Session - Learning Materials', function(hooks) {
       await page.learningMaterials.manager.save();
 
       assert.equal(page.learningMaterials.current[0].title, 'learning material 0');
-      assert.equal(page.learningMaterials.current[0].owner, '0 guy M. Mc0son');
+      assert.equal(page.learningMaterials.current[0].owner.userNameInfo.fullName, '0 guy M. Mc0son');
       assert.equal(page.learningMaterials.current[0].required, 'Yes');
       assert.notOk(page.learningMaterials.current[0].isNotePublic);
       assert.equal(page.learningMaterials.current[0].notes, 'Yes');
@@ -381,7 +391,7 @@ module('Acceptance | Session - Learning Materials', function(hooks) {
       await page.learningMaterials.manager.cancel();
 
       assert.equal(page.learningMaterials.current[0].title, 'learning material 0');
-      assert.equal(page.learningMaterials.current[0].owner, '0 guy M. Mc0son');
+      assert.equal(page.learningMaterials.current[0].owner.userNameInfo.fullName, '0 guy M. Mc0son');
       assert.equal(page.learningMaterials.current[0].required, 'No');
       assert.equal(page.learningMaterials.current[0].notes, 'No');
       assert.notOk(page.learningMaterials.current[0].isNotePublic);
@@ -674,7 +684,8 @@ module('Acceptance | Session - Learning Materials', function(hooks) {
       assert.equal(page.learningMaterials.current.length, 1);
 
       assert.equal(page.learningMaterials.current[0].title, 'learning material 0');
-      assert.equal(page.learningMaterials.current[0].owner, '0 guy M. Mc0son');
+      assert.equal(page.learningMaterials.current[0].owner.userNameInfo.fullName, '0 guy M. Mc0son');
+      assert.notOk(page.learningMaterials.current[0].owner.userNameInfo.hasAdditionalInfo);
       assert.equal(page.learningMaterials.current[0].required, 'No');
       assert.equal(page.learningMaterials.current[0].notes, 'No');
       assert.notOk(page.learningMaterials.current[0].isNotePublic);

--- a/tests/acceptance/course/session/offerings-test.js
+++ b/tests/acceptance/course/session/offerings-test.js
@@ -1,8 +1,5 @@
 import moment from 'moment';
-import {
-  module,
-  test
-} from 'qunit';
+import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -131,31 +128,31 @@ module('Acceptance | Session - Offerings', function(hooks) {
     assert.equal(blocks[0].offerings[0].location, this.offering1.room);
     assert.equal(blocks[0].offerings[0].url, this.offering1.url);
     assert.equal(blocks[0].offerings[0].instructors.length, 8);
-    assert.equal(blocks[0].offerings[0].instructors[0].title, '1 guy M. Mc1son');
-    assert.equal(blocks[0].offerings[0].instructors[1].title, '2 guy M. Mc2son');
-    assert.equal(blocks[0].offerings[0].instructors[2].title, '3 guy M. Mc3son');
-    assert.equal(blocks[0].offerings[0].instructors[3].title, '4 guy M. Mc4son');
-    assert.equal(blocks[0].offerings[0].instructors[4].title, '5 guy M. Mc5son');
-    assert.equal(blocks[0].offerings[0].instructors[5].title, '6 guy M. Mc6son');
-    assert.equal(blocks[0].offerings[0].instructors[6].title, '7 guy M. Mc7son');
-    assert.equal(blocks[0].offerings[0].instructors[7].title, '8 guy M. Mc8son');
+    assert.equal(blocks[0].offerings[0].instructors[0].userNameInfo.fullName, '1 guy M. Mc1son');
+    assert.equal(blocks[0].offerings[0].instructors[1].userNameInfo.fullName, '2 guy M. Mc2son');
+    assert.equal(blocks[0].offerings[0].instructors[2].userNameInfo.fullName, '3 guy M. Mc3son');
+    assert.equal(blocks[0].offerings[0].instructors[3].userNameInfo.fullName, '4 guy M. Mc4son');
+    assert.equal(blocks[0].offerings[0].instructors[4].userNameInfo.fullName, '5 guy M. Mc5son');
+    assert.equal(blocks[0].offerings[0].instructors[5].userNameInfo.fullName, '6 guy M. Mc6son');
+    assert.equal(blocks[0].offerings[0].instructors[6].userNameInfo.fullName, '7 guy M. Mc7son');
+    assert.equal(blocks[0].offerings[0].instructors[7].userNameInfo.fullName, '8 guy M. Mc8son');
 
     assert.equal(blocks[1].offerings[0].learnerGroups.length, 1);
     assert.equal(blocks[1].offerings[0].learnerGroups[0].title, 'learner group 1');
     assert.equal(blocks[1].offerings[0].location, this.offering2.room);
     assert.equal(blocks[1].offerings[0].instructors.length, 4);
-    assert.equal(blocks[1].offerings[0].instructors[0].title, '3 guy M. Mc3son');
-    assert.equal(blocks[1].offerings[0].instructors[1].title, '4 guy M. Mc4son');
-    assert.equal(blocks[1].offerings[0].instructors[2].title, '7 guy M. Mc7son');
-    assert.equal(blocks[1].offerings[0].instructors[3].title, '8 guy M. Mc8son');
+    assert.equal(blocks[1].offerings[0].instructors[0].userNameInfo.fullName, '3 guy M. Mc3son');
+    assert.equal(blocks[1].offerings[0].instructors[1].userNameInfo.fullName, '4 guy M. Mc4son');
+    assert.equal(blocks[1].offerings[0].instructors[2].userNameInfo.fullName, '7 guy M. Mc7son');
+    assert.equal(blocks[1].offerings[0].instructors[3].userNameInfo.fullName, '8 guy M. Mc8son');
 
     assert.equal(blocks[2].offerings[0].learnerGroups.length, 1);
     assert.equal(blocks[2].offerings[0].learnerGroups[0].title, 'learner group 1');
     assert.equal(blocks[2].offerings[0].location, this.offering3.room);
     assert.equal(blocks[2].offerings[0].url, this.offering3.url);
     assert.equal(blocks[2].offerings[0].instructors.length, 2);
-    assert.equal(blocks[2].offerings[0].instructors[0].title, '3 guy M. Mc3son');
-    assert.equal(blocks[2].offerings[0].instructors[1].title, '4 guy M. Mc4son');
+    assert.equal(blocks[2].offerings[0].instructors[0].userNameInfo.fullName, '3 guy M. Mc3son');
+    assert.equal(blocks[2].offerings[0].instructors[1].userNameInfo.fullName, '4 guy M. Mc4son');
   });
 
   test('confirm removal message', async function(assert) {
@@ -223,7 +220,7 @@ module('Acceptance | Session - Offerings', function(hooks) {
     assert.equal(block.offerings[0].learnerGroups[1].title, 'learner group 1');
     assert.equal(block.offerings[0].location, 'Rm. 111');
     assert.equal(block.offerings[0].instructors.length, 1);
-    assert.equal(block.offerings[0].instructors[0].title, '0 guy M. Mc0son');
+    assert.equal(block.offerings[0].instructors[0].userNameInfo.fullName, '0 guy M. Mc0son');
   });
 
 
@@ -266,7 +263,7 @@ module('Acceptance | Session - Offerings', function(hooks) {
     assert.equal(block.offerings[0].learnerGroups[1].title, 'learner group 1');
     assert.equal(block.offerings[0].location, 'Rm. 111');
     assert.equal(block.offerings[0].instructors.length, 1);
-    assert.equal(block.offerings[0].instructors[0].title, '0 guy M. Mc0son');
+    assert.equal(block.offerings[0].instructors[0].userNameInfo.fullName, '0 guy M. Mc0son');
   });
 
   test('users can create a new small group offering', async function(assert) {
@@ -302,15 +299,15 @@ module('Acceptance | Session - Offerings', function(hooks) {
     assert.equal(block.offerings[0].learnerGroups.length, 1);
     assert.equal(block.offerings[0].learnerGroups[0].title, 'learner group 0');
     assert.equal(block.offerings[0].instructors.length, 1);
-    assert.equal(block.offerings[0].instructors[0].title, '0 guy M. Mc0son');
+    assert.equal(block.offerings[0].instructors[0].userNameInfo.fullName, '0 guy M. Mc0son');
 
     assert.equal(block.offerings[1].learnerGroups.length, 1);
     assert.equal(block.offerings[1].learnerGroups[0].title, 'learner group 1');
     assert.equal(block.offerings[1].instructors.length, 4);
-    assert.equal(block.offerings[1].instructors[0].title, '1 guy M. Mc1son');
-    assert.equal(block.offerings[1].instructors[1].title, '2 guy M. Mc2son');
-    assert.equal(block.offerings[1].instructors[2].title, '5 guy M. Mc5son');
-    assert.equal(block.offerings[1].instructors[3].title, '6 guy M. Mc6son');
+    assert.equal(block.offerings[1].instructors[0].userNameInfo.fullName, '1 guy M. Mc1son');
+    assert.equal(block.offerings[1].instructors[1].userNameInfo.fullName, '2 guy M. Mc2son');
+    assert.equal(block.offerings[1].instructors[2].userNameInfo.fullName, '5 guy M. Mc5son');
+    assert.equal(block.offerings[1].instructors[3].userNameInfo.fullName, '6 guy M. Mc6son');
   });
 
 
@@ -354,11 +351,11 @@ module('Acceptance | Session - Offerings', function(hooks) {
     assert.equal(offering.learnerGroups.length, 1);
     assert.equal(offering.learnerGroups[0].title, 'learner group 1');
     assert.equal(offering.instructors.length, 5);
-    assert.equal(offering.instructors[0].title, '3 guy M. Mc3son');
-    assert.equal(offering.instructors[1].title, '4 guy M. Mc4son');
-    assert.equal(offering.instructors[2].title, '6 guy M. Mc6son');
-    assert.equal(offering.instructors[3].title, '7 guy M. Mc7son');
-    assert.equal(offering.instructors[4].title, '8 guy M. Mc8son');
+    assert.equal(offering.instructors[0].userNameInfo.fullName, '3 guy M. Mc3son');
+    assert.equal(offering.instructors[1].userNameInfo.fullName, '4 guy M. Mc4son');
+    assert.equal(offering.instructors[2].userNameInfo.fullName, '6 guy M. Mc6son');
+    assert.equal(offering.instructors[3].userNameInfo.fullName, '7 guy M. Mc7son');
+    assert.equal(offering.instructors[4].userNameInfo.fullName, '8 guy M. Mc8son');
     assert.equal(offering.location, 'Rm. 111');
     assert.equal(offering.url, 'https://example.org/');
   });
@@ -406,15 +403,15 @@ module('Acceptance | Session - Offerings', function(hooks) {
       assert.equal(block.offerings[0].learnerGroups[0].title, 'learner group 0');
 
       assert.equal(block.offerings[0].instructors.length, 1);
-      assert.equal(block.offerings[0].instructors[0].title, '0 guy M. Mc0son');
+      assert.equal(block.offerings[0].instructors[0].userNameInfo.fullName, '0 guy M. Mc0son');
 
       assert.equal(block.offerings[1].learnerGroups.length, 1);
       assert.equal(block.offerings[1].learnerGroups[0].title, 'learner group 1');
       assert.equal(block.offerings[1].instructors.length, 4);
-      assert.equal(block.offerings[1].instructors[0].title, '1 guy M. Mc1son');
-      assert.equal(block.offerings[1].instructors[1].title, '2 guy M. Mc2son');
-      assert.equal(block.offerings[1].instructors[2].title, '5 guy M. Mc5son');
-      assert.equal(block.offerings[1].instructors[3].title, '6 guy M. Mc6son');
+      assert.equal(block.offerings[1].instructors[0].userNameInfo.fullName, '1 guy M. Mc1son');
+      assert.equal(block.offerings[1].instructors[1].userNameInfo.fullName, '2 guy M. Mc2son');
+      assert.equal(block.offerings[1].instructors[2].userNameInfo.fullName, '5 guy M. Mc5son');
+      assert.equal(block.offerings[1].instructors[3].userNameInfo.fullName, '6 guy M. Mc6son');
     }
   });
 

--- a/tests/integration/components/detail-instructors-list-test.js
+++ b/tests/integration/components/detail-instructors-list-test.js
@@ -1,0 +1,59 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { component } from 'ilios-common/page-objects/components/detail-instructors-list';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+
+module('Integration | Component | detail instructors list', function(hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function() {
+    const instructor1 = this.server.create('user', { firstName: 'Joe', lastName: 'Doe', middleName: 'Michael' });
+    const instructor2 = this.server.create('user', { firstName: 'Jane', lastName: 'Doe', middleName: 'Anette' });
+    const instructor3 = this.server.create('user', { displayName: 'Aardvark' });
+
+    const group1 = this.server.create('instructorGroup', { title: 'Beta', users: [ instructor1 ]});
+    const group2 = this.server.create('instructorGroup', { title: 'Alpha', users: [ instructor2, instructor3 ]});
+
+    this.instructor1 =  await this.owner.lookup('service:store').find('user', instructor1.id);
+    this.instructor2 =  await this.owner.lookup('service:store').find('user', instructor2.id);
+    this.instructor3 =  await this.owner.lookup('service:store').find('user', instructor3.id);
+    this.group1 =  await this.owner.lookup('service:store').find('instructor-group', group1.id);
+    this.group2 =  await this.owner.lookup('service:store').find('instructor-group', group2.id);
+  });
+
+  test('it renders', async function(assert) {
+    this.set('groups', [ this.group1, this.group2 ]);
+    this.set('instructors', [ this.instructor1, this.instructor2, this.instructor3 ]);
+
+    await render(hbs`<DetailInstructorsList @instructors={{this.instructors}} @instructorGroups={{this.groups}} />`);
+    assert.equal(component.instructors.length, 3);
+    assert.equal(component.instructors[0].userNameInfo.fullName, "Aardvark");
+    assert.notOk(component.instructors[0].userNameInfo.isTooltipVisible);
+    await component.instructors[0].userNameInfo.expandTooltip();
+    assert.ok(component.instructors[0].userNameInfo.isTooltipVisible);
+    assert.equal(component.instructors[0].userNameInfo.tooltipContents, '2 guy M, Mc2son');
+    await component.instructors[0].userNameInfo.closeTooltip();
+    assert.equal(component.instructors[1].userNameInfo.fullName, "Jane A. Doe");
+    assert.notOk(component.instructors[1].userNameInfo.isTooltipVisible);
+    assert.equal(component.instructors[2].userNameInfo.fullName, "Joe M. Doe");
+    assert.notOk(component.instructors[2].userNameInfo.isTooltipVisible);
+    assert.equal(component.instructorGroups.length, 2);
+    assert.equal(component.instructorGroups[0].title, "Alpha");
+    assert.equal(component.instructorGroups[0].members.length, 2);
+    assert.equal(component.instructorGroups[0].members[0].userNameInfo.fullName, "Aardvark");
+    assert.notOk(component.instructorGroups[0].members[0].userNameInfo.isTooltipVisible);
+    await component.instructorGroups[0].members[0].userNameInfo.expandTooltip();
+    assert.ok(component.instructorGroups[0].members[0].userNameInfo.isTooltipVisible);
+    assert.equal(component.instructorGroups[0].members[0].userNameInfo.tooltipContents, '2 guy M, Mc2son');
+    await component.instructorGroups[0].members[0].userNameInfo.closeTooltip();
+    assert.equal(component.instructorGroups[0].members[1].userNameInfo.fullName, "Jane A. Doe");
+    assert.notOk(component.instructorGroups[0].members[1].userNameInfo.isTooltipVisible);
+    assert.equal(component.instructorGroups[1].members.length, 1);
+    assert.equal(component.instructorGroups[1].members[0].userNameInfo.fullName, 'Joe M. Doe');
+    assert.notOk(component.instructorGroups[1].members[0].userNameInfo.isTooltipVisible);
+    assert.equal(component.instructorGroups[1].title, "Beta");
+  });
+});

--- a/tests/integration/components/detail-learner-list-test.js
+++ b/tests/integration/components/detail-learner-list-test.js
@@ -12,31 +12,44 @@ module('Integration | Component | detail learner list', function(hooks) {
   hooks.beforeEach(async function() {
     const learner1 = this.server.create('user', {firstName: 'Joe', lastName: 'Doe', middleName: 'Michael'});
     const learner2 = this.server.create('user', {firstName: 'Jane', lastName: 'Doe', middleName: 'Anette'});
+    const learner3 = this.server.create('user', {displayName: 'Aardvark'});
     this.learnerModel1 =  await this.owner.lookup('service:store').find('user', learner1.id);
     this.learnerModel2 =  await this.owner.lookup('service:store').find('user', learner2.id);
+    this.learnerModel3 =  await this.owner.lookup('service:store').find('user', learner3.id);
   });
 
-
   test('it renders', async function(assert) {
-    assert.expect(5);
-    this.set('learners', [this.learnerModel1, this.learnerModel2]);
+    this.set('learners', [this.learnerModel1, this.learnerModel2, this.learnerModel3]);
     await render(hbs`<DetailLearnerList @learners={{this.learners}} @isManaging={{false}} />`);
-    assert.equal(component.learners.length, 2);
-    assert.equal(component.learners[0].userName, "Jane A. Doe");
+    assert.equal(component.learners.length, 3);
+    assert.equal(component.learners[0].userNameInfo.fullName, "Aardvark");
     assert.notOk(component.learners[0].isRemovable);
-    assert.equal(component.learners[1].userName, "Joe M. Doe");
+    assert.notOk(component.learners[0].userNameInfo.isTooltipVisible);
+    await component.learners[0].userNameInfo.expandTooltip();
+    assert.ok(component.learners[0].userNameInfo.isTooltipVisible);
+    assert.equal(component.learners[0].userNameInfo.tooltipContents, '2 guy M, Mc2son');
+    await component.learners[0].userNameInfo.closeTooltip();
+    assert.equal(component.learners[1].userNameInfo.fullName, "Jane A. Doe");
     assert.notOk(component.learners[1].isRemovable);
+    assert.equal(component.learners[2].userNameInfo.fullName, "Joe M. Doe");
+    assert.notOk(component.learners[2].isRemovable);
   });
 
   test('it renders in managing mode', async function(assert) {
-    assert.expect(5);
-    this.set('learners', [this.learnerModel1, this.learnerModel2]);
+    this.set('learners', [this.learnerModel1, this.learnerModel2, this.learnerModel3]);
     await render(hbs`<DetailLearnerList @learners={{this.learners}} @isManaging={{true}} @remove={{noop}} />`);
-    assert.equal(component.learners.length, 2);
-    assert.equal(component.learners[0].userName, "Jane A. Doe");
+    assert.equal(component.learners.length, 3);
+    assert.equal(component.learners[0].userNameInfo.fullName, "Aardvark");
     assert.ok(component.learners[0].isRemovable);
-    assert.equal(component.learners[1].userName, "Joe M. Doe");
+    assert.notOk(component.learners[0].userNameInfo.isTooltipVisible);
+    await component.learners[0].userNameInfo.expandTooltip();
+    assert.ok(component.learners[0].userNameInfo.isTooltipVisible);
+    assert.equal(component.learners[0].userNameInfo.tooltipContents, '2 guy M, Mc2son');
+    await component.learners[0].userNameInfo.closeTooltip();
+    assert.equal(component.learners[1].userNameInfo.fullName, "Jane A. Doe");
     assert.ok(component.learners[1].isRemovable);
+    assert.equal(component.learners[2].userNameInfo.fullName, "Joe M. Doe");
+    assert.ok(component.learners[2].isRemovable);
   });
 
   test('remove learner from list', async function(assert) {
@@ -47,7 +60,7 @@ module('Integration | Component | detail learner list', function(hooks) {
     });
     await render(hbs`<DetailLearnerList @learners={{this.learners}} @isManaging={{true}} @remove={{this.remove}}/>`);
     assert.equal(component.learners.length, 2);
-    assert.equal(component.learners[0].userName, "Jane A. Doe");
+    assert.equal(component.learners[0].userNameInfo.fullName, "Jane A. Doe");
     await component.learners[0].remove();
   });
 });

--- a/tests/integration/components/detail-learners-and-learnergroups-test.js
+++ b/tests/integration/components/detail-learners-and-learnergroups-test.js
@@ -64,9 +64,9 @@ module('Integration | Component | detail-learners-and-learner-groups', function(
     />`);
     assert.equal(component.title, 'Learners and Learner Groups (3/3)');
     assert.equal(component.detailLearnerList.learners.length, 3);
-    assert.equal(component.detailLearnerList.learners[0].userName, '0 guy M. Mc0son');
-    assert.equal(component.detailLearnerList.learners[1].userName, '1 guy M. Mc1son');
-    assert.equal(component.detailLearnerList.learners[2].userName, '2 guy M. Mc2son');
+    assert.equal(component.detailLearnerList.learners[0].userNameInfo.fullName, '0 guy M. Mc0son');
+    assert.equal(component.detailLearnerList.learners[1].userNameInfo.fullName, '1 guy M. Mc1son');
+    assert.equal(component.detailLearnerList.learners[2].userNameInfo.fullName, '2 guy M. Mc2son');
     assert.equal(component.detailLearnergroupsList.trees.length, 2);
     assert.equal(component.detailLearnergroupsList.trees[0].subgroups.length, 3);
     assert.equal(component.detailLearnergroupsList.trees[0].subgroups[0].title, 'Top Group 1 (0)');
@@ -93,15 +93,15 @@ module('Integration | Component | detail-learners-and-learner-groups', function(
     assert.ok(component.hasCancelButton);
     assert.equal(component.learnerSelectionManager.selectedLearners.detailLearnerList.learners.length, 3);
     assert.equal(
-      component.learnerSelectionManager.selectedLearners.detailLearnerList.learners[0].userName,
+      component.learnerSelectionManager.selectedLearners.detailLearnerList.learners[0].userNameInfo.fullName,
       '0 guy M. Mc0son'
     );
     assert.equal(
-      component.learnerSelectionManager.selectedLearners.detailLearnerList.learners[1].userName,
+      component.learnerSelectionManager.selectedLearners.detailLearnerList.learners[1].userNameInfo.fullName,
       '1 guy M. Mc1son'
     );
     assert.equal(
-      component.learnerSelectionManager.selectedLearners.detailLearnerList.learners[2].userName,
+      component.learnerSelectionManager.selectedLearners.detailLearnerList.learners[2].userNameInfo.fullName,
       '2 guy M. Mc2son'
     );
     assert.equal(component.learnergroupSelectionManager.selectedGroups.list.trees.length, 2);

--- a/tests/integration/components/instructor-selection-manager-test.js
+++ b/tests/integration/components/instructor-selection-manager-test.js
@@ -1,0 +1,152 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { component } from 'ilios-common/page-objects/components/instructor-selection-manager';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+
+module('Integration | Component | instructor selection manager', function(hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function() {
+    const instructor1 = this.server.create('user', { firstName: 'Joe', lastName: 'Doe', middleName: 'Michael' });
+    const instructor2 = this.server.create('user', { firstName: 'Jane', lastName: 'Doe', middleName: 'Anette' });
+    const instructor3 = this.server.create('user', { displayName: 'Aardvark' });
+    const group1 = this.server.create('instructorGroup', { users: [ instructor1 ], title: 'Beta' });
+    const group2 = this.server.create('instructorGroup', { users: [ instructor2, instructor3 ], title: 'Alpha' });
+    const group3 = this.server.create('instructorGroup', { title: 'Gamma' });
+    this.instructor1 = await this.owner.lookup('service:store').find('user', instructor1.id);
+    this.instructor2 = await this.owner.lookup('service:store').find('user', instructor2.id);
+    this.instructor3 = await this.owner.lookup('service:store').find('user', instructor3.id);
+    this.group1 = await this.owner.lookup('service:store').find('instructor-group', group1.id);
+    this.group2 = await this.owner.lookup('service:store').find('instructor-group', group2.id);
+    this.group3 = await this.owner.lookup('service:store').find('instructor-group', group3.id);
+  });
+
+  test('it renders', async function(assert) {
+    this.set('instructors', [this.instructor1, this.instructor2, this.instructor3 ]);
+    this.set('groups', [ this.group1, this.group2 ]);
+    this.set('availableGroups', []);
+    await render(hbs`<InstructorSelectionManager
+      @instructors={{this.instructors}}
+      @instructorGroups={{this.groups}}
+      @availableInstructorGroups={{this.availableGroups}}
+      @addInstructor={{noop}}
+      @addInstructorGroup={{noop}}
+      @removeInstructor={{noop}}
+      @removeInstructorGroup={{noop}}
+    />`);
+    assert.equal(component.instructors.length, 3);
+    assert.equal(component.instructors[0].userNameInfo.fullName, "Aardvark");
+    assert.notOk(component.instructors[0].userNameInfo.isTooltipVisible);
+    await component.instructors[0].userNameInfo.expandTooltip();
+    assert.ok(component.instructors[0].userNameInfo.isTooltipVisible);
+    assert.equal(component.instructors[0].userNameInfo.tooltipContents, '2 guy M, Mc2son');
+    await component.instructors[0].userNameInfo.closeTooltip();
+    assert.equal(component.instructors[1].userNameInfo.fullName, "Jane A. Doe");
+    assert.notOk(component.instructors[1].userNameInfo.isTooltipVisible);
+    assert.equal(component.instructors[2].userNameInfo.fullName, "Joe M. Doe");
+    assert.notOk(component.instructors[2].userNameInfo.isTooltipVisible);
+    assert.equal(component.instructorGroups.length, 2);
+    assert.equal(component.instructorGroups[0].title, "Alpha");
+    assert.equal(component.instructorGroups[0].members.length, 2);
+    assert.equal(component.instructorGroups[0].members[0].userNameInfo.fullName, "Aardvark");
+    assert.notOk(component.instructorGroups[0].members[0].userNameInfo.isTooltipVisible);
+    await component.instructorGroups[0].members[0].userNameInfo.expandTooltip();
+    assert.ok(component.instructorGroups[0].members[0].userNameInfo.isTooltipVisible);
+    assert.equal(component.instructorGroups[0].members[0].userNameInfo.tooltipContents, '2 guy M, Mc2son');
+    await component.instructorGroups[0].members[0].userNameInfo.closeTooltip();
+    assert.equal(component.instructorGroups[0].members[1].userNameInfo.fullName, "Jane A. Doe");
+    assert.notOk(component.instructorGroups[0].members[1].userNameInfo.isTooltipVisible);
+    assert.equal(component.instructorGroups[1].members.length, 1);
+    assert.equal(component.instructorGroups[1].members[0].userNameInfo.fullName, 'Joe M. Doe');
+    assert.notOk(component.instructorGroups[1].members[0].userNameInfo.isTooltipVisible);
+    assert.equal(component.instructorGroups[1].title, "Beta");
+  });
+
+  test('remove selected instructor', async function(assert) {
+    assert.expect(1);
+    this.set('instructors', [ this.instructor1 ]);
+    this.set('groups', []);
+    this.set('availableGroups', []);
+    this.set('removeInstructor', instructor => {
+      assert.equal(instructor, this.instructor1);
+    });
+    await render(hbs`<InstructorSelectionManager
+      @instructors={{this.instructors}}
+      @instructorGroups={{this.groups}}
+      @availableInstructorGroups={{this.availableGroups}}
+      @addInstructor={{noop}}
+      @addInstructorGroup={{noop}}
+      @removeInstructor={{this.removeInstructor}}
+      @removeInstructorGroup={{noop}}
+    />`);
+    await component.instructors[0].remove();
+  });
+
+  test('remove selected instructor group', async function(assert) {
+    assert.expect(1);
+    this.set('instructors', []);
+    this.set('groups', [ this.group1 ]);
+    this.set('availableGroups', []);
+    this.set('removeGroup', group => {
+      assert.equal(group, this.group1);
+    });
+    await render(hbs`<InstructorSelectionManager
+      @instructors={{this.instructors}}
+      @instructorGroups={{this.groups}}
+      @availableInstructorGroups={{this.availableGroups}}
+      @addInstructor={{noop}}
+      @addInstructorGroup={{noop}}
+      @removeInstructor={{noop}}
+      @removeInstructorGroup={{this.removeGroup}}
+    />`);
+    await component.instructorGroups[0].remove();
+  });
+
+  test('search and add instructor group', async function(assert) {
+    assert.expect(1);
+    this.set('instructors', []);
+    this.set('groups', []);
+    this.set('availableGroups', [ this.group3 ]);
+    this.set('addGroup', group => {
+      assert.equal(group, this.group3);
+    });
+    await render(hbs`<InstructorSelectionManager
+      @instructors={{this.instructors}}
+      @instructorGroups={{this.groups}}
+      @availableInstructorGroups={{this.availableGroups}}
+      @addInstructor={{noop}}
+      @addInstructorGroup={{this.addGroup}}
+      @removeInstructor={{noop}}
+      @removeInstructorGroup={{noop}}
+    />`);
+    await component.search('Gamma');
+    await component.searchResults[0].add();
+  });
+
+  test('search and add instructor', async function(assert) {
+    assert.expect(1);
+    this.server.get('api/users', (schema) => {
+      return schema.users.all();
+    });
+    this.set('instructors', []);
+    this.set('groups', []);
+    this.set('availableGroups', []);
+    this.set('addInstructor', instructor => {
+      assert.equal(instructor, this.instructor3);
+    });
+    await render(hbs`<InstructorSelectionManager
+      @instructors={{this.instructors}}
+      @instructorGroups={{this.groups}}
+      @availableInstructorGroups={{this.availableGroups}}
+      @addInstructor={{this.addInstructor}}
+      @addInstructorGroup={{noop}}
+      @removeInstructor={{noop}}
+      @removeInstructorGroup={{noop}}
+    />`);
+    await component.search('Aardvark');
+    await component.searchResults[0].add();
+  });
+});

--- a/tests/integration/components/leadership-list-test.js
+++ b/tests/integration/components/leadership-list-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, findAll } from '@ember/test-helpers';
+import { render, find, findAll, triggerEvent } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
@@ -34,8 +34,6 @@ module('Integration | Component | leadership list', function(hooks) {
   });
 
   test('it renders with data', async function(assert) {
-    assert.expect(10);
-
     this.set('directors', [this.user1, this.user3]);
     this.set('administrators', [this.user1, this.user2, this.user3]);
     this.set('studentAdvisors', [this.user2, this.user3]);
@@ -48,18 +46,42 @@ module('Integration | Component | leadership list', function(hooks) {
       @showDirectors={{true}}
       @showStudentAdvisors={{true}}
     />`);
-    const directors = 'table tbody tr:nth-of-type(1) td:nth-of-type(1) li [data-test-name]';
-    const administrators = 'table tbody tr:nth-of-type(1) td:nth-of-type(2) li [data-test-name]';
-    const studentAdvisors = 'table tbody tr:nth-of-type(1) td:nth-of-type(3) li [data-test-name]';
+    const directors = 'table tbody tr:nth-of-type(1) td:nth-of-type(1) li [data-test-fullname]';
+    const directorsUsernameInfo = 'table tbody tr:nth-of-type(1) td:nth-of-type(1) li [data-test-info]';
+    const administrators = 'table tbody tr:nth-of-type(1) td:nth-of-type(2) li [data-test-fullname]';
+    const administratorsUsernameInfo = 'table tbody tr:nth-of-type(1) td:nth-of-type(2) li [data-test-info]';
+    const studentAdvisors = 'table tbody tr:nth-of-type(1) td:nth-of-type(3) li [data-test-fullname]';
+    const studentAdvisorsUsernameInfo = 'table tbody tr:nth-of-type(1) td:nth-of-type(3) li [data-test-info]';
 
     assert.dom(directors).exists({ count: 2 });
+    assert.dom(directorsUsernameInfo).exists({ count: 1 });
+    assert.dom(findAll(directorsUsernameInfo)[0]).hasText('Campus name of record');
+    assert.dom(find('.ilios-tooltip')).doesNotExist();
+    await triggerEvent(findAll(directorsUsernameInfo)[0], 'mouseover');
+    assert.dom(find('.ilios-tooltip')).hasText('stuart leslie goddard');
+    await triggerEvent(findAll(directorsUsernameInfo)[0], 'mouseout');
+    assert.dom(find('.ilios-tooltip')).doesNotExist();
     assert.dom(findAll(directors)[0]).hasText('a b. person');
     assert.dom(findAll(directors)[1]).hasText('adam ant');
     assert.dom(administrators).exists({ count: 3 });
+    assert.dom(administratorsUsernameInfo).exists({ count: 1 });
+    assert.dom(findAll(administratorsUsernameInfo)[0]).hasText('Campus name of record');
+    assert.dom(find('.ilios-tooltip')).doesNotExist();
+    await triggerEvent(findAll(administratorsUsernameInfo)[0], 'mouseover');
+    assert.dom(find('.ilios-tooltip')).hasText('stuart leslie goddard');
+    await triggerEvent(findAll(administratorsUsernameInfo)[0], 'mouseout');
+    assert.dom(find('.ilios-tooltip')).doesNotExist();
     assert.dom(findAll(administrators)[0]).hasText('a b. person');
     assert.dom(findAll(administrators)[1]).hasText('adam ant');
     assert.dom(findAll(administrators)[2]).hasText('b a. person');
     assert.dom(studentAdvisors).exists({ count: 2 });
+    assert.dom(studentAdvisorsUsernameInfo).exists({ count: 1 });
+    assert.dom(findAll(studentAdvisorsUsernameInfo)[0]).hasText('Campus name of record');
+    assert.dom(find('.ilios-tooltip')).doesNotExist();
+    await triggerEvent(findAll(studentAdvisorsUsernameInfo)[0], 'mouseover');
+    assert.dom(find('.ilios-tooltip')).hasText('stuart leslie goddard');
+    await triggerEvent(findAll(studentAdvisorsUsernameInfo)[0], 'mouseout');
+    assert.dom(find('.ilios-tooltip')).doesNotExist();
     assert.dom(findAll(studentAdvisors)[0]).hasText('adam ant');
     assert.dom(findAll(studentAdvisors)[1]).hasText('b a. person');
   });
@@ -77,8 +99,8 @@ module('Integration | Component | leadership list', function(hooks) {
       @showStudentAdvisors={{true}}
       @studentAdvisors={{this.studentAdvisors}}
     />`);
-    const administrators = 'table tbody tr:nth-of-type(1) td:nth-of-type(1) li [data-test-name]';
-    const studentAdvisors = 'table tbody tr:nth-of-type(1) td:nth-of-type(2) li [data-test-name]';
+    const administrators = 'table tbody tr:nth-of-type(1) td:nth-of-type(1) li [data-test-fullname]';
+    const studentAdvisors = 'table tbody tr:nth-of-type(1) td:nth-of-type(2) li [data-test-fullname]';
 
     assert.dom(administrators).exists({ count: 1 });
     assert.dom(findAll(administrators)[0]).hasText('a b. person');
@@ -99,8 +121,8 @@ module('Integration | Component | leadership list', function(hooks) {
       @showStudentAdvisors={{true}}
       @studentAdvisors={{this.studentAdvisors}}
     />`);
-    const directors = 'table tbody tr:nth-of-type(1) td:nth-of-type(1) li [data-test-name]';
-    const studentAdvisors = 'table tbody tr:nth-of-type(1) td:nth-of-type(2) li [data-test-name]';
+    const directors = 'table tbody tr:nth-of-type(1) td:nth-of-type(1) li [data-test-fullname]';
+    const studentAdvisors = 'table tbody tr:nth-of-type(1) td:nth-of-type(2) li [data-test-fullname]';
 
     assert.dom(directors).exists({ count: 1 });
     assert.dom(findAll(directors)[0]).hasText('a b. person');
@@ -121,8 +143,8 @@ module('Integration | Component | leadership list', function(hooks) {
       @administrators={{this.administrators}}
       @showStudentAdvisors={{false}}
     />`);
-    const directors = 'table tbody tr:nth-of-type(1) td:nth-of-type(1) li [data-test-name]';
-    const administrators = 'table tbody tr:nth-of-type(1) td:nth-of-type(2) li [data-test-name]';
+    const directors = 'table tbody tr:nth-of-type(1) td:nth-of-type(1) li [data-test-fullname]';
+    const administrators = 'table tbody tr:nth-of-type(1) td:nth-of-type(2) li [data-test-fullname]';
 
     assert.dom(directors).exists({ count: 1 });
     assert.dom(findAll(directors)[0]).hasText('a b. person');
@@ -177,11 +199,11 @@ module('Integration | Component | leadership list', function(hooks) {
     const directors = 'table tbody tr:nth-of-type(1) td:nth-of-type(1) li';
     const administrators = 'table tbody tr:nth-of-type(1) td:nth-of-type(2) li';
     const studentAdvisors = 'table tbody tr:nth-of-type(1) td:nth-of-type(3) li';
-    const directorNames = `${directors} [data-test-name]`;
+    const directorNames = `${directors} [data-test-fullname]`;
     const disabledDirectors = `${directors} .fa-user-times`;
-    const administratorNames = `${administrators} [data-test-name]`;
+    const administratorNames = `${administrators} [data-test-fullname]`;
     const disabledAdministrators = `${administrators} .fa-user-times`;
-    const studentAdvisorNames = `${studentAdvisors} [data-test-name]`;
+    const studentAdvisorNames = `${studentAdvisors} [data-test-fullname]`;
     const disabledStudentAdvisors = `${studentAdvisors} .fa-user-times`;
 
     assert.dom(directors).exists({ count: 1 });

--- a/tests/integration/components/learner-selection-manager-test.js
+++ b/tests/integration/components/learner-selection-manager-test.js
@@ -10,20 +10,35 @@ module('Integration | Component | learner selection manager', function(hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(async function() {
-    const learner1 = this.server.create('user', {firstName: 'Joe', lastName: 'Doe', middleName: 'Michael'});
-    const learner2 = this.server.create('user', {firstName: 'Jane', lastName: 'Doe', middleName: 'Anette'});
+    const learner1 = this.server.create('user', { firstName: 'Joe', lastName: 'Doe', middleName: 'Michael' });
+    const learner2 = this.server.create('user', { firstName: 'Jane', lastName: 'Doe', middleName: 'Anette' });
+    const learner3 = this.server.create('user', { displayName: 'Clem Chowder' });
+
     this.learnerModel1 =  await this.owner.lookup('service:store').find('user', learner1.id);
     this.learnerModel2 =  await this.owner.lookup('service:store').find('user', learner2.id);
+    this.learnerModel3 =  await this.owner.lookup('service:store').find('user', learner3.id);
   });
 
   test('selected learners', async function(assert) {
-    assert.expect(4);
-    this.set('learners', [this.learnerModel1,  this.learnerModel2]);
+    this.set('learners', [ this.learnerModel1,  this.learnerModel2, this.learnerModel3 ]);
     await render(hbs`<LearnerSelectionManager @learners={{this.learners}} @add={{noop}} @remove={{noop}}/>`);
     assert.equal(component.selectedLearners.heading, 'Selected Learners');
-    assert.equal(component.selectedLearners.detailLearnerList.learners.length, 2);
-    assert.equal(component.selectedLearners.detailLearnerList.learners[0].userName, "Jane A. Doe");
-    assert.equal(component.selectedLearners.detailLearnerList.learners[1].userName, "Joe M. Doe");
+    assert.equal(component.selectedLearners.detailLearnerList.learners.length, 3);
+    assert.equal(component.selectedLearners.detailLearnerList.learners[0].userNameInfo.fullName, "Clem Chowder");
+    assert.ok(component.selectedLearners.detailLearnerList.learners[0].userNameInfo.hasAdditionalInfo);
+    assert.notOk(component.selectedLearners.detailLearnerList.learners[0].userNameInfo.isTooltipVisible);
+    await component.selectedLearners.detailLearnerList.learners[0].userNameInfo.expandTooltip();
+    assert.ok(component.selectedLearners.detailLearnerList.learners[0].userNameInfo.isTooltipVisible);
+    assert.equal(
+      component.selectedLearners.detailLearnerList.learners[0].userNameInfo.tooltipContents,
+      '2 guy M, Mc2son'
+    );
+    await component.selectedLearners.detailLearnerList.learners[0].userNameInfo.closeTooltip();
+    assert.notOk(component.selectedLearners.detailLearnerList.learners[0].userNameInfo.isTooltipVisible);
+    assert.equal(component.selectedLearners.detailLearnerList.learners[1].userNameInfo.fullName, "Jane A. Doe");
+    assert.notOk(component.selectedLearners.detailLearnerList.learners[1].userNameInfo.hasAdditionalInfo);
+    assert.equal(component.selectedLearners.detailLearnerList.learners[2].userNameInfo.fullName, "Joe M. Doe");
+    assert.notOk(component.selectedLearners.detailLearnerList.learners[2].userNameInfo.hasAdditionalInfo);
   });
 
   test('no selected learners', async function(assert) {
@@ -44,7 +59,7 @@ module('Integration | Component | learner selection manager', function(hooks) {
     await render(hbs`<LearnerSelectionManager @learners={{this.learners}} @add={{noop}} @remove={{remove}}/>`);
     assert.equal(component.selectedLearners.heading, 'Selected Learners');
     assert.equal(component.selectedLearners.detailLearnerList.learners.length, 2);
-    assert.equal(component.selectedLearners.detailLearnerList.learners[1].userName, "Joe M. Doe");
+    assert.equal(component.selectedLearners.detailLearnerList.learners[1].userNameInfo.fullName, "Joe M. Doe");
     await component.selectedLearners.detailLearnerList.learners[1].remove();
   });
 

--- a/tests/integration/components/new-learningmaterial-test.js
+++ b/tests/integration/components/new-learningmaterial-test.js
@@ -1,0 +1,36 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { setupAuthentication } from 'ilios-common';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { component } from 'ilios-common/page-objects/components/new-learningmaterial';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+
+// @todo flesh this integration test out [ST 2020/09/02]
+module('Integration | Component | new learningmaterial', function(hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  test('owning user has additional info', async function (assert) {
+    this.school = this.server.create('school');
+    await setupAuthentication({ school: this.school, displayName: 'Clem Chowder' });
+    this.set('type', 'citation');
+    await render(hbs`
+      <NewLearningmaterial
+        @type={{this.type}}
+        @learningMaterialStatuses={{array}}
+        @learningMaterialUserRoles={{array}}
+        @save={{noop}}
+        @cancel={{noop}}
+      />
+   `);
+    assert.equal(component.owningUser.userNameInfo.fullName, 'Clem Chowder');
+    assert.ok(component.owningUser.userNameInfo.hasAdditionalInfo);
+    assert.notOk(component.owningUser.userNameInfo.isTooltipVisible);
+    await component.owningUser.userNameInfo.expandTooltip();
+    assert.ok(component.owningUser.userNameInfo.isTooltipVisible);
+    assert.equal(component.owningUser.userNameInfo.tooltipContents, '0 guy M, Mc0son');
+    await component.owningUser.userNameInfo.closeTooltip();
+    assert.notOk(component.owningUser.userNameInfo.isTooltipVisible);
+  });
+});

--- a/tests/integration/components/user-name-info-test.js
+++ b/tests/integration/components/user-name-info-test.js
@@ -1,0 +1,35 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { component } from 'ilios-common/page-objects/components/user-name-info';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+
+module('Integration | Component | user-name-info', function(hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  test('it renders', async function(assert) {
+    const user = this.server.create('user');
+    const userModel = await this.owner.lookup('service:store').find('user', user.id);
+    this.set('user', userModel);
+    await render(hbs`<UserNameInfo @user={{this.user}} />`);
+    assert.notOk(component.hasAdditionalInfo);
+    assert.equal(component.fullName, '0 guy M. Mc0son');
+  });
+
+  test('it renders with additional info', async function(assert) {
+    const user = this.server.create('user', { displayName: 'Clem Chowder'});
+    const userModel = await this.owner.lookup('service:store').find('user', user.id);
+    this.set('user', userModel);
+    await render(hbs`<UserNameInfo @user={{this.user}} />`);
+    assert.ok(component.hasAdditionalInfo);
+    assert.equal(component.fullName, 'Clem Chowder');
+    assert.notOk(component.isTooltipVisible);
+    await component.expandTooltip();
+    assert.ok(component.isTooltipVisible);
+    assert.equal(component.tooltipContents, '0 guy M, Mc0son');
+    await component.closeTooltip();
+    assert.notOk(component.isTooltipVisible);
+  });
+});

--- a/tests/unit/models/user-test.js
+++ b/tests/unit/models/user-test.js
@@ -24,6 +24,63 @@ module('Unit | Model | User', function(hooks) {
     assert.equal(model.get('fullName'), 'first last');
   });
 
+  test('fullNameFromFirstMiddleLastName', function(assert) {
+    const model = this.owner.lookup('service:store').createRecord('user');
+    model.set('firstName', 'first');
+    model.set('lastName', 'last');
+    model.set('middleName', 'middle');
+    assert.equal(model.get('fullNameFromFirstMiddleLastName'), 'first middle last');
+  });
+
+  test('fullNameFromFirstMiddleInitialLastName', function(assert) {
+    const model = this.owner.lookup('service:store').createRecord('user');
+    model.set('firstName', 'first');
+    model.set('lastName', 'last');
+    model.set('middleName', 'middle');
+    assert.equal(model.get('fullNameFromFirstMiddleInitialLastName'), 'first m. last');
+  });
+
+  test('fullNameFromFirstLastName', function(assert) {
+    const model = this.owner.lookup('service:store').createRecord('user');
+    model.set('firstName', 'first');
+    model.set('lastName', 'last');
+    model.set('middleName', 'middle');
+    assert.equal(model.get('fullNameFromFirstLastName'), 'first last');
+  });
+
+  test('does not have different display name', function(assert) {
+    const fixtures = [
+      { firstName: 'first', lastName: 'last', middleName: null, displayName: 'first last' },
+      { firstName: '  first', lastName: ' last ', middleName: null, displayName: 'first last    ' },
+      { firstName: 'First', lastName: 'LAST', middleName: null, displayName: 'FiRsT LasT' },
+      { firstName: 'first', lastName: 'last', middleName: 'middle', displayName: 'first last' },
+      { firstName: 'first', lastName: 'last', middleName: 'middle', displayName: 'first middle last' },
+      { firstName: 'first', lastName: 'last', middleName: 'middle', displayName: 'first m. last' },
+      { firstName: 'first', lastName: 'last', middleName: null, displayName: null },
+    ];
+    fixtures.forEach(fixture => {
+      const model = this.owner.lookup('service:store').createRecord('user');
+      model.set('firstName', fixture.firstName);
+      model.set('lastName',  fixture.lastName);
+      model.set('middleName', fixture.middleName);
+      assert.notOk(model.get('hasDifferentDisplayName'));
+    });
+  });
+
+  test('has different display name', function(assert) {
+    const fixtures = [
+      { firstName: 'first', lastName: 'last', middleName: null, displayName: 'clem chowder' },
+      { firstName: 'first', lastName: 'last', middleName: 'n', displayName: 'first m. last' },
+    ];
+    fixtures.forEach(fixture => {
+      const model = this.owner.lookup('service:store').createRecord('user');
+      model.set('firstName', fixture.firstName);
+      model.set('lastName',  fixture.lastName);
+      model.set('middleName', fixture.middleName);
+      assert.notOk(model.get('hasDifferentDisplayName'));
+    });
+  });
+
   test('full name with displayName', function(assert) {
     const model = this.owner.lookup('service:store').createRecord('user');
     model.set('displayName', 'something else');

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -29,6 +29,7 @@ general:
   backToSessionList: "Back to Session List"
   backToTitle: "Back to {title}"
   calendar: Calendar
+  campusNameOfRecord: "Campus name of record"
   cancel: Cancel
   chooseCohortTitle: "Select Parent For"
   chooseFile: "Choose File"

--- a/translations/es.yaml
+++ b/translations/es.yaml
@@ -29,6 +29,7 @@ general:
   backToSessionList: "Atrás a La Lista de Sesiones"
   backToTitle: "Atrás a {title}"
   calendar: Calendario
+  campusNameOfRecord: "Nombre de registro del registrador"
   cancel: Cancelar
   chooseCohortTitle: "Seleccione Matriz Para"
   chooseFile: "Seleccione Archivo"

--- a/translations/fr.yaml
+++ b/translations/fr.yaml
@@ -29,6 +29,7 @@ general:
   backToSessionList: "Retour à Liste du Séances"
   backToTitle: "Retour à {title}"
   calendar: Calendrier
+  campusNameOfRecord: "Nombre de registro del campus"
   cancel: Annul
   chooseCohortTitle: "Choisi objectif mère pour"
   chooseFile: "Choisir un Fichier"


### PR DESCRIPTION
![Selection_126](https://user-images.githubusercontent.com/1410427/90942550-206b7180-e3cb-11ea-94a7-1633933f846b.png)
![Selection_127](https://user-images.githubusercontent.com/1410427/90942554-22353500-e3cb-11ea-9f3c-be1289892ced.png)
![Selection_139](https://user-images.githubusercontent.com/1410427/91365669-859dd900-e7b6-11ea-974c-909bb6aacff7.png)
![Selection_138](https://user-images.githubusercontent.com/1410427/91365686-92bac800-e7b6-11ea-9ac3-94c675d5a796.png)
![Selection_141](https://user-images.githubusercontent.com/1410427/91365663-7f0f6180-e7b6-11ea-9a1b-f3ce84c4eeb7.png)
![Selection_142](https://user-images.githubusercontent.com/1410427/91466207-a2ccb900-e843-11ea-99a0-6b67fb6a163f.png)
![Selection_143](https://user-images.githubusercontent.com/1410427/91471445-f8f12a80-e84a-11ea-804a-4396fde3d81c.png)


out of scope:
- course print view - we don't want/need tooltips in here, this is mean for print. 
- learning material sort manager: this is minor information there, adding tooltips in this sorting interface would add just add noise.
- learning material search: tool-tiping search results, no bueno. 
- offerings details in session grid: we run an abbreviated, comma separated list of user names there. again, adding tooltips here is too much, let's keep it to where user assignment is happening
- course instructor visualization: adding a tooltip within a tooltip, not desirable.
- the various user searches: in-scope for this, but will be handled as separate issue

refs https://github.com/ilios/frontend/issues/5524