### PR TITLE
Style select a bit

### DIFF
--- a/app/styles/ilios-common/components/body.scss
+++ b/app/styles/ilios-common/components/body.scss
@@ -54,6 +54,11 @@ h6 {
   @include ilios-heading-h6;
 }
 
+select {
+  color: $text-grey;
+  font-family: 'Nunito Sans', sans-serif;
+}
+
 .add,
 .yes {
   color: $ilios-green;


### PR DESCRIPTION
This was inheriting our default Nunito font which is a serif font,
instead styling this like our headers which are sans-serif and changing
the color to match our text color so it isn't stark black.

Fixes ilios/ilios#3112