### PR TITLE
adds IsHexColor validator.

### DIFF
--- a/addon/decorators/validation.js
+++ b/addon/decorators/validation.js
@@ -1,12 +1,13 @@
-import { BeforeDate }  from './validation/before-date';
-import { AfterDate }  from './validation/after-date';
-import { Length }  from './validation/length';
-import { NotBlank }  from './validation/not-blank';
-import { HtmlNotBlank }  from './validation/html-not-blank';
+import { BeforeDate } from './validation/before-date';
+import { AfterDate } from './validation/after-date';
+import { Length } from './validation/length';
+import { NotBlank } from './validation/not-blank';
+import { HtmlNotBlank } from './validation/html-not-blank';
 import { Gte } from './validation/gte';
 import { Gt } from './validation/gt';
 import { Lte } from './validation/lte';
 import { IsEmail } from './validation/is-email';
+import { IsHexColor } from './validation/is-hex-color';
 import { IsInt } from './validation/is-int';
 import { IsTrue } from './validation/is-true';
 import { IsURL } from './validation/is-url';
@@ -22,6 +23,7 @@ export {
   GteProp,
   Lte,
   IsEmail,
+  IsHexColor,
   IsInt,
   IsTrue,
   IsURL,

--- a/addon/decorators/validation/is-hex-color.js
+++ b/addon/decorators/validation/is-hex-color.js
@@ -1,0 +1,27 @@
+import { registerDecorator } from "class-validator";
+import { getOwner } from '@ember/application';
+
+const HEX_COLOR_PATTERN = /^#[a-fA-F0-9]{6}$/;
+
+export function IsHexColor(validationOptions) {
+  return function (object, propertyName) {
+    registerDecorator({
+      name: 'IsHexColor',
+      target: object.constructor,
+      propertyName: propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value) {
+          return HEX_COLOR_PATTERN.test(value);
+        },
+        defaultMessage({ object: target }) {
+          const owner = getOwner(target);
+          const intl = owner.lookup('service:intl');
+          const description = intl.t('errors.description');
+
+          return intl.t('errors.invalid', { description });
+        }
+      },
+    });
+  };
+}


### PR DESCRIPTION
needed for validating component props that are wired to `<input type="color">` input fields.

Most (modern) browsers will not let the users type into an actual input box, for example Chrome and Firefox bring up native color-picker dialogues. However, Safari renders an input box that can be typed in, so we have to validate user input in this fashion.

For reference see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/color