### PR TITLE
re-established cross-browser compat of this test.

### DIFF
--- a/tests/integration/components/weekly-calendar-test.js
+++ b/tests/integration/components/weekly-calendar-test.js
@@ -215,7 +215,7 @@ module('Integration | Component | weekly-calendar', function(hooks) {
     assert.equal(component.longWeekOfYear, 'Semana de 8 de diciembre de 1980');
     assert.equal(component.shortWeekOfYear, '8/12 — 14/12 1980');
     assert.ok(component.dayHeadings[0].isFirstDayOfWeek);
-    assert.equal(component.dayHeadings[0].text, 'lunes lun. 8 dic. 8');
+    assert.ok(component.dayHeadings[0].text.match('lunes lun.? 8 dic.? 8'));
 
     assert.equal(component.events.length, 1);
     assert.ok(component.events[0].isFourthDayOfWeek);
@@ -256,7 +256,7 @@ module('Integration | Component | weekly-calendar', function(hooks) {
     assert.equal(component.longWeekOfYear, 'Semana de 24 de febrero de 2020');
     assert.equal(component.shortWeekOfYear, '24/2 — 1/3 2020');
     assert.ok(component.dayHeadings[0].isFirstDayOfWeek);
-    assert.equal(component.dayHeadings[0].text, 'lunes lun. 24 feb. 24');
+    assert.ok(component.dayHeadings[0].text.match('lunes lun.? 24 feb.? 24'));
 
     assert.equal(component.events.length, 1);
     assert.ok(component.events[0].isSecondDayOfWeek);


### PR DESCRIPTION
lastest FF differs from latest Chrome by adding a dot to the abbreviated
month in the french translation.


![firefox](https://user-images.githubusercontent.com/1410427/106036444-34a64f80-608a-11eb-8f52-67818c58a722.png)
![chrome](https://user-images.githubusercontent.com/1410427/106036454-35d77c80-608a-11eb-8c2d-05465e95231d.png)
