### PR TITLE
moves scroll-into-view into wrapper component.

### DIFF
--- a/addon/components/new-offering.hbs
+++ b/addon/components/new-offering.hbs
@@ -1,5 +1,7 @@
-<div class="new-offering">
-  <div class="new-offering-title">
+<div
+  class="new-offering"
+>
+  <div class="new-offering-title" {{did-insert this.scrollHere}}>
     {{t "general.newOffering"}}
   </div>
   <div class="choose-offering-type">
@@ -21,6 +23,5 @@
     @save={{this.save}}
     @smallGroupMode={{this.smallGroupMode}}
     @session={{@session}}
-    @scrollToBottom={{true}}
   />
 </div>

--- a/addon/components/new-offering.js
+++ b/addon/components/new-offering.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import scrollIntoView from "scroll-into-view";
 
 export default class NewObjectiveComponent extends Component {
   @service store;
@@ -22,5 +23,10 @@ export default class NewObjectiveComponent extends Component {
     });
 
     return offering.save();
+  }
+
+  @action
+  scrollHere(element) {
+    scrollIntoView(element);
   }
 }

--- a/addon/components/offering-form.hbs
+++ b/addon/components/offering-form.hbs
@@ -1,8 +1,8 @@
 <div
   class="offering-form"
   data-test-offering-form
-  {{did-insert (perform this.load) @offering @cohorts @scrollToBottom}}
-  {{did-update (perform this.load) @offering @cohorts @scrollToBottom}}
+  {{did-insert (perform this.load) @offering @cohorts}}
+  {{did-update (perform this.load) @offering @cohorts}}
 >
   {{#unless this.loadData.isRunning}}
     <div class="toggle-offering-calendar">
@@ -21,7 +21,7 @@
         @session={{@session}}
       />
     {{/if}}
-    <div class="form" {{did-insert (set this.scrollTo)}}>
+    <div class="form">
       <fieldset class="scheduling">
         <legend>{{t "general.scheduling"}}</legend>
         <div class="scheduling-controls">

--- a/addon/components/offering-form.js
+++ b/addon/components/offering-form.js
@@ -9,7 +9,6 @@ import { timeout } from 'ember-concurrency';
 import { dropTask, restartableTask } from "ember-concurrency-decorators";
 import { ArrayNotEmpty, IsInt, Lte, Gte, Gt, NotBlank, Length, IsURL, validatable } from 'ilios-common/decorators/validation';
 import { ValidateIf } from "class-validator";
-import scrollIntoView from "scroll-into-view";
 
 const DEBOUNCE_DELAY = 600;
 const DEFAULT_URL_VALUE = 'https://';
@@ -128,12 +127,9 @@ export default class OfferingForm extends Component {
   }
 
   @restartableTask
-  * load(element, [offering, cohorts, scrollToBottom]) {
+  * load(element, [offering, cohorts]) {
     yield this.loadData.perform(offering, cohorts);
     yield timeout(1);
-    if (scrollToBottom) {
-      scrollIntoView(this.scrollTo);
-    }
   }
 
   @restartableTask()


### PR DESCRIPTION
@dartajax i moved the scroll-into-view functionality out of the offering form component itself and into the wrapper component for new offerings. the new scroll target is the "New Offering" label. 