### PR TITLE
Prevent editing course when rolling over

### DIFF
--- a/addon/components/ilios-course-details.hbs
+++ b/addon/components/ilios-course-details.hbs
@@ -10,8 +10,8 @@
       </LinkTo>
     </div>
   {{/if}}
-  <CourseHeader @course={{@course}} @editable={{@editable}} />
-  <CourseOverview @course={{@course}} @editable={{@editable}} />
+  <CourseHeader @course={{@course}} @editable={{and @editable this.notRolloverRoute}} />
+  <CourseOverview @course={{@course}} @editable={{and @editable this.notRolloverRoute}} />
   {{#unless @showDetails}}
     <div
       class="detail-collapsed-control"
@@ -26,7 +26,7 @@
   {{else}}
     <CourseEditing
       @course={{@course}}
-      @editable={{@editable}}
+      @editable={{and @editable this.notRolloverRoute}}
       @courseLeadershipDetails={{@courseLeadershipDetails}}
       @courseObjectiveDetails={{@courseObjectiveDetails}}
       @courseTaxonomyDetails={{@courseTaxonomyDetails}}

--- a/addon/components/ilios-course-details.js
+++ b/addon/components/ilios-course-details.js
@@ -1,12 +1,19 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import scrollIntoView from 'scroll-into-view';
+import { inject as service } from '@ember/service';
 
 export default class IliosCourseDetailsComponent extends Component {
+  @service router;
+
   @action
   collapse() {
     //when the button is clicked to collapse, animate the focus to the top of the page
     scrollIntoView(this.topSection);
     this.args.setShowDetails(false);
+  }
+
+  get notRolloverRoute(){
+    return this.router.currentRouteName !== 'course.rollover';
   }
 }


### PR DESCRIPTION
This is confusing as users may believe they're modifying the rollover
process and not the source course. Fixes #1883