### PR TITLE
re-styles selected learner groups as removable tag list mixin.

### DIFF
--- a/app/styles/ilios-common/components/detail-learnergroups-list.scss
+++ b/app/styles/ilios-common/components/detail-learnergroups-list.scss
@@ -12,7 +12,7 @@
     @include ilios-fieldset;
 
     ul {
-      @include ilios-list-badges();
+      @include ilios-removable-list;
 
       .top-level-group {
         background-color: $ilios-yellow;


### PR DESCRIPTION
this is a space-saving measure.

fixes #1776 

![Selection_054](https://user-images.githubusercontent.com/1410427/99468022-71203700-28f4-11eb-8be2-4b1f1f65c5b8.png)
