### PR TITLE
A Few Less Moments

### DIFF
--- a/addon-mirage-support/factories/userevent.js
+++ b/addon-mirage-support/factories/userevent.js
@@ -9,4 +9,5 @@ export default Factory.extend({
   courseObjectives: [],
   prerequisites: [],
   postrequisites: [],
+  color: '#ffffff',
 });

--- a/addon/components/course-materials.hbs
+++ b/addon/components/course-materials.hbs
@@ -204,7 +204,7 @@
               </td>
               <td>
                 {{#if lmObject.firstOfferingDate}}
-                  {{moment-format lmObject.firstOfferingDate "L"}}
+                  {{format-date lmObject.firstOfferingDate}}
                 {{else}}
                   {{t "general.none"}}
                 {{/if}}

--- a/addon/components/course-summary-header.hbs
+++ b/addon/components/course-summary-header.hbs
@@ -46,7 +46,7 @@
         {{t "general.startDate"}}:
       </label>
       <span>
-        {{moment-format @course.startDate "L"}}
+        {{format-date @course.startDate}}
       </span>
     </div>
     <div class="block">
@@ -62,7 +62,7 @@
         {{t "general.endDate"}}:
       </label>
       <span>
-        {{moment-format @course.endDate "L"}}
+        {{format-date @course.endDate}}
       </span>
     </div>
     <div class="block">

--- a/addon/components/daily-calendar-event.hbs
+++ b/addon/components/daily-calendar-event.hbs
@@ -30,11 +30,11 @@
     {{#if this.isIlm}}
       <span class="ilios-calendar-event-start">
         {{t "general.ilmDue"}}:
-        {{moment-format @event.startDate "h:mma"}}
+        {{format-date @event.startDate hour12=true hour="numeric" minute="numeric"}}
       </span>
     {{else}}
       <span class="ilios-calendar-event-start">
-        {{moment-format @event.startDate "h:mma"}}
+        {{format-date @event.startDate hour12=true hour="numeric" minute="numeric"}}
       </span>
     {{/if}}
   </span>

--- a/addon/components/daily-calendar.hbs
+++ b/addon/components/daily-calendar.hbs
@@ -4,7 +4,7 @@
 >
   <h2 class="day-of-week" data-test-day-of-week>
     <span class="short" data-test-short>
-      {{moment-format @date "l"}}
+      {{format-date @date}}
     </span>
     <span class="long" data-test-long>{{moment-format @date "dddd LL"}}</span>
   </h2>

--- a/addon/components/daily-calendar.hbs
+++ b/addon/components/daily-calendar.hbs
@@ -6,7 +6,7 @@
     <span class="short" data-test-short>
       {{format-date @date}}
     </span>
-    <span class="long" data-test-long>{{moment-format @date "dddd LL"}}</span>
+    <span class="long" data-test-long>{{format-date @date weekday="long" month="long" day="numeric" year="numeric"}}</span>
   </h2>
 
   <div

--- a/addon/components/dashboard-agenda.hbs
+++ b/addon/components/dashboard-agenda.hbs
@@ -84,8 +84,7 @@
                           {{t "general.dueBy"}}:
                         </span>
                       {{/if}}
-                      {{moment-format event.startDate "dddd, MMMM Do, YYYY h:mma"
-                      }}
+                      {{format-date event.startDate month="long" weekday="long" day="numeric" year="numeric" hour12=true hour="numeric" minute="numeric"}}
                     </LinkTo>
                   </td>
                   <td colspan="4">

--- a/addon/components/dashboard-agenda.hbs
+++ b/addon/components/dashboard-agenda.hbs
@@ -28,7 +28,7 @@
                         {{t "general.dueBy"}}
                       </span>
                     {{/if}}
-                    {{moment-format event.startDate "dddd, MMMM Do, YYYY h:mma"}}
+                    {{format-date event.startDate month="long" weekday="long" day="numeric" year="numeric" hour12=true hour="numeric" minute="numeric"}}
                   </td>
                   <td colspan="4">
                     {{#if event.ilmSession}}

--- a/addon/components/dashboard-materials.hbs
+++ b/addon/components/dashboard-materials.hbs
@@ -109,7 +109,7 @@
               </td>
               <td>
                 {{#if lmObject.firstOfferingDate}}
-                  {{moment-format lmObject.firstOfferingDate "L"}}
+                  {{format-date lmObject.firstOfferingDate}}
                 {{else}}
                   {{t "general.none"}}
                 {{/if}}

--- a/addon/components/ilios-calendar-event-month.hbs
+++ b/addon/components/ilios-calendar-event-month.hbs
@@ -24,11 +24,11 @@
     {{/if}}
     <span class="ilios-calendar-event-time">
       <span class="ilios-calendar-event-start">
-        {{moment-format @event.startDate "h:mma"}}
+        {{format-date @event.startDate  hour12=true hour="numeric" minute="numeric"}}
       </span>
       <span class="ilios-calendar-event-end">
         -
-        {{moment-format @event.endDate "h:mma"}}
+        {{format-date @event.endDate  hour12=true hour="numeric" minute="numeric"}}
       </span>
     </span>
     {{#unless @event.isMulti}}

--- a/addon/components/ilios-calendar-multiday-event.hbs
+++ b/addon/components/ilios-calendar-multiday-event.hbs
@@ -1,7 +1,7 @@
 <li>
-  {{moment-format @event.startDate "M/D/YY h:mma"}}
+  {{format-date @event.startDate month="numeric" day="numeric" year="2-digit" hour="numeric" minute="numeric"}}
   &ndash;
-  {{moment-format @event.endDate "M/D/YY h:mma"}}
+  {{format-date @event.endDate month="numeric" day="numeric" year="2-digit" hour="numeric" minute="numeric"}}
   <span
     class={{if (and this.clickable @isEventSelectable) "clickable"}}
     role="button"

--- a/addon/components/learningmaterial-manager.hbs
+++ b/addon/components/learningmaterial-manager.hbs
@@ -241,7 +241,7 @@
               @action={{fn this.updateTime "startDate"}}
             />
           {{else}}
-            {{moment-format this.startDate "h:mm a"}}
+            {{format-date this.startDate  hour12=true hour="numeric" minute="numeric"}}
           {{/if}}
         </div>
         {{#if @editable}}
@@ -285,7 +285,7 @@
               @action={{fn this.updateTime "endDate"}}
             />
           {{else}}
-            {{moment-format this.endDate "h:mm a"}}
+            {{format-date this.endDate  hour12=true hour="numeric" minute="numeric"}}
           {{/if}}
         </div>
         {{#each (await (compute (fn this.getErrorsFor) "endDate")) as |message|}}

--- a/addon/components/learningmaterial-manager.hbs
+++ b/addon/components/learningmaterial-manager.hbs
@@ -209,7 +209,7 @@
         {{t "general.uploadDate"}}:
       </label>
       <span class="upload-date">
-        {{moment-format this.uploadDate "M-D-YYYY"}}
+        {{format-date this.uploadDate}}
       </span>
     </div>
     <label>

--- a/addon/components/learningmaterial-manager.hbs
+++ b/addon/components/learningmaterial-manager.hbs
@@ -228,7 +228,7 @@
               @change={{fn this.updateDate "startDate"}}
             />
           {{else}}
-            {{moment-format this.startDate "L"}}
+            {{format-date this.startDate}}
           {{/if}}
         </div>
         <div class="item start-time">
@@ -272,7 +272,7 @@
               @change={{fn this.updateDate "endDate"}}
             />
           {{else}}
-            {{moment-format this.endDate "L"}}
+            {{format-date this.endDate}}
           {{/if}}
         </div>
         <div class="item end-time">

--- a/addon/components/learningmaterial-search.hbs
+++ b/addon/components/learningmaterial-search.hbs
@@ -54,7 +54,7 @@
             {{/if}}
             <li>
               {{t "general.uploadDate"}}:
-              {{moment-format learningMaterial.uploadDate "M-D-YYYY"}}
+              {{format-date learningMaterial.uploadDate}}
             </li>
           </ul>
         </li>

--- a/addon/components/monthly-calendar.hbs
+++ b/addon/components/monthly-calendar.hbs
@@ -1,5 +1,5 @@
 <section class="monthly-calendar" data-test-monthly-calendar>
-  <h2 class="month-year">{{moment-format this.firstDayOfMonth "MMMM YYYY"}}</h2>
+  <h2 class="month-year">{{format-date this.firstDayOfMonth month="long" year="numeric"}}</h2>
   <div class="calendar">
     {{#each this.days as |day|}}
       <div class="day week-{{day.weekOfMonth}} day-{{day.dayOfWeek}}" data-test-day>

--- a/addon/components/my-materials.hbs
+++ b/addon/components/my-materials.hbs
@@ -157,7 +157,7 @@
               </td>
               <td data-test-date>
                 {{#if lmObject.firstOfferingDate}}
-                  {{moment-format lmObject.firstOfferingDate "L"}}
+                  {{format-date lmObject.firstOfferingDate}}
                 {{else}}
                   {{t "general.none"}}
                 {{/if}}

--- a/addon/components/offering-form.hbs
+++ b/addon/components/offering-form.hbs
@@ -123,7 +123,7 @@
         </label>
         {{#if this.endDate}}
           <div class="text">
-            {{moment-format this.endDate "M/D/YYYY h:mm a"}}
+            {{format-date this.endDate month="numeric" day="numeric" year="numeric" hour="numeric" minute="numeric"}}
           </div>
         {{/if}}
       </div>

--- a/addon/components/print-course.hbs
+++ b/addon/components/print-course.hbs
@@ -426,9 +426,9 @@
               {{#each (await session.offerings) as |offering|}}
                 <tr>
                   <td class="text-left">
-                    {{moment-format offering.startDate "L LT"}}
+                    {{format-date offering.startDate month="numeric" day="numeric" year="numeric"  hour12=true hour="numeric" minute="numeric"}}
                     -
-                    {{moment-format offering.endDate "L LT"}}
+                    {{format-date offering.endDate month="numeric" day="numeric" year="numeric"  hour12=true hour="numeric" minute="numeric"}}
                   </td>
                   <td class="text-left">
                     {{offering.room}}

--- a/addon/components/print-course.hbs
+++ b/addon/components/print-course.hbs
@@ -23,7 +23,7 @@
           {{t "general.start"}}:
         </label>
         <div>
-          {{moment-format @course.startDate "L"}}
+          {{format-date @course.startDate}}
         </div>
       </div>
       <div class="inline-label-data-block">
@@ -47,7 +47,7 @@
           {{t "general.end"}}:
         </label>
         <div>
-          {{moment-format @course.endDate "L"}}
+          {{format-date @course.endDate}}
         </div>
       </div>
       <br>
@@ -394,7 +394,7 @@
                   {{get (await session.ilmSession) "hours"}}
                 </td>
                 <td>
-                  {{moment-format (get (await session.ilmSession) "dueDate") "L"}}
+                  {{format-date (get (await session.ilmSession) "dueDate")}}
                 </td>
               </tr>
             </tbody>

--- a/addon/components/session-overview.hbs
+++ b/addon/components/session-overview.hbs
@@ -207,7 +207,7 @@
               {{#if (is-fulfilled @session.ilmSession)}}
                 {{#if @editable}}
                   <EditableField
-                    @value={{moment-format @session.ilmSession.dueDate "L"}}
+                    @value={{format-date @session.ilmSession.dueDate}}
                     @save={{this.changeIlmDueDate}}
                     @close={{this.revertIlmDueDateChanges}}
                   >
@@ -222,7 +222,7 @@
                     {{/each}}
                   </EditableField>
                 {{else}}
-                  {{moment-format @session.ilmSession.dueDate "L"}}
+                  {{format-date @session.ilmSession.dueDate}}
                 {{/if}}
               {{/if}}
             </span>

--- a/addon/components/session/postrequisite-editor.hbs
+++ b/addon/components/session/postrequisite-editor.hbs
@@ -59,7 +59,7 @@
             <td colspan="3">
               {{#if (await postrequisite.firstOfferingDate)}}
                 {{#if postrequisite.ilmSession}}
-                  <strong>{{t "general.ilm"}}: {{t "general.dueBy"}}</strong> {{moment-format (await postrequisite.firstOfferingDate) "L"}}
+                  <strong>{{t "general.ilm"}}: {{t "general.dueBy"}}</strong> {{format-date (await postrequisite.firstOfferingDate)}}
                 {{else}}
                   {{moment-format (await postrequisite.firstOfferingDate) "L LT"}}
                 {{/if}}

--- a/addon/components/session/postrequisite-editor.hbs
+++ b/addon/components/session/postrequisite-editor.hbs
@@ -61,7 +61,7 @@
                 {{#if postrequisite.ilmSession}}
                   <strong>{{t "general.ilm"}}: {{t "general.dueBy"}}</strong> {{format-date (await postrequisite.firstOfferingDate)}}
                 {{else}}
-                  {{moment-format (await postrequisite.firstOfferingDate) "L LT"}}
+                  {{format-date (await postrequisite.firstOfferingDate) month="numeric" day="numeric" year="numeric"  hour12=true hour="numeric" minute="numeric"}}
                 {{/if}}
               {{/if}}
             </td>

--- a/addon/components/sessions-grid.hbs
+++ b/addon/components/sessions-grid.hbs
@@ -68,10 +68,7 @@
                   {{t "general.ilm"}}:
                   {{t "general.dueBy"}}
                 </strong>
-                {{moment-format
-                  (await obj.session.firstOfferingDate) "MM/DD/YYYY"
-                  allow-empty=true
-                }}
+                {{format-date (await obj.session.firstOfferingDate)}}
               {{/if}}
             {{else if obj.postrequisite}}
               <strong>

--- a/addon/components/sessions-grid.hbs
+++ b/addon/components/sessions-grid.hbs
@@ -85,7 +85,7 @@
                 {{truncate obj.postrequisite.title 18 true}}
               </LinkTo>
             {{else}}
-              {{moment-format (await obj.session.firstOfferingDate) "L LT" allow-empty=true}}
+              {{format-date (await obj.session.firstOfferingDate) month="numeric" day="numeric" year="numeric"  hour12=true hour="numeric" minute="numeric"}}
             {{/if}}
           {{/if}}
         </span>

--- a/addon/components/single-event.hbs
+++ b/addon/components/single-event.hbs
@@ -20,12 +20,12 @@
           <p>
             {{t "general.dueBefore"}}
             <a href={{this.postrequisiteLink}}>{{get (object-at 0 @event.postrequisites) "name"}}</a>
-            ({{moment-format (get (object-at 0 @event.postrequisites) "startDate") "dddd, MMMM Do YYYY, h:mm a"}})
+            ({{format-date (get (object-at 0 @event.postrequisites) "startDate") month="long" weekday="long" day="numeric" year="numeric" hour12=true hour="numeric" minute="numeric"}})
           </p>
         {{/if}}
         {{#unless @event.ilmSession}}
           <p>
-            {{moment-format @event.startDate "dddd, MMMM Do YYYY, h:mm a"}}
+            {{format-date @event.startDate month="long" weekday="long" day="numeric" year="numeric" hour12=true hour="numeric" minute="numeric"}}
           </p>
         {{/unless}}
       </div>

--- a/addon/components/timed-release-schedule.hbs
+++ b/addon/components/timed-release-schedule.hbs
@@ -2,18 +2,18 @@
   {{#if (and @startDate @endDate)}}
     ({{t
       "general.timedReleaseStartAndEndDate"
-      startDate=(moment-format @startDate "L LT")
-      endDate=(moment-format @endDate "L LT")
+      startDate=(format-date @startDate month="numeric" day="numeric" year="numeric"  hour12=true hour="numeric" minute="numeric")
+      endDate=(format-date @endDate month="numeric" day="numeric" year="numeric"  hour12=true hour="numeric" minute="numeric")
     }})
   {{/if}}
   {{#if (and @startDate (not @endDate) this.startDateInTheFuture)}}
     ({{t
       "general.timedReleaseOnlyStartDate"
-      startDate=(moment-format @startDate "L LT")
+      startDate=(format-date @startDate month="numeric" day="numeric" year="numeric"  hour12=true hour="numeric" minute="numeric")
     }})
   {{/if}}
   {{#if (and @endDate (not @startDate))}}
-    ({{t "general.timedReleaseOnlyEndDate" endDate=(moment-format @endDate "L LT")}})
+    ({{t "general.timedReleaseOnlyEndDate" endDate=(format-date @endDate month="numeric" day="numeric" year="numeric"  hour12=true hour="numeric" minute="numeric")}})
   {{/if}}
   {{#if (and (not @startDate) (not @endDate) this.showNoSchedule)}}
     {{t "general.timedReleaseNoSchedule"}}

--- a/addon/components/week-glance-event.hbs
+++ b/addon/components/week-glance-event.hbs
@@ -18,7 +18,7 @@
           {{t "general.dueBy"}}
         </span>
       {{/if}}
-      {{moment-format @event.startDate "dddd h:mma"}}
+      {{format-date @event.startDate weekday="long" hour="numeric" minute="numeric"}}
     </span>
   </h3>
   {{#if @event.prerequisites.length}}

--- a/addon/components/weekly-calendar-event.hbs
+++ b/addon/components/weekly-calendar-event.hbs
@@ -30,11 +30,11 @@
     {{#if this.isIlm}}
       <span class="ilios-calendar-event-start">
         {{t "general.ilmDue"}}:
-        {{moment-format @event.startDate "h:mma"}}
+        {{format-date @event.startDate  hour12=true hour="numeric" minute="numeric"}}
       </span>
     {{else}}
       <span class="ilios-calendar-event-start">
-        {{moment-format @event.startDate "h:mma"}}
+        {{format-date @event.startDate  hour12=true hour="numeric" minute="numeric"}}
       </span>
     {{/if}}
   </span>

--- a/addon/components/weekly-calendar.hbs
+++ b/addon/components/weekly-calendar.hbs
@@ -8,7 +8,7 @@
       {{format-date this.lastDayOfWeek month="numeric" day="numeric"}}
       {{format-date this.lastDayOfWeek year="numeric"}}
     </span>
-    <span class="long" data-test-long>{{t "general.weekOf" date=(moment-format this.firstDayOfWeek "MMMM Do YYYY")}}</span>
+    <span class="long" data-test-long>{{t "general.weekOf" date=(format-date this.firstDayOfWeek month="long" day="numeric" year="numeric")}}</span>
   </h2>
 
   <div
@@ -32,7 +32,7 @@
             type="button"
             {{on "click" (fn @changeToDayView day.date)}}
           >
-            {{moment-format day.date "dddd"}}
+            {{format-date day.date weekday="long"}}
           </button>
         </h3>
         {{#each day.events as |event|}}
@@ -60,10 +60,10 @@
           data-test-day
           aria-label={{day.longName}}
         >
-          <span class="long">{{moment-format day.date "dddd"}}</span>
-          <span class="short">{{moment-format day.date "ddd"}}</span>
-          <span class="long">{{moment-format day.date "MMM Do"}}</span>
-          <span class="short">{{moment-format day.date "Do"}}</span>
+          <span class="long">{{format-date day.date weekday="long"}}</span>
+          <span class="short">{{format-date day.date weekday="short"}}</span>
+          <span class="long">{{format-date day.date month="short" day="numeric"}}</span>
+          <span class="short">{{format-date day.date day="numeric"}}</span>
         </button>
       </div>
     {{/each}}

--- a/addon/components/weekly-calendar.hbs
+++ b/addon/components/weekly-calendar.hbs
@@ -4,9 +4,9 @@
 >
   <h2 class="week-of-year" data-test-week-of-year>
     <span class="short" data-test-short>
-      {{moment-format this.firstDayOfWeek "M/D"}} &mdash;
-      {{moment-format this.lastDayOfWeek "M/D"}}
-      {{moment-format this.lastDayOfWeek "YYYY"}}
+      {{format-date this.firstDayOfWeek month="numeric" day="numeric"}} &mdash;
+      {{format-date this.lastDayOfWeek month="numeric" day="numeric"}}
+      {{format-date this.lastDayOfWeek year="numeric"}}
     </span>
     <span class="long" data-test-long>{{t "general.weekOf" date=(moment-format this.firstDayOfWeek "MMMM Do YYYY")}}</span>
   </h2>

--- a/tests/acceptance/course/learningmaterials-test.js
+++ b/tests/acceptance/course/learningmaterials-test.js
@@ -7,6 +7,7 @@ import moment from 'moment';
 import { currentRouteName } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setupIntl } from 'ember-intl/test-support';
 import page from 'ilios-common/page-objects/course';
 
 const today = moment();
@@ -14,6 +15,7 @@ const today = moment();
 module('Acceptance | Course - Learning Materials', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+  setupIntl(hooks, 'en-us');
 
   hooks.beforeEach(async function () {
     this.school = this.server.create('school');
@@ -290,7 +292,7 @@ module('Acceptance | Course - Learning Materials', function(hooks) {
       assert.equal(page.learningMaterials.manager.name.value, 'learning material 1');
       assert.equal(page.learningMaterials.manager.author, 'Jennifer Johnson');
       assert.equal(await page.learningMaterials.manager.description.editorValue(), '<p>1 lm description</p>');
-      assert.equal(page.learningMaterials.manager.uploadDate, moment('2011-03-14').format('M-D-YYYY'));
+      assert.equal(page.learningMaterials.manager.uploadDate, '3/14/2011');
       assert.ok(page.learningMaterials.manager.hasFile);
       assert.equal(page.learningMaterials.manager.downloadText, 'filename');
       assert.equal(page.learningMaterials.manager.downloadUrl, 'http://example.com/file');
@@ -307,7 +309,7 @@ module('Acceptance | Course - Learning Materials', function(hooks) {
       assert.equal(page.learningMaterials.manager.name.value, 'learning material 2');
       assert.equal(page.learningMaterials.manager.author, 'Hunter Pence');
       assert.equal(await page.learningMaterials.manager.description.editorValue(), '<p>2 lm description</p>');
-      assert.equal(page.learningMaterials.manager.uploadDate, today.format('M-D-YYYY'));
+      assert.equal(page.learningMaterials.manager.uploadDate, today.toDate().toLocaleDateString());
       assert.ok(page.learningMaterials.manager.hasLink);
       assert.equal(page.learningMaterials.manager.link, 'www.example.com');
 
@@ -326,7 +328,7 @@ module('Acceptance | Course - Learning Materials', function(hooks) {
       assert.equal(page.learningMaterials.manager.name.value, 'learning material 3');
       assert.equal(page.learningMaterials.manager.author, 'Willie Mays');
       assert.equal(await page.learningMaterials.manager.description.editorValue(), '<p>3 lm description</p>');
-      assert.equal(page.learningMaterials.manager.uploadDate, moment('2016-12-12').format('M-D-YYYY'));
+      assert.equal(page.learningMaterials.manager.uploadDate, '12/12/2016');
       assert.ok(page.learningMaterials.manager.hasCitation);
       assert.equal(page.learningMaterials.manager.citation, 'a citation');
 
@@ -493,7 +495,7 @@ module('Acceptance | Course - Learning Materials', function(hooks) {
       assert.equal(page.learningMaterials.search.searchResults[0].properties.length, 3);
       assert.equal(page.learningMaterials.search.searchResults[0].properties[0].value, 'Owner: 0 guy M. Mc0son');
       assert.equal(page.learningMaterials.search.searchResults[0].properties[1].value, 'Content Author: ' + 'Marty McFly');
-      assert.equal(page.learningMaterials.search.searchResults[0].properties[2].value, 'Upload date: ' + moment('2016-03-03').format('M-D-YYYY'));
+      assert.equal(page.learningMaterials.search.searchResults[0].properties[2].value, 'Upload date: 3/3/2016');
       await page.learningMaterials.search.searchResults[0].add();
       assert.equal(page.learningMaterials.current.length, 5);
     });
@@ -513,7 +515,14 @@ module('Acceptance | Course - Learning Materials', function(hooks) {
       await page.learningMaterials.manager.save();
       assert.ok(page.learningMaterials.current[0].isTimedRelease);
       await page.learningMaterials.current[0].details();
-      assert.equal(page.learningMaterials.manager.timedReleaseSummary, '(Available: ' + newDate.format('L LT') + ')');
+      const formattedNewDate = newDate.toDate().toLocaleString('en-us', {
+        month: 'numeric',
+        day: 'numeric',
+        year: 'numeric',
+        hour: 'numeric',
+        minute: 'numeric',
+      });
+      assert.equal(page.learningMaterials.manager.timedReleaseSummary, `(Available: ${formattedNewDate})`);
     });
 
     test('add timed release start and end date', async function (assert) {
@@ -540,9 +549,21 @@ module('Acceptance | Course - Learning Materials', function(hooks) {
       await page.learningMaterials.manager.save();
       assert.ok(page.learningMaterials.current[0].isTimedRelease);
       await page.learningMaterials.current[0].details();
-      const formatedStartDate = newStartDate.locale('en').format('L LT');
-      const formatedEndDate = newEndDate.locale('en').format('L LT');
-      assert.equal(page.learningMaterials.manager.timedReleaseSummary, '(Available: ' + formatedStartDate + ' and available until ' + formatedEndDate + ')');
+      const formattedStartDate = newStartDate.toDate().toLocaleString('en', {
+        month: 'numeric',
+        day: 'numeric',
+        year: 'numeric',
+        hour: 'numeric',
+        minute: 'numeric',
+      });
+      const formattedEndDate = newEndDate.toDate().toLocaleString('en', {
+        month: 'numeric',
+        day: 'numeric',
+        year: 'numeric',
+        hour: 'numeric',
+        minute: 'numeric',
+      });
+      assert.equal(page.learningMaterials.manager.timedReleaseSummary, `(Available: ${formattedStartDate} and available until ${formattedEndDate})`);
     });
 
     test('add timed release end date', async function (assert) {
@@ -560,7 +581,14 @@ module('Acceptance | Course - Learning Materials', function(hooks) {
       await page.learningMaterials.manager.save();
       assert.ok(page.learningMaterials.current[0].isTimedRelease);
       await page.learningMaterials.current[0].details();
-      assert.equal(page.learningMaterials.manager.timedReleaseSummary, '(Available until ' + newDate.format('L LT') + ')');
+      const formattedNewDate = newDate.toDate().toLocaleString('en-us', {
+        month: 'numeric',
+        day: 'numeric',
+        year: 'numeric',
+        hour: 'numeric',
+        minute: 'numeric',
+      });
+      assert.equal(page.learningMaterials.manager.timedReleaseSummary, `(Available until ${formattedNewDate})`);
     });
 
     test('end date is after start date', async function (assert) {
@@ -586,8 +614,14 @@ module('Acceptance | Course - Learning Materials', function(hooks) {
       await page.learningMaterials.manager.save();
 
       assert.ok(page.learningMaterials.manager.hasEndDateValidationError);
-      const formatedDate = newDate.locale('en').format('L LT');
-      assert.equal(page.learningMaterials.manager.timedReleaseSummary, `(Available: ${formatedDate} and available until ${formatedDate})`);
+      const formattedDate = newDate.toDate().toLocaleString('en-us', {
+        month: 'numeric',
+        day: 'numeric',
+        year: 'numeric',
+        hour: 'numeric',
+        minute: 'numeric',
+      });
+      assert.equal(page.learningMaterials.manager.timedReleaseSummary, `(Available: ${formattedDate} and available until ${formattedDate})`);
     });
 
     test('edit learning material with no other links #3617', async function (assert) {

--- a/tests/acceptance/course/session/learningmaterials-test.js
+++ b/tests/acceptance/course/session/learningmaterials-test.js
@@ -7,6 +7,7 @@ import moment from 'moment';
 import { currentRouteName } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setupIntl } from 'ember-intl/test-support';
 import page from 'ilios-common/page-objects/session';
 
 const today = moment();
@@ -14,6 +15,7 @@ const today = moment();
 module('Acceptance | Session - Learning Materials', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+  setupIntl(hooks, 'en-us');
   hooks.beforeEach(async function () {
     this.school = this.server.create('school');
     this.user = await setupAuthentication({ school: this.school });
@@ -288,7 +290,7 @@ module('Acceptance | Session - Learning Materials', function(hooks) {
       assert.equal(page.learningMaterials.manager.nameValue, 'learning material 1');
       assert.equal(page.learningMaterials.manager.author, 'Jennifer Johnson');
       assert.equal(page.learningMaterials.manager.description.value, '1 lm description');
-      assert.equal(page.learningMaterials.manager.uploadDate, moment('2011-03-14').format('M-D-YYYY'));
+      assert.equal(page.learningMaterials.manager.uploadDate, '3/14/2011');
       assert.ok(page.learningMaterials.manager.hasFile);
       assert.equal(page.learningMaterials.manager.downloadText, 'filename');
       assert.equal(page.learningMaterials.manager.downloadUrl, 'http://example.com/file');
@@ -304,7 +306,7 @@ module('Acceptance | Session - Learning Materials', function(hooks) {
       assert.equal(page.learningMaterials.manager.nameValue, 'learning material 2');
       assert.equal(page.learningMaterials.manager.author, 'Hunter Pence');
       assert.equal(page.learningMaterials.manager.description.value, '2 lm description');
-      assert.equal(page.learningMaterials.manager.uploadDate, today.format('M-D-YYYY'));
+      assert.equal(page.learningMaterials.manager.uploadDate, today.toDate().toLocaleDateString());
       assert.ok(page.learningMaterials.manager.hasLink);
       assert.equal(page.learningMaterials.manager.link, 'www.example.com');
 
@@ -322,7 +324,7 @@ module('Acceptance | Session - Learning Materials', function(hooks) {
       assert.equal(page.learningMaterials.manager.nameValue, 'learning material 3');
       assert.equal(page.learningMaterials.manager.author, 'Willie Mays');
       assert.equal(page.learningMaterials.manager.description.value, '3 lm description');
-      assert.equal(page.learningMaterials.manager.uploadDate, moment('2016-12-12').format('M-D-YYYY'));
+      assert.equal(page.learningMaterials.manager.uploadDate, '12/12/2016');
       assert.ok(page.learningMaterials.manager.hasCitation);
       assert.equal(page.learningMaterials.manager.citation, 'a citation');
 
@@ -491,7 +493,7 @@ module('Acceptance | Session - Learning Materials', function(hooks) {
       assert.equal(page.learningMaterials.search.searchResults[0].properties.length, 3);
       assert.equal(page.learningMaterials.search.searchResults[0].properties[0].value, 'Owner: 0 guy M. Mc0son');
       assert.equal(page.learningMaterials.search.searchResults[0].properties[1].value, 'Content Author: ' + 'Marty McFly');
-      assert.equal(page.learningMaterials.search.searchResults[0].properties[2].value, 'Upload date: ' + moment('2016-03-03').format('M-D-YYYY'));
+      assert.equal(page.learningMaterials.search.searchResults[0].properties[2].value, 'Upload date: 3/3/2016');
       await page.learningMaterials.search.searchResults[0].add();
       assert.equal(page.learningMaterials.current.length, 5);
     });
@@ -511,7 +513,14 @@ module('Acceptance | Session - Learning Materials', function(hooks) {
       await page.learningMaterials.manager.save();
       assert.ok(page.learningMaterials.current[0].isTimedRelease);
       await page.learningMaterials.current[0].details();
-      assert.equal(page.learningMaterials.manager.timedReleaseSummary, '(Available: ' + newDate.format('L LT') + ')');
+      const formattedNewDate = newDate.toDate().toLocaleString('en-us', {
+        month: 'numeric',
+        day: 'numeric',
+        year: 'numeric',
+        hour: 'numeric',
+        minute: 'numeric',
+      });
+      assert.equal(page.learningMaterials.manager.timedReleaseSummary, `(Available: ${formattedNewDate})`);
     });
 
     test('add timed release start and end date', async function (assert) {
@@ -538,9 +547,21 @@ module('Acceptance | Session - Learning Materials', function(hooks) {
       await page.learningMaterials.manager.save();
       assert.ok(page.learningMaterials.current[0].isTimedRelease);
       await page.learningMaterials.current[0].details();
-      const formatedStartDate = newStartDate.locale('en').format('L LT');
-      const formatedEndDate = newEndDate.locale('en').format('L LT');
-      assert.equal(page.learningMaterials.manager.timedReleaseSummary, '(Available: ' + formatedStartDate + ' and available until ' + formatedEndDate + ')');
+      const formattedStartDate = newStartDate.toDate().toLocaleString('en', {
+        month: 'numeric',
+        day: 'numeric',
+        year: 'numeric',
+        hour: 'numeric',
+        minute: 'numeric',
+      });
+      const formattedEndDate = newEndDate.toDate().toLocaleString('en', {
+        month: 'numeric',
+        day: 'numeric',
+        year: 'numeric',
+        hour: 'numeric',
+        minute: 'numeric',
+      });
+      assert.equal(page.learningMaterials.manager.timedReleaseSummary, `(Available: ${formattedStartDate} and available until ${formattedEndDate})`);
     });
 
     test('add timed release end date', async function (assert) {
@@ -558,7 +579,14 @@ module('Acceptance | Session - Learning Materials', function(hooks) {
       await page.learningMaterials.manager.save();
       assert.ok(page.learningMaterials.current[0].isTimedRelease);
       await page.learningMaterials.current[0].details();
-      assert.equal(page.learningMaterials.manager.timedReleaseSummary, '(Available until ' + newDate.format('L LT') + ')');
+      const formattedNewDate = newDate.toDate().toLocaleString('en-us', {
+        month: 'numeric',
+        day: 'numeric',
+        year: 'numeric',
+        hour: 'numeric',
+        minute: 'numeric',
+      });
+      assert.equal(page.learningMaterials.manager.timedReleaseSummary, `(Available until ${formattedNewDate})`);
     });
 
     test('end date is after start date', async function (assert) {
@@ -584,8 +612,14 @@ module('Acceptance | Session - Learning Materials', function(hooks) {
       await page.learningMaterials.manager.save();
 
       assert.ok(page.learningMaterials.manager.hasEndDateValidationError);
-      const formatedDate = newDate.locale('en').format('L LT');
-      assert.equal(page.learningMaterials.manager.timedReleaseSummary, `(Available: ${formatedDate} and available until ${formatedDate})`);
+      const formattedDate = newDate.toDate().toLocaleString('en-us', {
+        month: 'numeric',
+        day: 'numeric',
+        year: 'numeric',
+        hour: 'numeric',
+        minute: 'numeric',
+      });
+      assert.equal(page.learningMaterials.manager.timedReleaseSummary, `(Available: ${formattedDate} and available until ${formattedDate})`);
     });
 
     test('edit learning material with no other links #3617', async function (assert) {

--- a/tests/acceptance/course/session/overview-test.js
+++ b/tests/acceptance/course/session/overview-test.js
@@ -115,11 +115,11 @@ module('Acceptance | Session - Overview', function(hooks) {
     await page.visit({ courseId: 1, sessionId: 1 });
 
     assert.equal(currentRouteName(), 'session.index');
-    assert.equal(page.overview.ilmDueDate.value, moment(ilmSession.dueDate).format('L'));
+    assert.equal(page.overview.ilmDueDate.value, new Date(ilmSession.dueDate).toLocaleDateString('en'));
     await page.overview.ilmDueDate.edit();
     await page.overview.ilmDueDate.set(newDate.toDate());
     await page.overview.ilmDueDate.save();
-    assert.equal(page.overview.ilmDueDate.value, newDate.locale('en').format('L'));
+    assert.equal(page.overview.ilmDueDate.value, newDate.toDate().toLocaleDateString('en'));
   });
 
   test('change title', async function(assert) {

--- a/tests/acceptance/course/sessionlist-test.js
+++ b/tests/acceptance/course/sessionlist-test.js
@@ -70,7 +70,13 @@ module('Acceptance | Course - Session List', function(hooks) {
     assert.equal(sessions[0].groupCount, '0');
     assert.equal(sessions[0].objectiveCount, '0');
     assert.equal(sessions[0].termCount, '0');
-    assert.equal(sessions[0].firstOffering, today.format('L LT'));
+    assert.equal(sessions[0].firstOffering, today.toDate().toLocaleString('en', {
+      month: 'numeric',
+      day: 'numeric',
+      year: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+    }));
     assert.equal(sessions[0].offeringCount, '3');
     assert.notOk(sessions[0].hasInstructionalNotes);
     assert.notOk(sessions[0].hasPrerequisites);
@@ -308,7 +314,13 @@ module('Acceptance | Course - Session List', function(hooks) {
     const { offerings } = sessions[0].offerings;
 
     assert.equal(sessions.length, 4);
-    assert.equal(sessions[0].firstOffering, today.format('L LT'));
+    assert.equal(sessions[0].firstOffering, today.toDate().toLocaleString('en', {
+      month: 'numeric',
+      day: 'numeric',
+      year: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+    }));
     await sessions[0].expandCollapse();
     await offerings[0].edit();
     const { offeringForm: form } = offerings[0];
@@ -319,7 +331,13 @@ module('Acceptance | Course - Session List', function(hooks) {
     await form.startTime.ampm(newDate.format('a'));
     await form.save();
 
-    assert.equal(sessions[0].firstOffering, newDate.format('L LT'));
+    assert.equal(sessions[0].firstOffering, newDate.toDate().toLocaleString('en', {
+      month: 'numeric',
+      day: 'numeric',
+      year: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+    }));
 
   });
 
@@ -372,7 +390,13 @@ module('Acceptance | Course - Session List', function(hooks) {
     const { offerings } = sessions[0].offerings;
 
     assert.equal(sessions.length, 4);
-    assert.equal(sessions[0].firstOffering, today.format('L LT'));
+    assert.equal(sessions[0].firstOffering, today.toDate().toLocaleString('en', {
+      month: 'numeric',
+      day: 'numeric',
+      year: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+    }));
     await sessions[0].expandCollapse();
     await offerings[0].edit();
     const { offeringForm: form } = offerings[0];

--- a/tests/integration/components/course-materials-test.js
+++ b/tests/integration/components/course-materials-test.js
@@ -108,17 +108,16 @@ module('Integration | Component | course materials', function(hooks) {
     assert.expect(29);
 
     const course = await setupPage(this);
-    this.set('nothing', parseInt);
     this.setProperties({
       course,
       courseSort: 'title',
       sessionSort: 'firstOfferingDate'
     });
     await render(hbs`<CourseMaterials
-      @course={{course}}
-      @courseSort={{courseSort}}
-      @sessionSort={{sessionSort}}
-      @onSessionSort={{action nothing}}
+      @course={{this.course}}
+      @courseSort={{this.courseSort}}
+      @sessionSort={{this.sessionSort}}
+      @onSessionSort={{noop}}
     />`);
 
     assert.equal(component.courses.length, 3);
@@ -135,7 +134,7 @@ module('Integration | Component | course materials', function(hooks) {
     assert.equal(component.sessions[0].type, 'Link');
     assert.equal(component.sessions[0].author, 'author1');
     assert.equal(component.sessions[0].sessionTitle, 'session1title');
-    assert.equal(component.sessions[0].firstOffering, '02/02/2020');
+    assert.equal(component.sessions[0].firstOffering, '2/2/2020');
 
     assert.equal(component.sessions.length, 3);
     assert.equal(component.sessions[1].title, 'title2');
@@ -144,7 +143,7 @@ module('Integration | Component | course materials', function(hooks) {
     assert.equal(component.sessions[1].type, 'File');
     assert.equal(component.sessions[1].author, 'author2');
     assert.equal(component.sessions[1].sessionTitle, 'session1title');
-    assert.equal(component.sessions[1].firstOffering, '02/02/2020');
+    assert.equal(component.sessions[1].firstOffering, '2/2/2020');
 
     assert.equal(component.sessions.length, 3);
     assert.equal(component.sessions[2].title, 'title3 citationtext');
@@ -152,7 +151,7 @@ module('Integration | Component | course materials', function(hooks) {
     assert.equal(component.sessions[2].type, 'Citation');
     assert.equal(component.sessions[2].author, 'author3');
     assert.equal(component.sessions[2].sessionTitle, 'session1title');
-    assert.equal(component.sessions[2].firstOffering, '02/02/2020');
+    assert.equal(component.sessions[2].firstOffering, '2/2/2020');
   });
 
   test('clicking sort fires action', async function(assert) {

--- a/tests/integration/components/course-summary-header-test.js
+++ b/tests/integration/components/course-summary-header-test.js
@@ -3,7 +3,6 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, findAll } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import moment from 'moment';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | course summary header', function(hooks) {
@@ -55,9 +54,9 @@ module('Integration | Component | course summary header', function(hooks) {
     assert.dom(materialsIcon).hasClass('fa-archive');
     assert.dom(printIcon).hasClass('fa-print');
     assert.dom(rolloverIcon).hasClass('fa-random');
-    assert.dom(start).hasText(moment(course.startDate).format('L'));
+    assert.dom(start).hasText((new Date(course.startDate)).toLocaleDateString());
     assert.dom(externalId).hasText('abc');
-    assert.dom(end).hasText(moment(course.endDate).format('L'));
+    assert.dom(end).hasText((new Date(course.endDate)).toLocaleDateString());
     assert.dom(level).hasText('3');
     assert.dom(status).hasText('Published');
   });

--- a/tests/integration/components/daily-calendar-event-test.js
+++ b/tests/integration/components/daily-calendar-event-test.js
@@ -51,7 +51,7 @@ module('Integration | Component | daily-calendar-event', function(hooks) {
         @allDayEvents={{array this.event}}
       />`);
       assert.dom(s).hasStyle(this.getStyle(97, 12, 50));
-      assert.dom(s).hasText('8:00am event 0');
+      assert.dom(s).hasText('8:00 AM event 0');
     });
 
     test('check event 0', async function (assert) {
@@ -63,7 +63,7 @@ module('Integration | Component | daily-calendar-event', function(hooks) {
       />`);
 
       assert.dom(s).hasStyle(this.getStyle(97, 12, 16));
-      assert.dom(s).hasText('8:00am event 0');
+      assert.dom(s).hasText('8:00 AM event 0');
     });
 
     test('check event 1', async function (assert) {
@@ -75,7 +75,7 @@ module('Integration | Component | daily-calendar-event', function(hooks) {
       />`);
 
       assert.dom(s).hasStyle(this.getStyle(97, 42, 16));
-      assert.dom(s).hasText('8:00am event 1');
+      assert.dom(s).hasText('8:00 AM event 1');
     });
 
     test('check event 2', async function (assert) {
@@ -87,7 +87,7 @@ module('Integration | Component | daily-calendar-event', function(hooks) {
       />`);
 
       assert.dom(s).hasStyle(this.getStyle(99, 22, 16));
-      assert.dom(s).hasText('8:10am event 2');
+      assert.dom(s).hasText('8:10 AM event 2');
     });
 
     test('check event 3', async function (assert) {
@@ -99,7 +99,7 @@ module('Integration | Component | daily-calendar-event', function(hooks) {
       />`);
 
       assert.dom(s).hasStyle(this.getStyle(121, 24, 16));
-      assert.dom(s).hasText('10:00am event 3');
+      assert.dom(s).hasText('10:00 AM event 3');
     });
 
     test('check event 4', async function (assert) {
@@ -111,7 +111,7 @@ module('Integration | Component | daily-calendar-event', function(hooks) {
       />`);
 
       assert.dom(s).hasStyle(this.getStyle(123, 22, 16));
-      assert.dom(s).hasText('10:10am event 4');
+      assert.dom(s).hasText('10:10 AM event 4');
     });
 
     test('check event 5', async function (assert) {
@@ -123,7 +123,7 @@ module('Integration | Component | daily-calendar-event', function(hooks) {
       />`);
 
       assert.dom(s).hasStyle(this.getStyle(145, 12, 50));
-      assert.dom(s).hasText('12:00pm event 5');
+      assert.dom(s).hasText('12:00 PM event 5');
     });
   });
 
@@ -153,7 +153,7 @@ module('Integration | Component | daily-calendar-event', function(hooks) {
       />`);
 
       assert.dom(s).hasStyle(this.getStyle(99, 22, 25));
-      assert.dom(s).hasText('8:10am event 0');
+      assert.dom(s).hasText('8:10 AM event 0');
     });
 
     test('check event 1', async function (assert) {
@@ -165,7 +165,7 @@ module('Integration | Component | daily-calendar-event', function(hooks) {
       />`);
 
       assert.dom(s).hasStyle(this.getStyle(99, 14, 25));
-      assert.dom(s).hasText('8:10am event 1');
+      assert.dom(s).hasText('8:10 AM event 1');
     });
 
     test('check event 2', async function (assert) {
@@ -177,7 +177,7 @@ module('Integration | Component | daily-calendar-event', function(hooks) {
       />`);
 
       assert.dom(s).hasStyle(this.getStyle(117, 10, 25));
-      assert.dom(s).hasText('9:40am event 2');
+      assert.dom(s).hasText('9:40 AM event 2');
     });
 
     test('check event 3', async function (assert) {
@@ -189,7 +189,7 @@ module('Integration | Component | daily-calendar-event', function(hooks) {
       />`);
 
       assert.dom(s).hasStyle(this.getStyle(123, 22, 7));
-      assert.dom(s).hasText('10:10am event 3');
+      assert.dom(s).hasText('10:10 AM event 3');
     });
 
     test('check event 4', async function (assert) {
@@ -201,7 +201,7 @@ module('Integration | Component | daily-calendar-event', function(hooks) {
       />`);
 
       assert.dom(s).hasStyle(this.getStyle(129, 22, 6));
-      assert.dom(s).hasText('10:40am event 4');
+      assert.dom(s).hasText('10:40 AM event 4');
     });
 
     test('check event 5', async function (assert) {
@@ -213,7 +213,7 @@ module('Integration | Component | daily-calendar-event', function(hooks) {
       />`);
 
       assert.dom(s).hasStyle(this.getStyle(129, 22, 6));
-      assert.dom(s).hasText('10:40am event 5');
+      assert.dom(s).hasText('10:40 AM event 5');
     });
 
     test('check event 6', async function (assert) {
@@ -225,7 +225,7 @@ module('Integration | Component | daily-calendar-event', function(hooks) {
       />`);
 
       assert.dom(s).hasStyle(this.getStyle(129, 22, 6));
-      assert.dom(s).hasText('10:40am event 6');
+      assert.dom(s).hasText('10:40 AM event 6');
     });
 
     test('check event 7', async function (assert) {
@@ -237,7 +237,7 @@ module('Integration | Component | daily-calendar-event', function(hooks) {
       />`);
 
       assert.dom(s).hasStyle(this.getStyle(129, 22, 6));
-      assert.dom(s).hasText('10:40am event 7');
+      assert.dom(s).hasText('10:40 AM event 7');
     });
 
     test('check event 8', async function (assert) {
@@ -249,7 +249,7 @@ module('Integration | Component | daily-calendar-event', function(hooks) {
       />`);
 
       assert.dom(s).hasStyle(this.getStyle(129, 22, 6));
-      assert.dom(s).hasText('10:40am event 8');
+      assert.dom(s).hasText('10:40 AM event 8');
     });
 
     test('check event 9', async function (assert) {
@@ -261,7 +261,7 @@ module('Integration | Component | daily-calendar-event', function(hooks) {
       />`);
 
       assert.dom(s).hasStyle(this.getStyle(129, 22, 6));
-      assert.dom(s).hasText('10:40am event 9');
+      assert.dom(s).hasText('10:40 AM event 9');
     });
 
     test('check event 10', async function (assert) {
@@ -273,7 +273,7 @@ module('Integration | Component | daily-calendar-event', function(hooks) {
       />`);
 
       assert.dom(s).hasStyle(this.getStyle(145, 12, 7));
-      assert.dom(s).hasText('12:00pm event 10');
+      assert.dom(s).hasText('12:00 PM event 10');
     });
   });
 });

--- a/tests/integration/components/daily-calendar-test.js
+++ b/tests/integration/components/daily-calendar-test.js
@@ -39,7 +39,7 @@ module('Integration | Component | daily-calendar', function(hooks) {
       @events={{array}}
     />`);
 
-    assert.equal(component.longDayOfWeek, 'Wednesday January 9, 2019');
+    assert.equal(component.longDayOfWeek, 'Wednesday, January 9, 2019');
     assert.equal(component.shortDayOfWeek, '1/9/2019');
 
     await a11yAudit(this.element);
@@ -57,7 +57,7 @@ module('Integration | Component | daily-calendar', function(hooks) {
       @events={{this.events}}
     />`);
 
-    assert.equal(component.longDayOfWeek, 'Wednesday January 9, 2019');
+    assert.equal(component.longDayOfWeek, 'Wednesday, January 9, 2019');
 
     assert.equal(component.events.length, 2);
     assert.equal(component.events[0].name, 'event 0');
@@ -130,7 +130,7 @@ module('Integration | Component | daily-calendar', function(hooks) {
       @selectEvent={{noop}}
     />`);
 
-    assert.equal(component.longDayOfWeek, 'Thursday December 11, 1980');
+    assert.equal(component.longDayOfWeek, 'Thursday, December 11, 1980');
     assert.equal(component.shortDayOfWeek, '12/11/1980');
     assert.equal(component.events.length, 1);
 
@@ -138,7 +138,7 @@ module('Integration | Component | daily-calendar', function(hooks) {
     this.owner.lookup('service:moment').setLocale('es');
     await settled();
 
-    assert.equal(component.longDayOfWeek, 'jueves 11 de diciembre de 1980');
+    assert.equal(component.longDayOfWeek, 'jueves, 11 de diciembre de 1980');
     assert.equal(component.shortDayOfWeek, '11/12/1980');
     assert.equal(component.events.length, 1);
 

--- a/tests/integration/components/dashboard-agenda-test.js
+++ b/tests/integration/components/dashboard-agenda-test.js
@@ -220,25 +220,33 @@ module('Integration | Component | dashboard agenda', function (hooks) {
     this.owner.register('service:user-events', userEventsMock);
     this.userEvents = this.owner.lookup('service:user-events');
 
-    await render(hbs`{{dashboard-agenda}}`);
+    await render(hbs`<DashboardAgenda />`);
     const title = 'h3';
 
     assert.dom(this.element.querySelector(title)).hasText('My Activities for the next 60 days');
     assert.equal(this.element.querySelectorAll('table tr').length, 6);
     for (let i = 0; i < 6; i++) {
       const tds = this.element.querySelectorAll(`table tr:nth-of-type(${i + 1}) td`);
-      assert.dom(tds[0]).hasText(moment(mockEvents[i].startDate).format('dddd, MMMM Do, YYYY h:mma'));
+      assert.dom(tds[0]).hasText((new Date(mockEvents[i].startDate)).toLocaleString([], {
+        weekday: 'long',
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: 'numeric',
+      }));
+      // moment().format('dddd, MMMM Do, YYYY h:mma'));
       assert.dom(tds[1]).hasText(mockEvents[i].name);
     }
     const preworkSelector = '[data-test-ilios-calendar-pre-work-event]';
     assert.equal(this.element.querySelectorAll(preworkSelector).length, 2);
     assert.dom(this.element.querySelector(`${preworkSelector}:nth-of-type(1)`))
       .hasText(
-        'prework 2 Due Before first (' + moment(mockEvents[0].startDate).format('M/D/YYYY') + ')'
+        'prework 2 Due Before first (' + (new Date(mockEvents[0].startDate)).toLocaleDateString() + ')'
       );
     assert.dom(this.element.querySelector(`${preworkSelector}:nth-of-type(2)`))
       .hasText(
-        'prework 1 Due Before third (' + moment(mockEvents[2].startDate).format('M/D/YYYY') + ')'
+        'prework 1 Due Before third (' + (new Date(mockEvents[2].startDate)).toLocaleDateString() + ')'
       );
   });
 
@@ -247,7 +255,7 @@ module('Integration | Component | dashboard agenda', function (hooks) {
     this.owner.register('service:user-events', userEventsMock);
     this.userEvents = this.owner.lookup('service:user-events');
 
-    await render(hbs`{{dashboard-agenda}}`);
+    await render(hbs`<DashboardAgenda />`);
     assert.equal(this.element.querySelectorAll('table tr:nth-of-type(1) td:nth-of-type(4) .fa-black-tie').length, 1);
     assert.equal(this.element.querySelectorAll('table tr:nth-of-type(1) td:nth-of-type(4) .fa-flask').length, 1);
     assert.equal(this.element.querySelectorAll('table tr:nth-of-type(1) td:nth-of-type(4) .fa-calendar-check').length, 1);
@@ -261,7 +269,7 @@ module('Integration | Component | dashboard agenda', function (hooks) {
     this.owner.register('service:user-events', blankEventsMock);
     this.userEvents = this.owner.lookup('service:user-events');
 
-    await render(hbs`{{dashboard-agenda}}`);
+    await render(hbs`<DashboardAgenda />`);
     const title = 'h3';
     const body = 'p';
 

--- a/tests/integration/components/ilios-calendar-event-month-test.js
+++ b/tests/integration/components/ilios-calendar-event-month-test.js
@@ -27,6 +27,6 @@ module('Integration | Component | ilios calendar event month', function(hooks) {
       'border-left-style': 'solid',
       'border-left-color': 'rgb(0, 173, 86)',
     });
-    assert.dom(s).hasText('8:00am - 9:00am : test');
+    assert.dom(s).hasText('8:00 AM - 9:00 AM : test');
   });
 });

--- a/tests/integration/components/ilios-calendar-test.js
+++ b/tests/integration/components/ilios-calendar-test.js
@@ -19,6 +19,6 @@ module('Integration | Component | ilios calendar', function(hooks) {
       @changeView={{noop}}
       @selectEvent={{noop}}
     />`);
-    assert.dom().includesText('Wednesday September 30, 2015');
+    assert.dom().includesText('Wednesday, September 30, 2015');
   });
 });

--- a/tests/integration/components/ilios-calendar-week-test.js
+++ b/tests/integration/components/ilios-calendar-week-test.js
@@ -19,7 +19,7 @@ module('Integration | Component | ilios calendar week', function(hooks) {
     this.set('date', date);
 
     await render(hbs`<IliosCalendarWeek @date={{this.date}} @calendarEvents={{array}} />`);
-    assert.dom().containsText('Week of September 27th 2015');
+    assert.dom().containsText('Week of September 27, 2015');
     assert.equal(weeklyCalendarComponent.events.length, 0);
   });
 

--- a/tests/integration/components/my-materials-test.js
+++ b/tests/integration/components/my-materials-test.js
@@ -69,8 +69,8 @@ module('Integration | Component | my-materials', function(hooks) {
     await render(hbs`<MyMaterials
       @materials={{this.materials}}
       @sortBy="firstOfferingDate"
-      @setCourseIdFilter={{action this.nothing}}
-      @setFilter={{action this.nothing}}
+      @setCourseIdFilter={{noop}}
+      @setFilter={{noop}}
     />`);
     assert.dom('[data-test-none]').exists();
   });
@@ -79,12 +79,11 @@ module('Integration | Component | my-materials', function(hooks) {
     assert.expect(42);
 
     this.set('materials', this.materials);
-    this.set('nothing', parseInt);
     await render(hbs`<MyMaterials
       @materials={{this.materials}}
       @sortBy="firstOfferingDate"
-      @setCourseIdFilter={{action this.nothing}}
-      @setFilter={{action this.nothing}}
+      @setCourseIdFilter={{noop}}
+      @setFilter={{noop}}
     />`);
 
     const table = 'table:nth-of-type(1)';
@@ -145,7 +144,7 @@ module('Integration | Component | my-materials', function(hooks) {
     assert.dom(firstLmSessionTitle).hasText('session1title');
     assert.dom(firstLmCourseTitle).hasText('course1title');
     assert.dom(firstLmInstructor).hasText('Instructor1name, Instructor2name');
-    assert.dom(firstLmFirstOffering).hasText('02/02/2003');
+    assert.dom(firstLmFirstOffering).hasText('2/2/2003');
     assert.equal(find(firstLmDownloadLink).href.trim(), 'http://myhost.com/url1');
 
     assert.dom(secondLmLink).hasText('title2');
@@ -154,7 +153,7 @@ module('Integration | Component | my-materials', function(hooks) {
     assert.dom(secondLmSessionTitle).hasText('session2title');
     assert.dom(secondLmCourseTitle).hasText('course2title');
     assert.dom(secondLmInstructor).hasText('Instructor1name, Instructor2name');
-    assert.dom(secondLmFirstOffering).hasText('02/02/2016');
+    assert.dom(secondLmFirstOffering).hasText('2/2/2016');
 
     assert.equal(find(thirdLmTitle).textContent.replace(/[\t\n\s]+/g, ""), 'Citationtitle3citationtext');
     assert.dom(thirdLmLink).doesNotExist();
@@ -162,7 +161,7 @@ module('Integration | Component | my-materials', function(hooks) {
     assert.dom(thirdLmSessionTitle).hasText('session3title');
     assert.dom(thirdLmCourseTitle).hasText('course3title');
     assert.dom(thirdLmInstructor).hasText('');
-    assert.dom(thirdLmFirstOffering).hasText('02/02/2020');
+    assert.dom(thirdLmFirstOffering).hasText('2/2/2020');
 
     assert.dom(fourthLmLink).hasText('title4');
     assert.equal(find(fourthLmLink).href.trim(), 'http://myhost.com/document.txt');
@@ -170,14 +169,14 @@ module('Integration | Component | my-materials', function(hooks) {
     assert.dom(fourthLmSessionTitle).hasText('session4title');
     assert.dom(fourthLmCourseTitle).hasText('course4title');
     assert.dom(fourthLmInstructor).hasText('Instructor3name, Instructor4name');
-    assert.dom(fourthLmFirstOffering).hasText('02/02/2030');
+    assert.dom(fourthLmFirstOffering).hasText('2/2/2030');
 
     assert.ok(find(fifthLmTitle).textContent.includes('title5'));
     assert.dom(fifthLmTypeIcon).exists({ count: 1 }, 'LM type icon is present.');
     assert.dom(fifthLmSessionTitle).hasText('session5title');
     assert.dom(fifthLmCourseTitle).hasText('course5title');
     assert.dom(fifthLmInstructor).hasText('');
-    assert.dom(fifthLmFirstOffering).hasText('02/02/2040');
+    assert.dom(fifthLmFirstOffering).hasText('2/2/2040');
 
     assert.dom(courseListOptions).exists({ count: 6 });
     assert.dom(allCourses).hasText('All Courses');
@@ -221,7 +220,7 @@ module('Integration | Component | my-materials', function(hooks) {
       @filter={{this.filter}}
       @materials={{this.materials}}
       @sortBy="firstOfferingDate"
-      @setCourseIdFilter={{action this.nothing}}
+      @setCourseIdFilter={{noop}}
       @setFilter={{action (mut this.filter)}}
     />`);
 
@@ -247,7 +246,7 @@ module('Integration | Component | my-materials', function(hooks) {
       @filter={{this.filter}}
       @materials={{this.materials}}
       @sortBy="firstOfferingDate"
-      @setCourseIdFilter={{action this.nothing}}
+      @setCourseIdFilter={{noop}}
       @setFilter={{action (mut this.filter)}}
     />`);
 
@@ -271,7 +270,7 @@ module('Integration | Component | my-materials', function(hooks) {
       @filter={{this.filter}}
       @materials={{this.materials}}
       @sortBy="firstOfferingDate"
-      @setCourseIdFilter={{action this.nothing}}
+      @setCourseIdFilter={{noop}}
       @setFilter={{action (mut this.filter)}}
     />`);
 
@@ -314,7 +313,6 @@ module('Integration | Component | my-materials', function(hooks) {
     assert.expect(8);
 
     this.set('materials', this.materials);
-    this.set('nothing', parseInt);
     let count = 0;
     const sortBys = ['title', 'title:desc', 'courseTitle', 'courseTitle:desc', 'sessionTitle', 'sessionTitle:desc', 'firstOfferingDate', 'firstOfferingDate:desc'];
     this.set('setSortBy', (what) => {
@@ -327,8 +325,8 @@ module('Integration | Component | my-materials', function(hooks) {
     await render(hbs`<MyMaterials
       @materials={{this.materials}}
       @sortBy={{this.sortBy}}
-      @setCourseIdFilter={{action this.nothing}}
-      @setFilter={{action this.nothing}}
+      @setCourseIdFilter={{noop}}
+      @setFilter={{noop}}
       @setSortBy={{action this.setSortBy}}
     />`);
 
@@ -352,7 +350,6 @@ module('Integration | Component | my-materials', function(hooks) {
     assert.expect(3);
 
     this.set('materials', this.materials);
-    this.set('nothing', parseInt);
     let count = 0;
     const courses = ['1', '3', ''];
     this.set('setCourseIdFilter', (what) => {
@@ -367,7 +364,7 @@ module('Integration | Component | my-materials', function(hooks) {
       @materials={{this.materials}}
       @sortBy="firstOfferingDate"
       @setCourseIdFilter={{action this.setCourseIdFilter}}
-      @setFilter={{action this.nothing}}
+      @setFilter={{noop}}
     />`);
 
     const select = '.course-filter select';
@@ -385,7 +382,7 @@ module('Integration | Component | my-materials', function(hooks) {
       @filter={{this.filter}}
       @materials={{this.materials}}
       @sortBy="firstOfferingDate"
-      @setCourseIdFilter={{action this.nothing}}
+      @setCourseIdFilter={{noop}}
       @setFilter={{action (mut this.filter)}}
     />`);
 

--- a/tests/integration/components/offering-form-test.js
+++ b/tests/integration/components/offering-form-test.js
@@ -294,7 +294,7 @@ module('Integration | Component | offering form', function(hooks) {
 
   test('changing start date changes end date', async function(assert) {
     await render(hbs`<OfferingForm @close={{noop}} />`);
-    const format = 'M/D/YYYY h:mm a';
+    const format = 'M/D/YYYY, h:mm A';
     const newStartDate = moment().add(1, 'day').toDate();
     assert.equal(moment().hour(9).minute(0).format(format), component.endDate.value);
     await component.startDate.set(newStartDate);
@@ -303,7 +303,7 @@ module('Integration | Component | offering form', function(hooks) {
 
   test('changing start time changes end date', async function(assert) {
     await render(hbs`<OfferingForm @close={{noop}} />`);
-    const format = 'M/D/YYYY h:mm a';
+    const format = 'M/D/YYYY, h:mm A';
     assert.equal(moment().hour(9).minute(0).format(format), component.endDate.value);
     await component.startTime.hour('2');
     await component.startTime.minutes('15');
@@ -313,7 +313,7 @@ module('Integration | Component | offering form', function(hooks) {
 
   test('changing duration changes end date', async function(assert) {
     await render(hbs`<OfferingForm @close={{noop}} />`);
-    const format = 'M/D/YYYY h:mm a';
+    const format = 'M/D/YYYY, h:mm A';
     assert.equal(moment().hour(9).minute(0).format(format), component.endDate.value);
     await component.duration.hours.set('2');
     await component.duration.minutes.set('15');
@@ -323,7 +323,7 @@ module('Integration | Component | offering form', function(hooks) {
   // @see https://github.com/ilios/frontend/issues/1903
   test('changing duration and start time changes end date', async function(assert) {
     await render(hbs`<OfferingForm @close={{noop}} />`);
-    const format = 'M/D/YYYY h:mm a';
+    const format = 'M/D/YYYY, h:mm A';
     assert.equal(moment().hour(9).minute(0).format(format), component.endDate.value);
     await component.startTime.hour('2');
     await component.startTime.minutes('10');

--- a/tests/integration/components/single-event-test.js
+++ b/tests/integration/components/single-event-test.js
@@ -124,7 +124,7 @@ module('Integration | Component | ilios calendar single event', function(hooks) 
     });
 
     this.set('event', ourEvent);
-    await render(hbs`<SingleEvent @event={{event}} />`);
+    await render(hbs`<SingleEvent @event={{this.event}} />`);
 
     assert.dom('.single-event-summary').containsText('test course', 'course title is displayed');
     assert.dom('.single-event-summary').containsText('test session', 'session title is displayed');
@@ -176,9 +176,16 @@ module('Integration | Component | ilios calendar single event', function(hooks) 
     });
 
     this.set('event', this.server.db.userevents[0]);
-    await render(hbs`<SingleEvent @event={{event}} />`);
+    await render(hbs`<SingleEvent @event={{this.event}} />`);
     assert.equal(component.title, 'course - Learn to Learn');
-    assert.equal(component.offeredAt, today.format('dddd, MMMM Do YYYY, h:mm a'));
+    assert.equal(component.offeredAt, today.toDate().toLocaleString([], {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+    }));
   });
 
   test('postrequisite date and title are displayed', async function(assert) {
@@ -208,9 +215,16 @@ module('Integration | Component | ilios calendar single event', function(hooks) 
     });
 
     this.set('event', this.server.db.userevents[0]);
-    await render(hbs`<SingleEvent @event={{event}} />`);
+    await render(hbs`<SingleEvent @event={{this.event}} />`);
     assert.equal(component.title, 'course - Learn to Learn');
-    const formatedDate = tomorrow.format('dddd, MMMM Do YYYY, h:mm a');
+    const formatedDate = tomorrow.toDate().toLocaleString([], {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+    });
     assert.equal(component.offeredAt, `Due Before postrequisite session (${formatedDate})`);
     assert.equal(component.offeredAtLink, `/events/1234`);
   });
@@ -246,7 +260,7 @@ module('Integration | Component | ilios calendar single event', function(hooks) 
     });
 
     this.set('event', this.server.db.userevents[0]);
-    await render(hbs`<SingleEvent @event={{event}} />`);
+    await render(hbs`<SingleEvent @event={{this.event}} />`);
     assert.equal(component.title, 'course - Learn to Learn');
     assert.equal(component.preWork.length, 2);
     assert.equal(component.preWork[0].title, 'prework 1');
@@ -283,10 +297,24 @@ module('Integration | Component | ilios calendar single event', function(hooks) 
     });
 
     this.set('event', this.server.db.userevents[0]);
-    await render(hbs`<SingleEvent @event={{event}} />`);
+    await render(hbs`<SingleEvent @event={{this.event}} />`);
     assert.equal(component.title, 'course - Learn to Learn');
-    const formattedTomorrow = tomorrow.format('dddd, MMMM Do YYYY, h:mm a');
-    const formattedToday = today.format('dddd, MMMM Do YYYY, h:mm a');
+    const formattedTomorrow = tomorrow.toDate().toLocaleString([], {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+    });
+    const formattedToday = today.toDate().toLocaleString([], {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+    });
     assert.equal(component.offeredAt, `Due Before postrequisite session (${formattedTomorrow}) ${formattedToday}`);
     assert.equal(component.offeredAtLink, `/events/1234`);
   });

--- a/tests/integration/components/timed-release-schedule-test.js
+++ b/tests/integration/components/timed-release-schedule-test.js
@@ -4,6 +4,13 @@ import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import moment from 'moment';
 
+const localeFormatOptions = {
+  year: 'numeric',
+  month: 'numeric',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: 'numeric',
+};
 module('Integration | Component | timed release schedule', function(hooks) {
   setupRenderingTest(hooks);
 
@@ -24,9 +31,9 @@ module('Integration | Component | timed release schedule', function(hooks) {
     const endDate = moment().add(1, 'day');
     this.set('startDate', startDate.toDate());
     this.set('endDate', endDate.toDate());
-    await render(hbs`<TimedReleaseSchedule @startDate={{startDate}} @endDate={{endDate}} />`);
-    const expectedStartDate = startDate.format('L LT');
-    const expectedEndDate = endDate.format('L LT');
+    await render(hbs`<TimedReleaseSchedule @startDate={{this.startDate}} @endDate={{this.endDate}} />`);
+    const expectedStartDate = startDate.toDate().toLocaleString([], localeFormatOptions);
+    const expectedEndDate = endDate.toDate().toLocaleString([], localeFormatOptions);
 
     assert.dom(this.element).hasText(`(Available: ${expectedStartDate} and available until ${expectedEndDate})`);
   });
@@ -35,7 +42,7 @@ module('Integration | Component | timed release schedule', function(hooks) {
     const tomorrow = moment().add(1, 'day');
     this.set('tomorrow', tomorrow.toDate());
     await render(hbs`<TimedReleaseSchedule @startDate={{tomorrow}} />`);
-    const expectedDate = tomorrow.format('L LT');
+    const expectedDate = tomorrow.toDate().toLocaleString([], localeFormatOptions);
 
     assert.dom(this.element).hasText(`(Available: ${expectedDate})`);
   });
@@ -51,7 +58,7 @@ module('Integration | Component | timed release schedule', function(hooks) {
     const tomorrow = moment().add(1, 'day');
     this.set('tomorrow', tomorrow.toDate());
     await render(hbs`<TimedReleaseSchedule @endDate={{tomorrow}} />`);
-    const expectedDate = tomorrow.format('L LT');
+    const expectedDate = tomorrow.toDate().toLocaleString([], localeFormatOptions);
 
     assert.dom(this.element).hasText(`(Available until ${expectedDate})`);
   });
@@ -60,7 +67,7 @@ module('Integration | Component | timed release schedule', function(hooks) {
     const tomorrow = moment().subtract(1, 'day');
     this.set('tomorrow', tomorrow.toDate());
     await render(hbs`<TimedReleaseSchedule @endDate={{tomorrow}} />`);
-    const expectedDate = tomorrow.format('L LT');
+    const expectedDate = tomorrow.toDate().toLocaleString([], localeFormatOptions);
     assert.dom(this.element).hasText(`(Available until ${expectedDate})`);
   });
 });

--- a/tests/integration/components/week-glance-test.js
+++ b/tests/integration/components/week-glance-test.js
@@ -101,7 +101,7 @@ module('Integration | Component | week glance', function(hooks) {
       @collapsible={{false}}
       @collapsed={{false}}
       @showFullTitle={{true}}
-      @year={{moment-format this.today "YYYY"}}
+      @year={{format-date this.today year="numeric"}}
       @week={{moment-format this.today "W"}}
     />`);
 
@@ -126,7 +126,7 @@ module('Integration | Component | week glance', function(hooks) {
       @collapsible={{false}}
       @collapsed={{false}}
       @showFullTitle={{true}}
-      @year={{moment-format this.today "YYYY"}}
+      @year={{format-date this.today year="numeric"}}
       @week={{moment-format this.today "W"}}
     />`);
     const title = '[data-test-week-title]';
@@ -150,7 +150,7 @@ module('Integration | Component | week glance', function(hooks) {
       @collapsible={{false}}
       @collapsed={{false}}
       @showFullTitle={{false}}
-      @year={{moment-format this.today "YYYY"}}
+      @year={{format-date this.today year="numeric"}}
       @week={{moment-format this.today "W"}}
     />`);
     const title = '[data-test-week-title]';
@@ -170,7 +170,7 @@ module('Integration | Component | week glance', function(hooks) {
       @collapsible={{true}}
       @collapsed={{true}}
       @showFullTitle={{false}}
-      @year={{moment-format this.today "YYYY"}}
+      @year={{format-date this.today year="numeric"}}
       @week={{moment-format this.today "W"}}
     />`);
     const title = '[data-test-week-title]';
@@ -199,7 +199,7 @@ module('Integration | Component | week glance', function(hooks) {
       @collapsible={{true}}
       @collapsed={{true}}
       @showFullTitle={{false}}
-      @year={{moment-format this.today "YYYY"}}
+      @year={{format-date this.today year="numeric"}}
       @week={{moment-format this.today "W"}}
       @toggleCollapsed={{action toggle}}
     />`);
@@ -221,7 +221,7 @@ module('Integration | Component | week glance', function(hooks) {
       @collapsible={{true}}
       @collapsed={{false}}
       @showFullTitle={{false}}
-      @year={{moment-format this.today "YYYY"}}
+      @year={{format-date this.today year="numeric"}}
       @week={{moment-format this.today "W"}}
       @toggleCollapsed={{action toggle}}
     />`);

--- a/tests/integration/components/weekly-calendar-event-test.js
+++ b/tests/integration/components/weekly-calendar-event-test.js
@@ -51,7 +51,7 @@ module('Integration | Component | weekly-calendar-event', function(hooks) {
         @allDayEvents={{array this.event}}
       />`);
       assert.dom(s).hasStyle(this.getStyle(97, 12, 50));
-      assert.dom(s).hasText('8:00am event 0');
+      assert.dom(s).hasText('8:00 AM event 0');
     });
 
     test('check event 0', async function (assert) {
@@ -63,7 +63,7 @@ module('Integration | Component | weekly-calendar-event', function(hooks) {
       />`);
 
       assert.dom(s).hasStyle(this.getStyle(97, 12, 16));
-      assert.dom(s).hasText('8:00am event 0');
+      assert.dom(s).hasText('8:00 AM event 0');
     });
 
     test('check event 1', async function (assert) {
@@ -75,7 +75,7 @@ module('Integration | Component | weekly-calendar-event', function(hooks) {
       />`);
 
       assert.dom(s).hasStyle(this.getStyle(97, 42, 16));
-      assert.dom(s).hasText('8:00am event 1');
+      assert.dom(s).hasText('8:00 AM event 1');
     });
 
     test('check event 2', async function (assert) {
@@ -87,7 +87,7 @@ module('Integration | Component | weekly-calendar-event', function(hooks) {
       />`);
 
       assert.dom(s).hasStyle(this.getStyle(99, 22, 16));
-      assert.dom(s).hasText('8:10am event 2');
+      assert.dom(s).hasText('8:10 AM event 2');
     });
 
     test('check event 3', async function (assert) {
@@ -99,7 +99,7 @@ module('Integration | Component | weekly-calendar-event', function(hooks) {
       />`);
 
       assert.dom(s).hasStyle(this.getStyle(121, 24, 16));
-      assert.dom(s).hasText('10:00am event 3');
+      assert.dom(s).hasText('10:00 AM event 3');
     });
 
     test('check event 4', async function (assert) {
@@ -111,7 +111,7 @@ module('Integration | Component | weekly-calendar-event', function(hooks) {
       />`);
 
       assert.dom(s).hasStyle(this.getStyle(123, 22, 16));
-      assert.dom(s).hasText('10:10am event 4');
+      assert.dom(s).hasText('10:10 AM event 4');
     });
 
     test('check event 5', async function (assert) {
@@ -123,7 +123,7 @@ module('Integration | Component | weekly-calendar-event', function(hooks) {
       />`);
 
       assert.dom(s).hasStyle(this.getStyle(145, 12, 50));
-      assert.dom(s).hasText('12:00pm event 5');
+      assert.dom(s).hasText('12:00 PM event 5');
     });
   });
 
@@ -153,7 +153,7 @@ module('Integration | Component | weekly-calendar-event', function(hooks) {
       />`);
 
       assert.dom(s).hasStyle(this.getStyle(99, 22, 25));
-      assert.dom(s).hasText('8:10am event 0');
+      assert.dom(s).hasText('8:10 AM event 0');
     });
 
     test('check event 1', async function (assert) {
@@ -165,7 +165,7 @@ module('Integration | Component | weekly-calendar-event', function(hooks) {
       />`);
 
       assert.dom(s).hasStyle(this.getStyle(99, 14, 25));
-      assert.dom(s).hasText('8:10am event 1');
+      assert.dom(s).hasText('8:10 AM event 1');
     });
 
     test('check event 2', async function (assert) {
@@ -177,7 +177,7 @@ module('Integration | Component | weekly-calendar-event', function(hooks) {
       />`);
 
       assert.dom(s).hasStyle(this.getStyle(117, 10, 25));
-      assert.dom(s).hasText('9:40am event 2');
+      assert.dom(s).hasText('9:40 AM event 2');
     });
 
     test('check event 3', async function (assert) {
@@ -189,7 +189,7 @@ module('Integration | Component | weekly-calendar-event', function(hooks) {
       />`);
 
       assert.dom(s).hasStyle(this.getStyle(123, 22, 7));
-      assert.dom(s).hasText('10:10am event 3');
+      assert.dom(s).hasText('10:10 AM event 3');
     });
 
     test('check event 4', async function (assert) {
@@ -201,7 +201,7 @@ module('Integration | Component | weekly-calendar-event', function(hooks) {
       />`);
 
       assert.dom(s).hasStyle(this.getStyle(129, 22, 6));
-      assert.dom(s).hasText('10:40am event 4');
+      assert.dom(s).hasText('10:40 AM event 4');
     });
 
     test('check event 5', async function (assert) {
@@ -213,7 +213,7 @@ module('Integration | Component | weekly-calendar-event', function(hooks) {
       />`);
 
       assert.dom(s).hasStyle(this.getStyle(129, 22, 6));
-      assert.dom(s).hasText('10:40am event 5');
+      assert.dom(s).hasText('10:40 AM event 5');
     });
 
     test('check event 6', async function (assert) {
@@ -225,7 +225,7 @@ module('Integration | Component | weekly-calendar-event', function(hooks) {
       />`);
 
       assert.dom(s).hasStyle(this.getStyle(129, 22, 6));
-      assert.dom(s).hasText('10:40am event 6');
+      assert.dom(s).hasText('10:40 AM event 6');
     });
 
     test('check event 7', async function (assert) {
@@ -237,7 +237,7 @@ module('Integration | Component | weekly-calendar-event', function(hooks) {
       />`);
 
       assert.dom(s).hasStyle(this.getStyle(129, 22, 6));
-      assert.dom(s).hasText('10:40am event 7');
+      assert.dom(s).hasText('10:40 AM event 7');
     });
 
     test('check event 8', async function (assert) {
@@ -249,7 +249,7 @@ module('Integration | Component | weekly-calendar-event', function(hooks) {
       />`);
 
       assert.dom(s).hasStyle(this.getStyle(129, 22, 6));
-      assert.dom(s).hasText('10:40am event 8');
+      assert.dom(s).hasText('10:40 AM event 8');
     });
 
     test('check event 9', async function (assert) {
@@ -261,7 +261,7 @@ module('Integration | Component | weekly-calendar-event', function(hooks) {
       />`);
 
       assert.dom(s).hasStyle(this.getStyle(129, 22, 6));
-      assert.dom(s).hasText('10:40am event 9');
+      assert.dom(s).hasText('10:40 AM event 9');
     });
 
     test('check event 10', async function (assert) {
@@ -273,7 +273,7 @@ module('Integration | Component | weekly-calendar-event', function(hooks) {
       />`);
 
       assert.dom(s).hasStyle(this.getStyle(145, 12, 7));
-      assert.dom(s).hasText('12:00pm event 10');
+      assert.dom(s).hasText('12:00 PM event 10');
     });
   });
 

--- a/tests/integration/components/weekly-calendar-test.js
+++ b/tests/integration/components/weekly-calendar-test.js
@@ -40,11 +40,11 @@ module('Integration | Component | weekly-calendar', function(hooks) {
       @changeToDayView={{noop}}
     />`);
 
-    assert.equal(component.longWeekOfYear, 'Week of January 6th 2019');
+    assert.equal(component.longWeekOfYear, 'Week of January 6, 2019');
     assert.equal(component.shortWeekOfYear, '1/6 — 1/12 2019');
     assert.equal(component.dayHeadings.length, 7);
     assert.ok(component.dayHeadings[0].isFirstDayOfWeek);
-    assert.equal(component.dayHeadings[0].text, 'Sunday Sun Jan 6th 6th');
+    assert.equal(component.dayHeadings[0].text, 'Sunday Sun Jan 6 6');
 
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
@@ -64,7 +64,7 @@ module('Integration | Component | weekly-calendar', function(hooks) {
 
     assert.equal(component.dayHeadings.length, 7);
     assert.ok(component.dayHeadings[0].isFirstDayOfWeek);
-    assert.equal(component.dayHeadings[0].text, 'Sunday Sun Jan 6th 6th');
+    assert.equal(component.dayHeadings[0].text, 'Sunday Sun Jan 6 6');
 
     assert.equal(component.events.length, 2);
     assert.ok(component.events[0].isFourthDayOfWeek);
@@ -94,7 +94,7 @@ module('Integration | Component | weekly-calendar', function(hooks) {
 
     assert.equal(component.dayHeadings.length, 7);
     assert.ok(component.dayHeadings[0].isFirstDayOfWeek);
-    assert.equal(component.dayHeadings[0].text, 'Sunday Sun Jan 6th 6th');
+    assert.equal(component.dayHeadings[0].text, 'Sunday Sun Jan 6 6');
 
     assert.equal(component.events.length, 6);
     assert.ok(component.events[0].isSecondDayOfWeek);
@@ -198,11 +198,11 @@ module('Integration | Component | weekly-calendar', function(hooks) {
       @selectEvent={{noop}}
     />`);
 
-    assert.equal(component.longWeekOfYear, 'Week of December 7th 1980');
+    assert.equal(component.longWeekOfYear, 'Week of December 7, 1980');
     assert.equal(component.shortWeekOfYear, '12/7 — 12/13 1980');
 
     assert.ok(component.dayHeadings[0].isFirstDayOfWeek);
-    assert.equal(component.dayHeadings[0].text, 'Sunday Sun Dec 7th 7th');
+    assert.equal(component.dayHeadings[0].text, 'Sunday Sun Dec 7 7');
 
     assert.equal(component.events.length, 1);
     assert.ok(component.events[0].isFifthDayOfWeek);
@@ -212,10 +212,10 @@ module('Integration | Component | weekly-calendar', function(hooks) {
     this.owner.lookup('service:moment').setLocale('es');
     await settled();
 
-    assert.equal(component.longWeekOfYear, 'Semana de diciembre 8º 1980');
-    assert.equal(component.shortWeekOfYear, '12/8 — 12/14 1980');
+    assert.equal(component.longWeekOfYear, 'Semana de 8 de diciembre de 1980');
+    assert.equal(component.shortWeekOfYear, '8/12 — 14/12 1980');
     assert.ok(component.dayHeadings[0].isFirstDayOfWeek);
-    assert.equal(component.dayHeadings[0].text, 'lunes lun. dic. 8º 8º');
+    assert.equal(component.dayHeadings[0].text, 'lunes lun. 8 dic. 8');
 
     assert.equal(component.events.length, 1);
     assert.ok(component.events[0].isFourthDayOfWeek);
@@ -239,11 +239,11 @@ module('Integration | Component | weekly-calendar', function(hooks) {
       @selectEvent={{noop}}
     />`);
 
-    assert.equal(component.longWeekOfYear, 'Week of February 23rd 2020');
+    assert.equal(component.longWeekOfYear, 'Week of February 23, 2020');
     assert.equal(component.shortWeekOfYear, '2/23 — 2/29 2020');
 
     assert.ok(component.dayHeadings[0].isFirstDayOfWeek);
-    assert.equal(component.dayHeadings[0].text, 'Sunday Sun Feb 23rd 23rd');
+    assert.equal(component.dayHeadings[0].text, 'Sunday Sun Feb 23 23');
 
     assert.equal(component.events.length, 1);
     assert.ok(component.events[0].isThirdDayOfWeek);
@@ -253,10 +253,10 @@ module('Integration | Component | weekly-calendar', function(hooks) {
     this.owner.lookup('service:moment').setLocale('es');
     await settled();
 
-    assert.equal(component.longWeekOfYear, 'Semana de febrero 24º 2020');
-    assert.equal(component.shortWeekOfYear, '2/24 — 3/1 2020');
+    assert.equal(component.longWeekOfYear, 'Semana de 24 de febrero de 2020');
+    assert.equal(component.shortWeekOfYear, '24/2 — 1/3 2020');
     assert.ok(component.dayHeadings[0].isFirstDayOfWeek);
-    assert.equal(component.dayHeadings[0].text, 'lunes lun. feb. 24º 24º');
+    assert.equal(component.dayHeadings[0].text, 'lunes lun. 24 feb. 24');
 
     assert.equal(component.events.length, 1);
     assert.ok(component.events[0].isSecondDayOfWeek);


### PR DESCRIPTION
Targeting `moment-format` in templates to replace with the locale aware `format-date`. The only downside of this is that we loose the ordinal suffixes on dates (1st, 3rd, etc). Those aren't part of the date format spec at this time. If that's too much to give up we can do some custom helper formatting for those locations.