### PR TITLE
always allow toggling of session/course leadership expanded/collapsed view

### DIFF
--- a/addon/components/course-editing.hbs
+++ b/addon/components/course-editing.hbs
@@ -1,10 +1,5 @@
 <div>
-  {{#if
-    (or
-      (and (eq @course.directors.length 0) (eq @course.administrators.length 0))
-      @courseLeadershipDetails
-    )
-  }}
+  {{#if @courseLeadershipDetails}}
     <CourseLeadershipExpanded
       @course={{@course}}
       @editable={{@editable}}

--- a/addon/components/course-leadership-expanded.hbs
+++ b/addon/components/course-leadership-expanded.hbs
@@ -4,9 +4,9 @@
 >
   <div class="course-leadership-expanded-header">
     <h3
-      class="title {{if this.isCollapsible "collapsible clickable"}}"
+      class="title {{unless @isManaging "collapsible clickable"}}"
       role="button"
-      {{on "click" (if this.isCollapsible @collapse (noop))}}
+      {{on "click" (unless @isManaging @collapse (noop))}}
       data-test-title
     >
       {{t "general.courseLeadership"}}

--- a/addon/components/course-leadership-expanded.js
+++ b/addon/components/course-leadership-expanded.js
@@ -8,16 +8,7 @@ export default class CourseLeadershipExpandedComponent extends Component {
   @tracked directors = [];
   @tracked administrators = [];
   @tracked studentAdvisors = [];
-  get isCollapsible() {
-    const administratorIds = this.args.course.hasMany('administrators').ids();
-    const directorIds = this.args.course.hasMany('directors').ids();
-    const studentAdvisorIds = this.args.course.hasMany('studentAdvisors').ids();
 
-    return (
-      (administratorIds.length > 0 || directorIds.length > 0 || studentAdvisorIds.length > 0) &&
-      !this.args.isManaging
-    );
-  }
   @action
   addDirector(user) {
     this.directors = [...this.directors, user];

--- a/addon/components/session-leadership-expanded.hbs
+++ b/addon/components/session-leadership-expanded.hbs
@@ -4,9 +4,9 @@
 >
   <div class="session-leadership-expanded-header">
     <h3
-      class="title {{if this.isCollapsible "collapsible clickable"}}"
+      class="title {{unless @isManaging "collapsible clickable"}}"
       role="button"
-      {{on "click" (if this.isCollapsible @collapse (noop))}}
+      {{on "click" (unless @isManaging @collapse (noop))}}
       data-test-title
     >
       {{t "general.sessionLeadership"}}

--- a/addon/components/session-leadership-expanded.js
+++ b/addon/components/session-leadership-expanded.js
@@ -7,12 +7,7 @@ import { hash } from 'rsvp';
 export default class CourseLeadershipExpandedComponent extends Component {
   @tracked administrators = [];
   @tracked studentAdvisors = [];
-  get isCollapsible() {
-    const administratorIds = this.args.session.hasMany('administrators').ids();
-    const studentAdvisorIds = this.args.session.hasMany('studentAdvisors').ids();
 
-    return (administratorIds.length > 0 || studentAdvisorIds.length > 0) && !this.args.isManaging;
-  }
   @action
   addAdministrator(user) {
     this.administrators = [...this.administrators, user];

--- a/tests/integration/components/course-leadership-expanded-test.js
+++ b/tests/integration/components/course-leadership-expanded-test.js
@@ -104,25 +104,6 @@ module('Integration | Component | course leadership expanded', function (hooks) 
     await component.collapse();
   });
 
-  test('clicking the header does not collapse where there are no linked leaders', async function (assert) {
-    assert.expect(0);
-    const course = this.server.create('course');
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
-    this.set('course', courseModel);
-    this.set('click', () => {
-      assert.ok(false);
-    });
-    await render(hbs`<CourseLeadershipExpanded
-      @course={{this.course}}
-      @editable={{true}}
-      @collapse={{this.click}}
-      @expand={{noop}}
-      @isManaging={{false}}
-      @setIsManaging={{noop}}
-    />`);
-    await component.collapse();
-  });
-
   test('clicking manage fires action', async function (assert) {
     assert.expect(1);
     const course = this.server.create('course');
@@ -134,8 +115,8 @@ module('Integration | Component | course leadership expanded', function (hooks) 
     await render(hbs`<CourseLeadershipExpanded
       @course={{this.course}}
       @editable={{true}}
-      @collapse={{this.nothing}}
-      @expand={{this.nothing}}
+      @collapse={{noop}}
+      @expand={{noop}}
       @isManaging={{false}}
       @setIsManaging={{this.click}}
     />`);

--- a/tests/integration/components/session-leadership-expanded-test.js
+++ b/tests/integration/components/session-leadership-expanded-test.js
@@ -85,25 +85,6 @@ module('Integration | Component | session leadership expanded', function (hooks)
     await component.collapse();
   });
 
-  test('clicking the header does not collapse where there are no linked leaders', async function (assert) {
-    assert.expect(0);
-    const session = this.server.create('session');
-    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
-    this.set('session', sessionModel);
-    this.set('click', () => {
-      assert.ok(false);
-    });
-    await render(hbs`<SessionLeadershipExpanded
-      @session={{this.session}}
-      @canUpdate={{true}}
-      @collapse={{this.click}}
-      @expand={{noop}}
-      @isManaging={{false}}
-      @setIsManaging={{noop}}
-    />`);
-    await component.collapse();
-  });
-
   test('clicking manage fires action', async function (assert) {
     assert.expect(1);
     const session = this.server.create('session');
@@ -115,8 +96,8 @@ module('Integration | Component | session leadership expanded', function (hooks)
     await render(hbs`<SessionLeadershipExpanded
       @session={{this.session}}
       @canUpdate={{true}}
-      @collapse={{this.nothing}}
-      @expand={{this.nothing}}
+      @collapse={{noop}}
+      @expand={{noop}}
       @isManaging={{false}}
       @setIsManaging={{this.click}}
     />`);


### PR DESCRIPTION
the `isCollapsed` getters did not correctly recompute on leadership changes, among other things.
i threw this logic and other related state-management code out altogether in favor of a a less convoluted solution that _always_ let's the user expand/collapse the leadership components 

fixes #2188 