### PR TITLE
Only save materials where sort order has changed

### DIFF
--- a/addon/components/detail-learning-materials.hbs
+++ b/addon/components/detail-learning-materials.hbs
@@ -203,11 +203,4 @@
       </table>
     {{/if}}
   </div>
-  {{#if this.saveSortOrder.isRunning}}
-    <WaitSaving
-      @showProgress={{true}}
-      @totalProgress={{this.totalMaterialsToSave}}
-      @currentProgress={{this.currentMaterialsSaved}}
-    />
-  {{/if}}
 </section>


### PR DESCRIPTION
This speeds up sorting significantly in a large list and hopefully makes
the wait-saving indicator unnecessary.

Refs https://github.com/ilios/frontend/issues/5900