### PR TITLE
restyles "backto" links for course rollover and session copying.

### DIFF
--- a/addon/components/course-rollover.hbs
+++ b/addon/components/course-rollover.hbs
@@ -3,9 +3,11 @@
   {{did-insert (perform this.load) @course}}
   {{did-update (perform this.load) @course}}
 >
-  <LinkTo @route="course" @model={{@course}}>
-    {{t "general.backToTitle" title=@course.title}}
-  </LinkTo>
+  <div class="backtolink">
+    <LinkTo @route="course" @model={{@course}}>
+      {{t "general.backToTitle" title=@course.title}}
+    </LinkTo>
+  </div>
   <div class="rollover-form">
     <h3 class="title">
       {{t "general.courseRollover"}}

--- a/addon/components/session-copy.hbs
+++ b/addon/components/session-copy.hbs
@@ -4,9 +4,11 @@
   {{did-update (perform this.setup) @session}}
 >
   {{#if (and (is-array this.years) (is-array this.courses))}}
-    <LinkTo @route="session" @model={{@session}}>
-      {{t "general.backToTitle" title=@session.title}}
-    </LinkTo>
+    <div class="backtolink">
+      <LinkTo @route="session" @model={{@session}}>
+        {{t "general.backToTitle" title=@session.title}}
+      </LinkTo>
+    </div>
     <div class="rollover-form">
       <h3 class="title">
         {{t "general.copySession"}}

--- a/app/styles/ilios-common/components/body.scss
+++ b/app/styles/ilios-common/components/body.scss
@@ -100,3 +100,7 @@ select {
 .scheduled {
   color: $scheduled-brown;
 }
+
+.backtolink {
+  margin: 1rem 0;
+}

--- a/app/styles/ilios-common/components/course-visualizations.scss
+++ b/app/styles/ilios-common/components/course-visualizations.scss
@@ -1,10 +1,6 @@
 .course-visualizations {
   padding-left: 1rem;
 
-  .backtolink {
-    margin: 1rem 0;
-  }
-
   .visualizations {
     display: flex;
     flex-wrap: wrap;


### PR DESCRIPTION
fixes #1804 

![Selection_095](https://user-images.githubusercontent.com/1410427/101419572-210a1400-38a5-11eb-8c1f-bed4009a354d.png)
![Selection_096](https://user-images.githubusercontent.com/1410427/101419565-1d768d00-38a5-11eb-9e74-c69e539398cd.png)
