### PR TITLE
fixes deprecation warning with code uglifier plugin.

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -9,13 +9,6 @@ module.exports = function(defaults) {
     dotEnv: {
       clientAllowedKeys: ['ILIOS_FRONTEND_API_NAMESPACE', 'ILIOS_FRONTEND_API_HOST']
     },
-    'ember-cli-terser': {
-      terser: {
-        compress: {
-          collapse_vars: false
-        }
-      }
-    },
     'ember-cli-babel': {
       throwUnlessParallelizable: true
     },

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -9,8 +9,8 @@ module.exports = function(defaults) {
     dotEnv: {
       clientAllowedKeys: ['ILIOS_FRONTEND_API_NAMESPACE', 'ILIOS_FRONTEND_API_HOST']
     },
-    'ember-cli-uglify': {
-      uglify: {
+    'ember-cli-terser': {
+      terser: {
         compress: {
           collapse_vars: false
         }


### PR DESCRIPTION
was seeing 

```
$ SKIP_A11Y=true npm start

> ilios-common@53.0.0 start /home/stefan/dev/projects/common
> ember serve

WARNING: [ember-cli-terser] Passing options as `ember-cli-uglify` in `ember-cli-build.js` is deprecated, please update to passing `ember-cli-terser` (with a `terser` property) instead.

Build successful (55605ms) – Serving on http://localhost:4200/
```

this fixes it. 