### PR TITLE
Fix tag stripping in sessions and session objectives

### DIFF
--- a/addon/models/session-objective.js
+++ b/addon/models/session-objective.js
@@ -1,6 +1,7 @@
 import Model, { hasMany, belongsTo, attr } from '@ember-data/model';
 import { computed } from '@ember/object';
 import { all } from 'rsvp';
+import striptags from 'striptags';
 
 export default Model.extend({
   title: attr('string'),
@@ -61,10 +62,6 @@ export default Model.extend({
   }),
 
   textTitle: computed('title', function(){
-    const title = this.get('title');
-    if(title === undefined){
-      return '';
-    }
-    return title.replace(/(<([^>]+)>)/ig,"");
+    return striptags(this.title);
   }),
 });

--- a/addon/models/session.js
+++ b/addon/models/session.js
@@ -4,6 +4,7 @@ import { isPresent, isEmpty } from '@ember/utils';
 import { all } from 'rsvp';
 import moment from 'moment';
 import sortableByPosition from 'ilios-common/utils/sortable-by-position';
+import striptags from 'striptags';
 
 const { alias, collect, mapBy, sum, oneWay, not } = computed;
 
@@ -392,10 +393,6 @@ export default Model.extend({
   },
 
   textDescription: computed('description', function(){
-    var title = this.get('description');
-    if(title === undefined){
-      return '';
-    }
-    return title.replace(/(<([^>]+)>)/ig,"");
+    return striptags(this.description);
   }),
 });

--- a/tests/unit/models/session-objective-test.js
+++ b/tests/unit/models/session-objective-test.js
@@ -47,4 +47,10 @@ module('Unit | Model | session objective', function(hooks) {
     assert.ok(terms.includes(term5));
     assert.ok(terms.includes(term6));
   });
+
+  test('text only empty title', async function(assert){
+    assert.expect(1);
+    const subject = this.owner.lookup('service:store').createRecord('session-objective');
+    assert.equal('', subject.textTitle);
+  });
 });

--- a/tests/unit/models/session-test.js
+++ b/tests/unit/models/session-test.js
@@ -435,4 +435,10 @@ module('Unit | Model | Session', function(hooks) {
     assert.ok(allInstructors.includes(user1));
     assert.ok(allInstructors.includes(user2));
   });
+
+  test('text only empty description', async function(assert){
+    assert.expect(1);
+    const subject = this.owner.lookup('service:store').createRecord('session');
+    assert.equal('', subject.textDescription);
+  });
 });


### PR DESCRIPTION
Sessions with no description where failing because the undefined check
wasn't catching null values. Instead of using our own regex this change
uses the strip tags library we're already using elsewhere. Since that
library handles null values this fixes the issue.

Refs ilios/ilios#3097