### PR TITLE
adds url and needsAttribution atts to learnergroup model.

### DIFF
--- a/addon-mirage-support/factories/learner-group.js
+++ b/addon-mirage-support/factories/learner-group.js
@@ -2,4 +2,5 @@ import { Factory } from 'ember-cli-mirage';
 
 export default Factory.extend({
   title: (i) => `learner group ${i}`,
+  needsAccommodation: false,
 });

--- a/addon-test-support/ilios-common/page-objects/session.js
+++ b/addon-test-support/ilios-common/page-objects/session.js
@@ -168,6 +168,7 @@ export default create({
         }),
         location: text('[data-test-location]'),
         url: property('href', '[data-test-url] a'),
+        hasUrl: isVisible('[data-test-url]'),
         instructors: collection('.offering-manager-instructors [data-test-instructor]', {
           userNameInfo
         }),

--- a/addon/components/offering-form.js
+++ b/addon/components/offering-form.js
@@ -448,10 +448,9 @@ export default class OfferingForm extends Component {
         if (isPresent(defaultLocation)) {
           room = defaultLocation;
         }
-        const url = learnerGroup.get('url') ;
         const instructors = await learnerGroup.instructors;
         const instructorGroups = await learnerGroup.instructorGroups;
-        const offering = {startDate, endDate, room, url, instructorGroups, instructors, learners};
+        const offering = {startDate, endDate, room, url: learnerGroup.url, instructorGroups, instructors, learners};
         offering.learnerGroups = [learnerGroup];
 
         smallGroupOfferings.pushObject(offering);

--- a/addon/components/offering-form.js
+++ b/addon/components/offering-form.js
@@ -441,16 +441,17 @@ export default class OfferingForm extends Component {
 
     for (let i = 0; i < offerings.length; i++) {
       const {startDate, endDate, learnerGroups, learners} = offerings[i];
-      let {room} = offerings[i];
+      let { room } = offerings[i];
       for (let j = 0; j < learnerGroups.length; j++) {
         const learnerGroup = learnerGroups[j];
         const defaultLocation = learnerGroup.get('location');
         if (isPresent(defaultLocation)) {
           room = defaultLocation;
         }
+        const url = learnerGroup.get('url') ;
         const instructors = await learnerGroup.instructors;
         const instructorGroups = await learnerGroup.instructorGroups;
-        const offering = {startDate, endDate, room, instructorGroups, instructors, learners};
+        const offering = {startDate, endDate, room, url, instructorGroups, instructors, learners};
         offering.learnerGroups = [learnerGroup];
 
         smallGroupOfferings.pushObject(offering);

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -9,6 +9,8 @@ const { map, all } = RSVP;
 export default Model.extend({
   title: attr('string'),
   location: attr('string'),
+  url: attr('string'),
+  needsAccommodation: attr('boolean'),
   cohort: belongsTo('cohort', { async: true }),
   parent: belongsTo('learner-group', { async: true, inverse: 'children' }),
   children: hasMany('learner-group', { async: true, inverse: 'parent' }),

--- a/tests/acceptance/course/session/offerings-test.js
+++ b/tests/acceptance/course/session/offerings-test.js
@@ -36,6 +36,7 @@ module('Acceptance | Session - Offerings', function(hooks) {
       cohort,
       location: 'default 1',
       instructors: [this.user],
+      url: 'https://iliosproject.org/'
     });
     const learnerGroup2 = this.server.create('learner-group', {
       users: [users[2], users[3]],
@@ -268,7 +269,7 @@ module('Acceptance | Session - Offerings', function(hooks) {
 
   test('users can create a new small group offering', async function(assert) {
     this.user.update({ administeredSchools: [this.school] });
-    assert.expect(19);
+    assert.expect(21);
 
     await page.visit({ courseId: 1, sessionId: 1 });
     await page.offerings.header.createNew();
@@ -300,6 +301,7 @@ module('Acceptance | Session - Offerings', function(hooks) {
     assert.equal(block.offerings[0].learnerGroups[0].title, 'learner group 0');
     assert.equal(block.offerings[0].instructors.length, 1);
     assert.equal(block.offerings[0].instructors[0].userNameInfo.fullName, '0 guy M. Mc0son');
+    assert.equal(block.offerings[0].url, 'https://iliosproject.org/');
 
     assert.equal(block.offerings[1].learnerGroups.length, 1);
     assert.equal(block.offerings[1].learnerGroups[0].title, 'learner group 1');
@@ -308,6 +310,8 @@ module('Acceptance | Session - Offerings', function(hooks) {
     assert.equal(block.offerings[1].instructors[1].userNameInfo.fullName, '2 guy M. Mc2son');
     assert.equal(block.offerings[1].instructors[2].userNameInfo.fullName, '5 guy M. Mc5son');
     assert.equal(block.offerings[1].instructors[3].userNameInfo.fullName, '6 guy M. Mc6son');
+    assert.notOk(block.offerings[1].hasUrl);
+
   });
 
 


### PR DESCRIPTION
companion PR to https://github.com/ilios/ilios/pull/3098

this also adds the functionality to populate offering urls from learner group default urls during small group offering creation.

it does not do anything with the needs-accommodation flag yet.