### PR TITLE
Give the events grid some columns

### DIFF
--- a/app/styles/ilios-common/components/daily-calendar.scss
+++ b/app/styles/ilios-common/components/daily-calendar.scss
@@ -57,6 +57,7 @@
       display: grid;
       grid-column: 2;
       grid-row: 1 / -1;
+      grid-template-columns: repeat(50, 1fr);
       grid-template-rows: repeat($minute-rows, $hour-height);
       border: 1px solid $grid-border-color;
       @for $day from 1 through 7 {

--- a/app/styles/ilios-common/components/weekly-calendar.scss
+++ b/app/styles/ilios-common/components/weekly-calendar.scss
@@ -61,6 +61,7 @@
       @include ilios-list-reset;
       display: grid;
       grid-row: 1 / -1;
+      grid-template-columns: repeat(50, 1fr);
       grid-template-rows: repeat($minute-rows, $hour-height);
       border: 1px solid $grid-border-color;
       @for $day from 1 through 7 {


### PR DESCRIPTION
We use span 50 and fractions of that to place events on the calendar
along side other events at the same time. This mostly worked, but
without specifying the number of columns in the grid sometimes it
overflows on mobile. This fix uses 50 evenly spaced columns to fill out
each day of the calendar.

Fixes #2157