### PR TITLE
Allow multiple ember-get-config versions

### DIFF
--- a/tests/dummy/config/dependency-lint.js
+++ b/tests/dummy/config/dependency-lint.js
@@ -3,6 +3,7 @@
 
 module.exports = {
   allowedVersions: {
-    'ember-in-element-polyfill': '*'
+    'ember-in-element-polyfill': '*',
+    'ember-get-config': '0.2.4 || 0.3.0',
   }
 };


### PR DESCRIPTION
No API difference between these versions, while we await a 1.0 release
we can just accept them both.