### PR TITLE
Update our auto update action

### DIFF
--- a/.github/workflows/update-transitive-dependenies.yaml
+++ b/.github/workflows/update-transitive-dependenies.yaml
@@ -2,7 +2,7 @@ name: Update Transitive Dependencies
 
 on:
   schedule:
-    - cron: '15 11 * * 1' # weekly, on Monday morning (UTC)
+    - cron: '15 11 * * 0' # weekly, on Sunday morning (UTC)
 
 jobs:
   update:
@@ -19,7 +19,7 @@ jobs:
         rm package-lock.json
         npm install
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v2
+      uses: peter-evans/create-pull-request@v3
       with:
           token: ${{ secrets.ZORGBORT_TOKEN }}
           commit-message: Update Transitive Dependencies


### PR DESCRIPTION
The latest version of create-pull-request should fix some errors we're
seeing in our action runs now.

I also moved this to Sunday to decrease the likelihood of conflicts with
dependabot updates.