### PR TITLE
check against report owning school, not linked program's owning school.

### DIFF
--- a/addon/services/permission-checker.js
+++ b/addon/services/permission-checker.js
@@ -321,8 +321,7 @@ export default Service.extend({
       return false;
     }
 
-    const program = await curriculumInventoryReport.get('program');
-    const school = await program.get('school');
+    const school = await curriculumInventoryReport.get('school');
     if (await this.canChangeInSchool(school, 'CAN_UPDATE_ALL_CURRICULUM_INVENTORY_REPORTS')) {
       return true;
     }


### PR DESCRIPTION
this fixes a discrepancy between the permissions checker implementations in backend and common.

realigned with what the backend validator by checking the school property of the correct entity: 

https://github.com/ilios/ilios/blob/master/src/RelationshipVoter/CurriculumInventoryExport.php#L43

refs https://github.com/ilios/frontend/issues/5570