### PR TITLE
Update Tracking of Relationships

### DIFF
--- a/addon-test-support/ilios-common/page-objects/course-publish-all.js
+++ b/addon-test-support/ilios-common/page-objects/course-publish-all.js
@@ -1,0 +1,19 @@
+import {
+  create,
+  isVisible,
+  visitable,
+} from 'ember-cli-page-object';
+
+import objectives from './components/course/objectives';
+
+export default create({
+  visit: visitable('/courses/:courseId/publishall'),
+  course: {
+    scope: '[data-test-ilios-course-details]',
+    objectives,
+  },
+  publishAll: {
+    scope: '[data-test-publish-all-sessions]',
+    hasUnlinkedWarning: isVisible('[data-test-unlinked-warning]'),
+  }
+});

--- a/addon/components/collapsed-competencies.hbs
+++ b/addon/components/collapsed-competencies.hbs
@@ -1,14 +1,14 @@
 <section
   class="collapsed-competencies"
-  {{did-insert (perform this.load) (await @subject.competencies)}}
-  {{did-update (perform this.load) (await @subject.competencies)}}
+  {{did-insert (perform this.load) @subject}}
+  {{did-update (perform this.load) @subject @subject.competencies}}
   data-test-collapsed-competencies
 >
   <div class="title" role="button" {{on "click" @expand}} data-test-title>
     {{t "general.competencies"}} ({{get (await @subject.competencies) "length"}})
   </div>
-  {{#unless this.summary}}
-    <LoadingSpinner @tagName="h3" />
+  {{#unless this.load.lastSuccessful}}
+    <LoadingSpinner />
   {{else}}
     <div class="content">
       <table>

--- a/addon/components/course-materials.hbs
+++ b/addon/components/course-materials.hbs
@@ -1,8 +1,9 @@
 <div
   class="course-materials"
   data-test-course-materials
-  {{did-insert (perform this.load) (await @course.learningMaterials) (await @course.sessions)}}
-  {{did-update (perform this.load) (await @course.learningMaterials) (await @course.sessions)}}
+  {{did-insert (perform this.load)}}
+  {{did-update (perform this.load) @course}}
+  {{did-update (perform this.update) this.courseMaterialsRelationship this.sessionsRelationship}}
 >
   <div class="material-list">
     <h3>
@@ -97,7 +98,7 @@
   </div>
   <div class="material-list">
     <h3 class="session-material-title">
-      {{t "general.sessionLearningMaterials"}} ({{get this.sessionLearningMaterialObjects "length"}})
+      {{t "general.sessionLearningMaterials"}} ({{this.sessionLearningMaterialObjects.length}})
     </h3>
     <span class="filter-session-lms">
       <input

--- a/addon/components/course-materials.js
+++ b/addon/components/course-materials.js
@@ -10,6 +10,8 @@ const DEBOUNCE_DELAY = 250;
 export default class CourseMaterialsComponent extends Component {
   @tracked courseLearningMaterialObjects = [];
   @tracked sessionLearningMaterialObjects = [];
+  @tracked courseMaterialsRelationship;
+  @tracked sessionsRelationship;
   @tracked courseQuery;
   @tracked sessionQuery;
 
@@ -19,17 +21,20 @@ export default class CourseMaterialsComponent extends Component {
   }
 
   @restartableTask
-  *load(element, [
-    courseLearningMaterials,
-    sessions
-  ]) {
-    if (courseLearningMaterials) {
-      this.courseLearningMaterialObjects = yield map(courseLearningMaterials.toArray(), async (clm) => {
+  *load() {
+    this.courseMaterialsRelationship = yield this.args.course.learningMaterials;
+    this.sessionsRelationship = yield this.args.course.sessions;
+  }
+
+  @restartableTask
+  *update() {
+    if (this.courseMaterialsRelationship) {
+      this.courseLearningMaterialObjects = yield map(this.courseMaterialsRelationship.toArray(), async (clm) => {
         return await this.buildClmObject(clm);
       });
     }
-    if (sessions) {
-      const sessionMaterials = yield map(sessions.toArray(), async (session) => {
+    if (this.sessionsRelationship) {
+      const sessionMaterials = yield map(this.sessionsRelationship.toArray(), async (session) => {
         const data = await session.learningMaterials;
         return data.toArray();
       });

--- a/addon/components/course-overview.js
+++ b/addon/components/course-overview.js
@@ -20,21 +20,11 @@ export default class CourseOverview extends Component {
   @BeforeDate('endDate', { granularity: 'day'}) @tracked startDate = null;
   @AfterDate('startDate', { granularity: 'day'}) @tracked endDate = null;
   @tracked level = null;
-  @tracked levelOptions = null;
-  @tracked clerkshipTypeId = null;
-  @tracked manageDirectors = false;
-  @tracked showDirectorManagerLoader = true;
-  @tracked currentRoute = '';
-
+  @tracked levelOptions = [1, 2, 3, 4, 5];
+  @tracked clerkshipTypeId;
   @tracked clerkshipTypeOptions;
-
   @tracked canCreateCourseInSchool = false;
   @tracked school = null;
-
-  constructor() {
-    super(...arguments);
-    this.levelOptions = [1, 2, 3, 4, 5];
-  }
 
   @restartableTask
   *load() {
@@ -46,14 +36,6 @@ export default class CourseOverview extends Component {
     this.school = yield this.args.course.school;
     this.clerkshipTypeId = this.args.course.belongsTo('clerkshipType').id();
     this.canCreateCourseInSchool = yield this.permissionChecker.canCreateCourse(this.school);
-    yield this.directorsToPassToManager.perform();
-  }
-
-  @restartableTask
-  *directorsToPassToManager() {
-    const users = yield this.args.course.directors;
-    this.showDirectorManagerLoader = false;
-    return users;
   }
 
   get selectedClerkshipType() {
@@ -78,14 +60,6 @@ export default class CourseOverview extends Component {
     }
 
     return this.selectedClerkshipType.title;
-  }
-
-  @action
-  async saveDirectors(newDirectors){
-    this.args.course.set('directors', newDirectors.toArray());
-    await this.args.course.save();
-    this.directorsToPassToManager.perform();
-    return this.manageDirectors = false;
   }
   @action
   async changeClerkshipType() {

--- a/addon/components/course-publicationcheck.hbs
+++ b/addon/components/course-publicationcheck.hbs
@@ -1,7 +1,7 @@
 <div
   class="course-publicationcheck"
-  {{did-insert (fn this.load) (await @course.courseObjectives)}}
-  {{did-update (fn this.load) (await @course.courseObjectives)}}
+  {{did-insert (perform this.load)}}
+  {{did-update (perform this.load) @course.courseObjectives}}
 >
   <div class="title">
     {{t "general.missingItems"}} ({{@course.allPublicationIssuesLength}})

--- a/addon/components/course/collapsed-objectives.hbs
+++ b/addon/components/course/collapsed-objectives.hbs
@@ -1,13 +1,13 @@
 <section
   class="course-collapsed-objectives"
   data-test-course-collapsed-objectives
-  {{did-insert (perform this.load) @course.courseObjectives}}
+  {{did-insert (perform this.load)}}
   {{did-update (perform this.load) @course.courseObjectives}}
 >
   <div class="title" role="button" {{on "click" @expand}} data-test-title>
     {{t "general.objectives"}} ({{get this.objectives "length"}})
   </div>
-  {{#if this.load.lastSuccessful.value}}
+  {{#if this.load.lastSuccessful}}
     <div class="content">
       <table>
         <thead>

--- a/addon/components/course/collapsed-objectives.js
+++ b/addon/components/course/collapsed-objectives.js
@@ -3,33 +3,32 @@ import { tracked } from '@glimmer/tracking';
 import { restartableTask } from 'ember-concurrency-decorators';
 
 export default class CourseCollapsedObjectivesComponent extends Component {
-  @tracked objectives;
-  @tracked objectivesWithParents;
-  @tracked objectivesWithMesh;
-  @tracked objectivesWithTerms;
+  @tracked objectivesRelationship;
 
   @restartableTask
-  *load(element, [objectivePromise]) {
-    if (!objectivePromise) {
-      return false;
-    }
-    this.objectives = yield objectivePromise;
+  *load() {
+    this.objectivesRelationship = yield this.args.course.courseObjectives;
+  }
 
-    this.objectivesWithParents = this.objectives.filter(objective => {
-      const parentIds = objective.hasMany('programYearObjectives').ids();
+  get objectives() {
+    return this.objectivesRelationship ? this.objectivesRelationship.toArray() : [];
+  }
 
-      return parentIds.length > 0;
+  get objectivesWithParents() {
+    return this.objectives.filter(objective => {
+      return objective.programYearObjectives.length > 0;
     });
-    this.objectivesWithMesh = this.objectives.filter(objective => {
-      const meshDescriptorIds = objective.hasMany('meshDescriptors').ids();
+  }
 
-      return meshDescriptorIds.length > 0;
+  get objectivesWithMesh() {
+    return this.objectives.filter(objective => {
+      return objective.meshDescriptors.length > 0;
     });
-    this.objectivesWithTerms = this.objectives.filter(objective => {
-      const termIds = objective.hasMany('terms').ids();
-      return termIds.length > 0;
-    });
+  }
 
-    return true;
+  get objectivesWithTerms() {
+    return this.objectives.filter(objective => {
+      return objective.terms.length > 0;
+    });
   }
 }

--- a/addon/components/course/objectives.hbs
+++ b/addon/components/course/objectives.hbs
@@ -1,7 +1,7 @@
 <section
   class="course-objectives {{if this.showCollapsible "collapsible"}}"
-  {{did-insert this.load @course}}
-  {{did-update this.load @course @course.courseObjectives}}
+  {{did-insert (perform this.load)}}
+  {{did-update (perform this.load) @course}}
   data-test-course-objectives
 >
   <div class="header">

--- a/addon/components/course/objectives.js
+++ b/addon/components/course/objectives.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import { dropTask } from 'ember-concurrency-decorators';
+import { dropTask, restartableTask } from 'ember-concurrency-decorators';
 import { action } from '@ember/object';
 
 export default class CourseObjectivesComponent extends Component {
@@ -10,7 +10,7 @@ export default class CourseObjectivesComponent extends Component {
 
   @tracked newObjectiveEditorOn = false;
   @tracked newObjectiveTitle;
-  @tracked objectiveCount;
+  @tracked objectivesRelationship;
 
   get showCollapsible(){
     return this.hasObjectives && !this.isManaging;
@@ -20,9 +20,13 @@ export default class CourseObjectivesComponent extends Component {
     return this.objectiveCount > 0;
   }
 
-  @action
-  load(element, [course]) {
-    this.objectiveCount = course.hasMany('courseObjectives').ids().length;
+  get objectiveCount() {
+    return this.objectivesRelationship ? this.objectivesRelationship.length : 0;
+  }
+
+  @restartableTask
+  *load() {
+    this.objectivesRelationship = yield this.args.course.courseObjectives;
   }
 
   @dropTask

--- a/addon/components/dashboard-agenda.hbs
+++ b/addon/components/dashboard-agenda.hbs
@@ -1,8 +1,4 @@
-<div
-  class="dashboard-agenda"
-  {{did-insert (perform this.load)}}
-  {{did-update (perform this.load)}}
->
+<div class="dashboard-agenda">
   <h3>
     {{t "general.upcomingActivities" days=this.daysInAdvance}}
   </h3>

--- a/addon/components/dashboard-agenda.js
+++ b/addon/components/dashboard-agenda.js
@@ -12,6 +12,11 @@ export default class DashboardAgendaComponent extends Component {
   @tracked sixDaysAgo = moment().hour(0).minute(0).subtract(6, 'days');
   @tracked weeksEvents = null;
 
+  constructor(){
+    super(...arguments);
+    this.load.perform();
+  }
+
   @restartableTask
   *load() {
     const from = moment().hour(0).minute(0).unix();

--- a/addon/components/dashboard-materials.hbs
+++ b/addon/components/dashboard-materials.hbs
@@ -1,8 +1,4 @@
-<div
-  class="dashboard-materials"
-  {{did-insert (perform this.load)}}
-  {{did-update (perform this.load)}}
->
+<div class="dashboard-materials">
   <div class="all-materials" data-test-all-materials-link>
     {{t "general.view"}}:
     <LinkTo @route="mymaterials">

--- a/addon/components/dashboard-materials.js
+++ b/addon/components/dashboard-materials.js
@@ -12,6 +12,11 @@ export default class DashboardMaterialsComponent extends Component {
   @tracked daysInAdvance = 60;
   @tracked materials = null;
 
+  constructor() {
+    super(...arguments);
+    this.load.perform();
+  }
+
   @restartableTask
   *load() {
     const from = moment().hour(0).minute(0).unix();

--- a/addon/components/dashboard/courses-calendar-filter.hbs
+++ b/addon/components/dashboard/courses-calendar-filter.hbs
@@ -1,6 +1,7 @@
 <div
   class="calendar-filter-list large-filter-list dashboard-courses-calendar-filter"
-  {{did-insert (perform this.load) @school}}
+  {{did-insert (set this.el)}}
+  {{did-insert (perform this.load)}}
   {{did-update (perform this.load) @school}}
   data-test-courses-calendar-filter
 >

--- a/addon/components/detail-competencies.hbs
+++ b/addon/components/detail-competencies.hbs
@@ -1,7 +1,7 @@
 <section
  class="detail-competencies {{if this.hasCompetencies "collapsible"}}"
-  {{did-insert (fn this.load) (await @course.competencies)}}
-  {{did-update (fn this.load) (await @course.competencies)}}
+  {{did-insert (perform this.load)}}
+  {{did-update (perform this.load) @course.competencies}}
 >
   <div
     class="title {{if this.hasCompetencies "clickable collapsible"}}"

--- a/addon/components/detail-competencies.js
+++ b/addon/components/detail-competencies.js
@@ -1,18 +1,25 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import { restartableTask } from 'ember-concurrency-decorators';
 
 export default class DetailCompetenciesComponent extends Component {
-  @tracked hasCompetencies = false;
-  @tracked competencyCount;
+  @tracked competenciesRelationship;
 
-  @action
-  load(event, [competencies]) {
-    if (!competencies) {
-      return;
+  @restartableTask
+  *load() {
+    this.competenciesRelationship = yield this.args.course.competencies;
+  }
+
+  get competencyCount() {
+    if (!this.competenciesRelationship) {
+      return 0;
     }
-    this.competencyCount = competencies.length;
-    this.hasCompetencies = this.competencyCount > 0;
+    return this.competenciesRelationship.length;
+  }
+
+  get hasCompetencies() {
+    return this.competencyCount > 0;
   }
 
   @action

--- a/addon/components/detail-instructors.hbs
+++ b/addon/components/detail-instructors.hbs
@@ -1,8 +1,6 @@
 <section
   class="detail-instructors"
   data-test-detail-instructors
-  {{did-insert (perform this.load) @ilmSession}}
-  {{did-update (perform this.load) @ilmSession}}
 >
   <div class="detail-instructors-header">
     <div class="title">

--- a/addon/components/detail-instructors.js
+++ b/addon/components/detail-instructors.js
@@ -12,6 +12,11 @@ export default class DetailInstructorsComponent extends Component {
   @tracked instructorBuffer = [];
   @tracked availableInstructorGroups;
 
+  constructor() {
+    super(...arguments);
+    this.load.perform();
+  }
+
   @restartableTask
   *load() {
     const user = yield this.currentUser.getModel();

--- a/addon/components/detail-learning-materials.hbs
+++ b/addon/components/detail-learning-materials.hbs
@@ -114,7 +114,7 @@
                 </span>
               </td>
               <td class="text-center" colspan="2">
-                <UserNameInfo @user={{get (await lmProxy.learningMaterial) "owningUser"}} />
+                <UserNameInfo @user={{await (get (await lmProxy.learningMaterial) "owningUser")}} />
               </td>
               <td class="text-center" colspan="2">
                 {{#if lmProxy.required}}

--- a/addon/components/detail-learning-materials.hbs
+++ b/addon/components/detail-learning-materials.hbs
@@ -1,8 +1,8 @@
 <section
   class="detail-learningmaterials {{if this.displaySearchBox "display-search-box"}}"
   data-test-detail-learning-materials
-  {{did-insert (perform this.load) (await @subject.learningMaterials)}}
-  {{did-update (perform this.load) (await @subject.learningMaterials)}}
+  {{did-insert (perform this.load)}}
+  {{did-update (perform this.load) @subject.learningMaterials}}
 >
   <div class="detail-learningmaterials-header">
     <div class="title">
@@ -11,13 +11,13 @@
           {{t "general.learningMaterialManageTitle"}}
         </span>
       {{else}}
-        {{t "general.learningMaterials"}} ({{get (await @subject.learningMaterials) "length"}})
+        {{t "general.learningMaterials"}} ({{@subject.learningMaterials.length}})
       {{/if}}
     </div>
     {{#if this.displaySearchBox}}
       <LearningmaterialSearch
         @add={{perform this.addLearningMaterial}}
-        @currentMaterials={{this.parentMaterials}}
+        @currentMaterialIds={{this.parentMaterialIds}}
       />
     {{/if}}
     <div class="detail-learningmaterials-actions">

--- a/addon/components/detail-mesh.hbs
+++ b/addon/components/detail-mesh.hbs
@@ -1,8 +1,8 @@
 <section
   class="detail-mesh"
   data-test-detail-mesh
-  {{did-insert (fn this.load) (await @subject.meshDescriptors)}}
-  {{did-update (fn this.load) (await @subject.meshDescriptors)}}
+  {{did-insert (perform this.load)}}
+  {{did-update (perform this.load) @subject.meshDescriptors}}
 >
   {{#if (is-array this.meshDescriptors)}}
     <div class="detail-mesh-header">

--- a/addon/components/detail-mesh.js
+++ b/addon/components/detail-mesh.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import { dropTask } from 'ember-concurrency-decorators';
+import { dropTask, restartableTask } from 'ember-concurrency-decorators';
 import { action } from '@ember/object';
 
 export default class DetailMeshComponent extends Component {
@@ -10,14 +10,18 @@ export default class DetailMeshComponent extends Component {
 
   @tracked isManaging = false;
   @tracked bufferedDescriptors = null;
-  @tracked meshDescriptors = null;
+  @tracked meshDescriptorRelationship;
 
-  @action
-  load(event, [meshDescriptors]) {
-    if (!meshDescriptors) {
-      return;
+  @restartableTask
+  *load() {
+    this.meshDescriptorRelationship = yield this.args.subject.meshDescriptors;
+  }
+  get meshDescriptors() {
+    if (!this.meshDescriptorRelationship) {
+      return [];
     }
-    this.meshDescriptors = meshDescriptors.toArray();
+
+    return this.meshDescriptorRelationship.toArray();
   }
   @action
   manage() {

--- a/addon/components/learningmaterial-search.hbs
+++ b/addon/components/learningmaterial-search.hbs
@@ -15,11 +15,7 @@
     <ul class="lm-search-results">
       {{#each this.searchResults as |learningMaterial|}}
         <li
-          class={{if
-            (includes learningMaterial (await @currentMaterials))
-            "disabled"
-            ""
-          }}
+          class={{if (includes learningMaterial.id @currentMaterialIds) "disabled"}}
           role="button"
           {{on "click" (perform this.addLearningMaterial learningMaterial)}}
         >

--- a/addon/components/learningmaterial-search.js
+++ b/addon/components/learningmaterial-search.js
@@ -71,6 +71,8 @@ export default class LearningMaterialSearchComponent extends Component {
 
   @enqueueTask
   *addLearningMaterial(lm) {
-    yield this.args.add(lm);
+    if (!this.args.currentMaterialIds.includes(lm.id)) {
+      yield this.args.add(lm);
+    }
   }
 }

--- a/addon/components/new-session.hbs
+++ b/addon/components/new-session.hbs
@@ -1,10 +1,7 @@
 <div
-
   class="new-session"
   data-test-new-session
   ...attributes
-  {{did-insert (fn this.load) @sessionTypes}}
-  {{did-update (fn this.load) @sessionTypes}}
 >
   <h4>{{t "general.newSession"}}</h4>
   <div class="new-session-content">

--- a/addon/components/new-session.js
+++ b/addon/components/new-session.js
@@ -11,15 +11,9 @@ export default class NewSessionComponent extends Component {
 
   @NotBlank() @Length(3, 200) @tracked title;
   @tracked selectedSessionTypeId;
-  @tracked activeSessionTypes;
 
-  @action
-  load(element, [sessionTypes]) {
-    if (!sessionTypes) {
-      return;
-    }
-
-    this.activeSessionTypes = sessionTypes.filterBy('active', true);
+  get activeSessionTypes() {
+    return this.args.sessionTypes.filterBy('active', true);
   }
 
   get selectedSessionType() {

--- a/addon/components/print-course.hbs
+++ b/addon/components/print-course.hbs
@@ -1,7 +1,7 @@
 <section
   class="print-course"
-  {{did-insert (perform this.load) @course}}
-  {{did-update (perform this.load) @course}}
+  {{did-insert (perform this.load)}}
+  {{did-update (perform this.load) @course.sessions @course.learningMaterials}}
   ...attributes
 >
   <div class="header" data-test-course-header>
@@ -122,10 +122,10 @@
   </section>
   <section class="block" data-test-course-learningmaterials>
     <div class="title">
-      {{t "general.learningMaterials"}} ({{get (await this.courseLearningMaterials) "length"}})
+      {{t "general.learningMaterials"}} ({{this.courseLearningMaterials.length}})
     </div>
     <div class="content">
-      {{#if (get (await this.courseLearningMaterials) "length")}}
+      {{#if this.courseLearningMaterials}}
         <table>
           <thead>
             <tr>
@@ -147,7 +147,7 @@
             </tr>
           </thead>
           <tbody>
-            {{#each (await this.courseLearningMaterials) as |lm|}}
+            {{#each this.courseLearningMaterials as |lm|}}
               <tr>
                 <td class="text-left text-top" colspan="2">
                   {{lm.learningMaterial.title}}

--- a/addon/components/print-course.js
+++ b/addon/components/print-course.js
@@ -9,21 +9,32 @@ export default class PrintCourseComponent extends Component {
 
   @tracked sortTitle;
   @tracked sortDirectorsBy;
-  @tracked sessions = [];
-  @tracked courseLearningMaterials = [];
+  @tracked courseLearningMaterialsRelationship;
+  @tracked sessionsRelationship;
 
   @dropTask
-  *load(event, [course]) {
-    if (!course) {
-      return;
-    }
-    this.courseLearningMaterials = (yield course.learningMaterials).toArray().sort(sortableByPosition);
+  *load() {
+    this.courseLearningMaterialsRelationship = yield this.args.course.learningMaterials;
+    this.sessionsRelationship = yield this.args.course.sessions;
+  }
 
-    let sessions = yield course.sessions;
+  get courseLearningMaterials() {
+    if (!this.courseLearningMaterialsRelationship) {
+      return [];
+    }
+
+    return this.courseLearningMaterialsRelationship.toArray().sort(sortableByPosition);
+  }
+
+  get sessions() {
+    if (!this.sessionsRelationship) {
+      return [];
+    }
+
     if (!this.args.includeUnpublishedSessions) {
-      sessions = sessions.filterBy('isPublishedOrScheduled');
+      return this.sessionsRelationship.filterBy('isPublishedOrScheduled');
     }
 
-    this.sessions = sessions;
+    return this.sessionsRelationship.toArray();
   }
 }

--- a/addon/components/publish-all-sessions.hbs
+++ b/addon/components/publish-all-sessions.hbs
@@ -1,7 +1,7 @@
 <div
   class="publish-all-sessions"
-  {{did-insert (perform this.load) @sessions @course.objectives}}
-  {{did-update (perform this.load) @sessions @course.objectives}}
+  data-test-publish-all-sessions
+  {{did-insert (perform this.load)}}
 >
   {{#unless this.load.isRunning}}
     <section class="publish-all-sessions-unpublishable">

--- a/addon/components/publish-all-sessions.js
+++ b/addon/components/publish-all-sessions.js
@@ -14,9 +14,9 @@ export default class PublishAllSessionsComponent extends Component {
   @tracked sessionsToOverride = [];
   @tracked publishableCollapsed = true;
   @tracked unPublishableCollapsed = true;
-  @tracked showWarning = false;
   @tracked totalSessionsToSave;
   @tracked currentSessionsSaved;
+  @tracked courseObjectivesRelationship;
 
   get noSessionsAsIs() {
     return this.sessionsToOverride.length === 0;
@@ -34,15 +34,21 @@ export default class PublishAllSessionsComponent extends Component {
   }
 
   @restartableTask
-  *load(element, [sessions]) {
-    const objectives = yield this.args.course.courseObjectives;
-    this.showWarning = objectives.toArray().any(objective => ! objective.programYearObjectives.length);
-    this.sessionsToOverride = [];
-    if (sessions) {
-      this.sessionsToOverride = this.overridableSessions.filter(session => {
-        return session.published && ! session.publishedAsTbd;
-      });
+  *load() {
+    this.courseObjectivesRelationship = yield this.args.course.courseObjectives;
+    this.sessionsToOverride = this.overridableSessions.filter(session => {
+      return session.published && ! session.publishedAsTbd;
+    });
+  }
+
+  get showWarning(){
+    if (!this.courseObjectivesRelationship) {
+      return false;
     }
+
+    return this.courseObjectivesRelationship.toArray().any(objective => {
+      return objective.programYearObjectives.length === 0;
+    });
   }
 
   get allSessionsAsIs(){

--- a/addon/components/selectable-terms-list.hbs
+++ b/addon/components/selectable-terms-list.hbs
@@ -1,9 +1,9 @@
 <ul
   class="selectable-terms-list"
-  {{did-insert (perform this.load) @vocabulary @terms @termFilter}}
-  {{did-update (perform this.load) @vocabulary @terms @termFilter}}
+  {{did-insert (perform this.loadFilteredTerms)}}
+  {{did-update (perform this.loadFilteredTerms) this.topLevelTermsRelationshipPromise @termFilter @terms}}
 >
-  {{#if this.terms}}
+  {{#unless this.loadFilteredTerms.isRunning}}
     {{#each (sort-by "title" this.terms) as |term|}}
       {{#if (await term.isActiveInTree)}}
         <li class={{if term.isTopLevel "top-level" "nested"}}>
@@ -25,5 +25,5 @@
         </li>
       {{/if}}
     {{/each}}
-  {{/if}}
+  {{/unless}}
 </ul>

--- a/addon/components/selectable-terms-list.js
+++ b/addon/components/selectable-terms-list.js
@@ -1,38 +1,32 @@
-import { isEmpty } from '@ember/utils';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { restartableTask } from "ember-concurrency-decorators";
 import { filter } from 'rsvp';
 
-
 export default class SelectableTermsList extends Component {
   @tracked terms = [];
 
+  get topLevelTermsRelationshipPromise() {
+    return this.args.vocabulary ? this.args.vocabulary.get('topLevelTerms') : null;
+  }
+
   @restartableTask
-  *load(element, [vocabulary, terms, termFilter]) {
-    if (vocabulary) {
-      const topLevelTerms = yield vocabulary.get('topLevelTerms');
-      if (isEmpty(termFilter)) {
-        this.terms = topLevelTerms;
-      } else {
-        const exp = new RegExp(termFilter, 'gi');
-        this.terms = yield filter(topLevelTerms.toArray(), async term => {
-          const searchString = await term.get('titleWithDescendantTitles');
-          return searchString.match(exp);
-        });
-      }
-    } else if (terms) {
-      if (isEmpty(termFilter)) {
-        this.terms = terms.toArray();
-      } else {
-        const exp = new RegExp(termFilter, 'gi');
-        this.terms = yield filter(terms.toArray(), async term => {
-          const searchString = await term.get('titleWithDescendantTitles');
-          return searchString.match(exp);
-        });
-      }
+  *loadFilteredTerms() {
+    let terms = [];
+    if (this.topLevelTermsRelationshipPromise) {
+      terms = (yield this.topLevelTermsRelationshipPromise).toArray();
+    } else if (this.args.terms) {
+      terms = this.args.terms.toArray();
+    }
+
+    if (this.args.termFilter) {
+      const exp = new RegExp(this.args.termFilter, 'gi');
+      this.terms = yield filter(terms, async term => {
+        const searchString = await term.get('titleWithDescendantTitles');
+        return searchString.match(exp);
+      });
     } else {
-      this.terms = [];
+      this.terms = terms;
     }
   }
 }

--- a/addon/components/session-offerings-list.hbs
+++ b/addon/components/session-offerings-list.hbs
@@ -1,7 +1,7 @@
 <div
   class="session-offerings-list"
-  {{did-insert (perform this.load) @session @session.offerings}}
-  {{did-update (perform this.load) @session @session.offerings}}
+  {{did-insert (perform this.load)}}
+  {{did-update (perform this.load) @session}}
   data-test-session-offerings-list
 >
   {{#each (await this.offeringBlocks) as |block|}}

--- a/addon/components/session-offerings-list.js
+++ b/addon/components/session-offerings-list.js
@@ -7,17 +7,18 @@ import { restartableTask } from 'ember-concurrency-decorators';
 
 export default class SessionOfferingsListComponent extends Component {
   @service store;
-  @tracked offerings;
+  @tracked offeringsRelationship;
 
   @restartableTask
-  *load(element, [session]){
-    this.offerings = (yield session.offerings).toArray();
+  *load(){
+    this.offeringsRelationship = yield this.args.session.offerings;
+  }
+
+  get offerings() {
+    return this.offeringsRelationship ? this.offeringsRelationship.toArray() : [];
   }
 
   get offeringBlocks() {
-    if (!this.offerings) {
-      return [];
-    }
     const dateBlocks = {};
     this.offerings.forEach(offering => {
       const key = offering.get('dateKey');

--- a/addon/components/session-publicationcheck.hbs
+++ b/addon/components/session-publicationcheck.hbs
@@ -1,7 +1,7 @@
 <div
   class="session-publicationcheck"
-  {{did-insert (fn this.load) (await @session.sessionObjectives)}}
-  {{did-update (fn this.load) (await @session.sessionObjectives)}}
+  {{did-insert (perform this.load)}}
+  {{did-update (perform this.load) @session}}
 >
   <SessionOverview
     @session={{@session}}

--- a/addon/components/session/collapsed-objectives.hbs
+++ b/addon/components/session/collapsed-objectives.hbs
@@ -1,13 +1,13 @@
 <section
   class="session-collapsed-objectives"
   data-test-session-collapsed-objectives
-  {{did-insert (perform this.load) @session.sessionObjectives}}
+  {{did-insert (perform this.load)}}
   {{did-update (perform this.load) @session.sessionObjectives}}
 >
   <div class="title" role="button" {{on "click" @expand}} data-test-title>
     {{t "general.objectives"}} ({{get this.objectives "length"}})
   </div>
-  {{#if this.load.lastSuccessful.value}}
+  {{#if this.load.lastSuccessful}}
     <div class="content">
       <table>
         <thead>

--- a/addon/components/session/collapsed-objectives.js
+++ b/addon/components/session/collapsed-objectives.js
@@ -3,33 +3,32 @@ import { tracked } from '@glimmer/tracking';
 import { restartableTask } from 'ember-concurrency-decorators';
 
 export default class SessionCollapsedObjectivesComponent extends Component {
-  @tracked objectives;
-  @tracked objectivesWithParents;
-  @tracked objectivesWithMesh;
-  @tracked objectivesWithTerms;
+  @tracked objectivesRelationship;
 
   @restartableTask
-  *load(element, [objectivePromise]) {
-    if (!objectivePromise) {
-      return false;
-    }
-    this.objectives = yield objectivePromise;
+  *load() {
+    this.objectivesRelationship = yield this.args.session.sessionObjectives;
+  }
 
-    this.objectivesWithParents = this.objectives.filter(objective => {
-      const parentIds = objective.hasMany('courseObjectives').ids();
+  get objectives() {
+    return this.objectivesRelationship ? this.objectivesRelationship.toArray() : [];
+  }
 
-      return parentIds.length > 0;
+  get objectivesWithParents() {
+    return this.objectives.filter(objective => {
+      return objective.courseObjectives.length > 0;
     });
-    this.objectivesWithMesh = this.objectives.filter(objective => {
-      const meshDescriptorIds = objective.hasMany('meshDescriptors').ids();
+  }
 
-      return meshDescriptorIds.length > 0;
+  get objectivesWithMesh() {
+    return this.objectives.filter(objective => {
+      return objective.meshDescriptors.length > 0;
     });
-    this.objectivesWithTerms = this.objectives.filter(objective => {
-      const termIds = objective.hasMany('terms').ids();
-      return termIds.length > 0;
-    });
+  }
 
-    return true;
+  get objectivesWithTerms() {
+    return this.objectives.filter(objective => {
+      return objective.terms.length > 0;
+    });
   }
 }

--- a/addon/components/session/objectives.hbs
+++ b/addon/components/session/objectives.hbs
@@ -1,7 +1,7 @@
 <section
   class="session-objectives {{if this.showCollapsible "collapsible"}}"
-  {{did-insert this.load @session}}
-  {{did-update this.load @session @session.sessionObjectives}}
+  {{did-insert (perform this.load) }}
+  {{did-update (perform this.load) @session}}
   data-test-session-objectives
 >
   <div class="header">

--- a/addon/components/session/objectives.js
+++ b/addon/components/session/objectives.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import { dropTask } from 'ember-concurrency-decorators';
+import { dropTask, restartableTask } from 'ember-concurrency-decorators';
 import { action } from '@ember/object';
 
 export default class SessionObjectivesComponent extends Component {
@@ -10,7 +10,7 @@ export default class SessionObjectivesComponent extends Component {
 
   @tracked newObjectiveEditorOn = false;
   @tracked newObjectiveTitle;
-  @tracked objectiveCount;
+  @tracked objectivesRelationship;
 
   get showCollapsible(){
     return this.hasObjectives && !this.isManaging;
@@ -20,9 +20,13 @@ export default class SessionObjectivesComponent extends Component {
     return this.objectiveCount > 0;
   }
 
-  @action
-  load(element, [session]) {
-    this.objectiveCount = session.hasMany('sessionObjectives').ids().length;
+  get objectiveCount() {
+    return this.objectivesRelationship ? this.objectivesRelationship.length : 0;
+  }
+
+  @restartableTask
+  *load() {
+    this.objectivesRelationship = yield this.args.session.sessionObjectives;
   }
 
   @dropTask

--- a/addon/components/user-name-info.hbs
+++ b/addon/components/user-name-info.hbs
@@ -1,8 +1,8 @@
 <span
   class="user-name-info"
   data-test-user-name-info
-  {{did-insert this.load (await @user)}}
-  {{did-update this.load (await @user)}}
+  {{did-insert this.load}}
+  {{did-update this.load @user}}
 >
   <span data-test-fullname>{{this.fullName}}</span>
   {{#if this.hasDifferentCampusNameOfRecord}}

--- a/addon/components/user-name-info.js
+++ b/addon/components/user-name-info.js
@@ -9,13 +9,13 @@ export default class UserNameInfoComponent extends Component {
   @tracked hasDifferentCampusNameOfRecord = false;
 
   @action
-  load(element, [user]){
-    if (! user) {
-      return;
+  load(){
+    if (!this.args.user) {
+      return false;
     }
-    this.fullName = user.get('fullName');
-    this.hasDifferentCampusNameOfRecord = user.get('hasDifferentDisplayName');
-    this.campusNameOfRecord = user.get('fullNameFromFirstMiddleLastName');
+    this.fullName = this.args.user.get('fullName');
+    this.hasDifferentCampusNameOfRecord = this.args.user.get('hasDifferentDisplayName');
+    this.campusNameOfRecord = this.args.user.get('fullNameFromFirstMiddleLastName');
   }
 
   @action

--- a/tests/integration/components/collapsed-competencies-test.js
+++ b/tests/integration/components/collapsed-competencies-test.js
@@ -14,24 +14,29 @@ module('Integration | Component | collapsed competencies', function(hooks) {
     const schoolB = this.server.create('school', { title: 'Pharmacy' });
     const competencyA = this.server.create('competency', { school: schoolA });
     const competencyB = this.server.create('competency', { school: schoolB });
+    const competencyC = this.server.create('competency', { school: schoolB });
     const programYear = this.server.create('programYear');
     const pyObjectiveA = this.server.create('programYearObjective', { programYear, competency: competencyA });
     const pyObjectiveB = this.server.create('programYearObjective', { programYear, competency: competencyB });
+    const pyObjectiveC = this.server.create('programYearObjective', { programYear, competency: competencyC });
     const course = this.server.create('course');
-    this.server.create('courseObjective', { course, programYearObjectives: [ pyObjectiveA ]});
+    this.server.create('courseObjective', { course, programYearObjectives: [ pyObjectiveA, pyObjectiveC ]});
     this.server.create('courseObjective', { course, programYearObjectives: [ pyObjectiveB ]});
+    this.server.create('courseObjective', { course, programYearObjectives: [ pyObjectiveC ]});
     this.course = await this.owner.lookup('service:store').find('course', course.id);
   });
 
   test('it renders', async function(assert) {
-    assert.expect(5);
+    assert.expect(7);
     this.set('subject', this.course);
     await render(hbs`<CollapsedCompetencies @subject={{this.subject}} @expand={{noop}} />`);
-    assert.equal(component.title, 'Competencies (2)');
+    assert.equal(component.title, 'Competencies (3)');
     assert.equal(component.headers[0].text, 'School');
     assert.equal(component.headers[1].text, 'Competencies');
     assert.equal(component.competencies[0].school, 'Medicine');
-    assert.equal(component.competencies[1].count, '1');
+    assert.equal(component.competencies[0].count, '1');
+    assert.equal(component.competencies[1].school, 'Pharmacy');
+    assert.equal(component.competencies[1].count, '2');
   });
 
   test('clicking the header expands the list', async function(assert) {
@@ -41,7 +46,7 @@ module('Integration | Component | collapsed competencies', function(hooks) {
       assert.ok(true, 'Action was fired');
     });
     await render(hbs`<CollapsedCompetencies @subject={{this.subject}} @expand={{this.click}} />`);
-    assert.equal(component.title, 'Competencies (2)');
+    assert.equal(component.title, 'Competencies (3)');
     await component.expand();
   });
 });

--- a/tests/integration/components/detail-learning-materials-test.js
+++ b/tests/integration/components/detail-learning-materials-test.js
@@ -42,7 +42,6 @@ module('Integration | Component | detail learning materials', function(hooks) {
     await render(hbs`<DetailLearningMaterials
       @subject={{this.subject}}
       @isCourse={{true}}
-      @isCourse={{true}}
       @editable={{true}}
     />`);
     assert.equal(component.current.length, 1);

--- a/tests/integration/components/publish-all-sessions-test.js
+++ b/tests/integration/components/publish-all-sessions-test.js
@@ -42,12 +42,12 @@ module('Integration | Component | publish all sessions', function(hooks) {
     this.server.create('offering', { session: completeSession });
     this.server.create('offering', { session: fullyPublishedByIncompleteSession });
     this.server.create('sessionObjective', { session: completeSession });
-    this.publishableSession = await this.owner.lookup('service:store').find('session', publishableSession.id);
-    this.unpublishableSession = await this.owner.lookup('service:store').find('session', unpublishableSession.id);
-    this.completeSession = await this.owner.lookup('service:store').find('session', completeSession.id);
-    this.fullyPublishedByIncompleteSession
-      = await this.owner.lookup('service:store').find('session', fullyPublishedByIncompleteSession.id);
-    this.course = await this.owner.lookup('service:store').find('course', course.id);
+    const store = this.owner.lookup('service:store');
+    this.publishableSession = await store.find('session', publishableSession.id);
+    this.unpublishableSession = await store.find('session', unpublishableSession.id);
+    this.completeSession = await store.find('session', completeSession.id);
+    this.fullyPublishedByIncompleteSession = await store.find('session', fullyPublishedByIncompleteSession.id);
+    this.course = await store.find('course', course.id);
   });
 
   test('it renders', async function(assert) {


### PR DESCRIPTION
Ember data and `did-update` don't always play nice. So instead of re-running the load method when a relationships changes a better course is to resolve the realtionship into a tracked property which we can then manipulate and use elsewhere. Ember data will handle ensuring autotracking on the resolved value unless we call a utility that converts it into an array such as `.map` or `.toArray`.