### PR TITLE
Add autofocus modifier

### DIFF
--- a/addon/modifiers/autofocus.js
+++ b/addon/modifiers/autofocus.js
@@ -1,0 +1,3 @@
+import { modifier } from 'ember-modifier';
+
+export default modifier((element) => element.focus());

--- a/app/modifiers/autofocus.js
+++ b/app/modifiers/autofocus.js
@@ -1,0 +1,1 @@
+export { default } from 'ilios-common/modifiers/autofocus';

--- a/tests/integration/modifiers/autofocus-test.js
+++ b/tests/integration/modifiers/autofocus-test.js
@@ -1,0 +1,14 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Modifier | autofocus', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it focuses', async function (assert) {
+    await render(hbs`<input {{autofocus}} />`);
+
+    assert.dom('input').isFocused();
+  });
+});


### PR DESCRIPTION
This allows us to place focus easily within an element as soon as it is
inserted.