### PR TITLE
Fix deprecation deprecations

### DIFF
--- a/addon/services/api-version.js
+++ b/addon/services/api-version.js
@@ -13,9 +13,11 @@ export default Service.extend({
   }),
 
   isMismatched: computed('iliosConfig.apiVersion', 'version', async function () {
-    deprecate('Async Computed Called', false, {
+    deprecate('isMismatched Computed Called', false, {
       id: 'common.async-computed',
-      until: '40',
+      for: 'ilios-common',
+      until: '56',
+      since: '39.0.2',
     });
     const serverApiVersion = await this.iliosConfig.getApiVersion();
     return serverApiVersion !== this.version;

--- a/addon/services/current-user.js
+++ b/addon/services/current-user.js
@@ -24,9 +24,11 @@ export default Service.extend({
   }),
 
   model: computed('currentUserId', async function () {
-    deprecate('Async Computed Called', false, {
+    deprecate('model Computed Called', false, {
       id: 'common.async-computed',
-      until: '40',
+      for: 'ilios-common',
+      until: '56',
+      since: '39.0.2',
     });
     return this.getModel();
   }),
@@ -47,9 +49,11 @@ export default Service.extend({
   },
 
   userRoleTitles: computed('model.roles.[]', async function () {
-    deprecate('Async Computed Called', false, {
+    deprecate('userRoleTitles Computed Called', false, {
       id: 'common.async-computed',
-      until: '40',
+      for: 'ilios-common',
+      until: '56',
+      since: '39.0.2',
     });
     return this.getUserRoleTitles();
   }),
@@ -63,9 +67,11 @@ export default Service.extend({
   },
 
   userIsStudent: computed('useRoleTitles.[]', async function () {
-    deprecate('Async Computed Called', false, {
+    deprecate('userIsStudent Computed Called', false, {
       id: 'common.async-computed',
-      until: '40',
+      for: 'ilios-common',
+      until: '56',
+      since: '39.0.2',
     });
     return this.getIsStudent();
   }),
@@ -75,9 +81,11 @@ export default Service.extend({
   },
 
   userIsFormerStudent: computed('useRoleTitles.[]', async function () {
-    deprecate('Async Computed Called', false, {
+    deprecate('userIsFormerStudent Computed Called', false, {
       id: 'common.async-computed',
-      until: '40',
+      for: 'ilios-common',
+      until: '56',
+      since: '39.0.2',
     });
     return this.isFormerStudent();
   }),
@@ -95,9 +103,11 @@ export default Service.extend({
     'model.administeredCourses.[]',
     'model.instructorIlmSessions.[]',
     async function () {
-      deprecate('Async Computed Called', false, {
+      deprecate('activeRelatedCoursesInThisYearAndLastYear Computed Called', false, {
         id: 'common.async-computed',
-        until: '40',
+        for: 'ilios-common',
+        until: '56',
+        since: '39.0.2',
       });
       return this.getActiveRelatedCoursesInThisYearAndLastYear();
     }

--- a/addon/services/ilios-config.js
+++ b/addon/services/ilios-config.js
@@ -9,7 +9,7 @@ export default Service.extend({
   _configPromise: null,
 
   config: computed('apiHost', function () {
-    deprecate('Async Computed Called', false, {
+    deprecate('config Computed Called', false, {
       id: 'common.async-computed',
       for: 'ilios-common',
       until: '56',
@@ -32,7 +32,7 @@ export default Service.extend({
   },
 
   userSearchType: computed('config.userSearchType', function () {
-    deprecate('Async Computed Called', false, {
+    deprecate('userSearchType Computed Called', false, {
       id: 'common.async-computed',
       for: 'ilios-common',
       until: '56',
@@ -45,7 +45,7 @@ export default Service.extend({
   },
 
   authenticationType: computed('config.type', function () {
-    deprecate('Async Computed Called', false, {
+    deprecate('authenticationType Computed Called', false, {
       id: 'common.async-computed',
       for: 'ilios-common',
       until: '56',
@@ -58,7 +58,7 @@ export default Service.extend({
   },
 
   maxUploadSize: computed('config.maxUploadSize', function () {
-    deprecate('Async Computed Called', false, {
+    deprecate('maxUploadSize Computed Called', false, {
       id: 'common.async-computed',
       for: 'ilios-common',
       until: '56',
@@ -71,7 +71,7 @@ export default Service.extend({
   },
 
   apiVersion: computed('config.apiVersion', function () {
-    deprecate('Async Computed Called', false, {
+    deprecate('apiVersion Computed Called', false, {
       id: 'common.async-computed',
       for: 'ilios-common',
       until: '56',
@@ -84,7 +84,7 @@ export default Service.extend({
   },
 
   trackingEnabled: computed('config.trackingEnabled', function () {
-    deprecate('Async Computed Called', false, {
+    deprecate('trackingEnabled Computed Called', false, {
       id: 'common.async-computed',
       for: 'ilios-common',
       until: '56',
@@ -97,7 +97,7 @@ export default Service.extend({
   },
 
   trackingCode: computed('config.trackingCode', function () {
-    deprecate('Async Computed Called', false, {
+    deprecate('trackingCode Computed Called', false, {
       id: 'common.async-computed',
       for: 'ilios-common',
       until: '56',
@@ -110,7 +110,7 @@ export default Service.extend({
   },
 
   loginUrl: computed('config.loginUrl', function () {
-    deprecate('Async Computed Called', false, {
+    deprecate('loginUrl Computed Called', false, {
       id: 'common.async-computed',
       for: 'ilios-common',
       until: '56',
@@ -123,7 +123,7 @@ export default Service.extend({
   },
 
   casLoginUrl: computed('config.casLoginUrl', function () {
-    deprecate('Async Computed Called', false, {
+    deprecate('casLoginUrl Computed Called', false, {
       id: 'common.async-computed',
       for: 'ilios-common',
       until: '56',
@@ -166,7 +166,7 @@ export default Service.extend({
   }),
 
   searchEnabled: computed('config.searchEnabled', async function () {
-    deprecate('Async Computed Called', false, {
+    deprecate('searchEnabled Computed Called', false, {
       id: 'common.async-computed',
       for: 'ilios-common',
       until: '56',

--- a/addon/services/permission-matrix.js
+++ b/addon/services/permission-matrix.js
@@ -6,9 +6,11 @@ export default Service.extend({
   store: service(),
   _permissionMatrixPromise: null,
   permissionMatrix: computed(async function () {
-    deprecate('Async Computed Called', false, {
+    deprecate('permissionMatrix Computed Called', false, {
       id: 'common.async-computed',
-      until: '40',
+      for: 'ilios-common',
+      until: '56',
+      since: '39.0.2',
     });
     return this.getPermissionMatrix();
   }),

--- a/tests/dummy/config/deprecation-workflow.js
+++ b/tests/dummy/config/deprecation-workflow.js
@@ -4,7 +4,6 @@ window.deprecationWorkflow = window.deprecationWorkflow || {};
 window.deprecationWorkflow.config = {
   workflow: [
     { handler: 'silence', matchId: 'computed-property.volatile' },
-    { handler: 'silence', matchId: 'common.async-computed' },
     { handler: 'silence', matchId: 'ember-metal.get-with-default' },
     { handler: 'silence', matchId: 'ember-string.htmlsafe-ishtmlsafe' },
   ],


### PR DESCRIPTION
We needed to add some required attributes to our deprecation notices to
avoid throwing a second notice.  Also added more context info to help
with tracking these down.