### PR TITLE
Replace slash with math.div

### DIFF
--- a/app/styles/ilios-common/components/daily-calendar.scss
+++ b/app/styles/ilios-common/components/daily-calendar.scss
@@ -1,6 +1,8 @@
+@use "sass:math";
+
 .daily-calendar {
   $hour-height: .3rem;
-  $minute-rows: 24 * 60 / 5; //every 5 minutes
+  $minute-rows: math.div(24 * 60, 5); //every 5 minutes
   --hour-space: 2.9rem;
   $grid-border-color: $grey;
 

--- a/app/styles/ilios-common/components/progress-bar.scss
+++ b/app/styles/ilios-common/components/progress-bar.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 .progress-bar {
   $progress-border-color: $base-border-color;
   $progress-border: 1px solid $progress-border-color;
@@ -21,7 +23,7 @@
     background-repeat: repeat-x;
     background-size: 40px 40px;
     border: $progress-meter-border;
-    border-radius: $base-border-radius / 1.5;
+    border-radius: math.div($base-border-radius, 1.5);
     border-bottom-right-radius: 0;
     border-top-right-radius: 0;
     box-sizing: border-box;

--- a/app/styles/ilios-common/components/weekly-calendar.scss
+++ b/app/styles/ilios-common/components/weekly-calendar.scss
@@ -1,6 +1,8 @@
+@use "sass:math";
+
 .weekly-calendar {
   $hour-height: .3rem;
-  $minute-rows: 24 * 60 / 5; //every 5 minutes
+  $minute-rows: math.div(24 * 60, 5); //every 5 minutes
   --hour-space: 2.9rem;
   $grid-border-color: $grey;
 

--- a/app/styles/ilios-common/mixins/ilios-table.scss
+++ b/app/styles/ilios-common/mixins/ilios-table.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @mixin ilios-table-structure () {
   border-collapse: collapse;
   margin: ($base-line-height * .5em) 0;
@@ -5,13 +7,13 @@
   width: 100%;
 
   th {
-    padding: ($base-line-height * .5em / 2) 0;
+    padding: math.div($base-line-height * .5em, 2) 0;
     text-align: left;
   }
 
   td {
     border: 0;
-    padding: ($base-line-height * .5em / 2) 0;
+    padding: math.div($base-line-height * .5em, 2) 0;
   }
 
   th,


### PR DESCRIPTION
This is required due to the deprecation of / for division in SASS.

Fixes #2151