### PR TITLE
Use a getter to built headers

### DIFF
--- a/addon/adapters/ilios.js
+++ b/addon/adapters/ilios.js
@@ -9,15 +9,16 @@ export default class IliosAdapter extends JSONAPIAdapter {
   coalesceFindRequests = true;
   sortQueryParams = false;
 
-  constructor() {
-    super(...arguments);
-    this.headers = {};
-    if (this.session && this.session.isAuthenticated) {
+  get headers() {
+    const headers = {};
+    if (this.session?.isAuthenticated) {
       const { jwt } = this.session.data.authenticated;
       if (jwt) {
-        this.headers['X-JWT-Authorization'] = `Token ${jwt}`;
+        headers['X-JWT-Authorization'] = `Token ${jwt}`;
       }
     }
+
+    return headers;
   }
 
   get host() {


### PR DESCRIPTION
This ensures it will react to changes that happen after this adapter is
constructed.