### PR TITLE
fix: change undefined identifier in error message

### DIFF
--- a/lib/set-transform.js
+++ b/lib/set-transform.js
@@ -49,7 +49,7 @@ module.exports = class SetTransform {
       if (!node.params[0] || node.params[0].type !== 'PathExpression') {
         throw new Error(
           'the (set) helper requires a path to be passed in as its first parameter, received: ' +
-            path.original
+            node.params[0]
         );
       }
 


### PR DESCRIPTION
`path` will always be undefined. I believe `node.params[0]` was intended
instead.