### PR TITLE
Add a default value to resolve async helper

### DIFF
--- a/addon/classes/resolve-async-value.js
+++ b/addon/classes/resolve-async-value.js
@@ -8,6 +8,11 @@ export default class ResolveAsyncValueResource extends Resource {
   }
 
   async setup() {
+    //when a second value is passed it is the default until the promise gets resolved
+    if (this.args.positional.length > 1) {
+      this.data = this.args.positional[1];
+    }
+
     this.data = await this.args.positional[0];
   }
 }


### PR DESCRIPTION
This allows passing an array or null in to ensure some expected value
will exist when this is `@use`ed in another component and alleviating the
need for an interim getter.

Wip:
- [x] Convert existing usage of this helper to use the default value where needed