### PR TITLE
removes click-event handler

### DIFF
--- a/addon/components/date-picker.hbs
+++ b/addon/components/date-picker.hbs
@@ -1,6 +1,5 @@
 <input
   {{did-insert (perform this.setupPicker)}}
   {{did-update (perform this.updatePicker) @value @maxDate @minDate}}
-  {{on "click" (if this.isOpen this.close (noop))}}
   ...attributes
 />

--- a/addon/components/date-picker.js
+++ b/addon/components/date-picker.js
@@ -4,7 +4,6 @@ import { dropTask, restartableTask } from 'ember-concurrency-decorators';
 import { waitForProperty } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
 import flatpickr from "flatpickr";
-import { action } from '@ember/object';
 import { later } from '@ember/runloop';
 
 export default class DatePickerComponent extends Component {
@@ -55,11 +54,6 @@ export default class DatePickerComponent extends Component {
       maxDate: this.args.maxDate ?? null,
       minDate: this.args.minDate ?? null,
     });
-  }
-
-  @action
-  close() {
-    this?._flatPickerInstance.close();
   }
 
   willDestroy() {


### PR DESCRIPTION
it was making the date picker too trigger happy.
turns out it is not necessary in order to close the picker.

tested with latest FF and Chrome on Linux.

fixes https://github.com/ilios/common/issues/1838