### PR TITLE
check if dashboard route exists before linking to it.

### DIFF
--- a/addon/components/not-found.hbs
+++ b/addon/components/not-found.hbs
@@ -1,7 +1,9 @@
 <p>
   {{t "general.notFoundMessage"}}
   <br>
-  <LinkTo @route="dashboard" @query={{null}}>
-    {{t "general.backToDashboard"}}
-  </LinkTo>
+  {{#if (has-route "dashboard")}}
+    <LinkTo @route="dashboard" @query={{null}}>
+      {{t "general.backToDashboard"}}
+    </LinkTo>
+  {{/if}}
 </p>


### PR DESCRIPTION
something i noticed while click-testing the LTI dashboard app, where the "dashboard" route doesn't exist (it's the application route there).