### PR TITLE
Configure page-title

### DIFF
--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Ilios</title>
 
     {{content-for "head"}}
 

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,1 +1,2 @@
+{{page-title "Ilios"}}
 {{outlet}}

--- a/tests/index.html
+++ b/tests/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Ilios Common Tests</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 


### PR DESCRIPTION
In order for this addon to work in the dummy app the title can't be in
index.html and we need to specify a root title for the application.

Fixes #2169
Supersedes #2170 