### PR TITLE
Silence noisy htmlSafe deprecation

### DIFF
--- a/tests/dummy/config/deprecation-workflow.js
+++ b/tests/dummy/config/deprecation-workflow.js
@@ -9,5 +9,6 @@ window.deprecationWorkflow.config = {
     { handler: 'silence', matchId: 'ember-metal.get-with-default' },
     { handler: 'silence', matchId: 'ember-source.deprecation-without-for' },
     { handler: 'silence', matchId: 'ember-source.deprecation-without-since' },
+    { handler: 'silence', matchId: 'ember-string.htmlsafe-ishtmlsafe' },
   ],
 };


### PR DESCRIPTION
We've fixed this here, but it is still present in some upstream
dependencies.