### PR TITLE
drop older LTS in favour of current one.

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -7,18 +7,18 @@ module.exports = async function () {
   return {
     scenarios: [
       {
-        name: 'ember-lts-3.16',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.16.0',
-          },
-        },
-      },
-      {
         name: 'ember-lts-3.20',
         npm: {
           devDependencies: {
             'ember-source': '~3.20.5',
+          },
+        },
+      },
+      {
+        name: 'ember-lts-3.24',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.24.0',
           },
         },
       },


### PR DESCRIPTION
for reference: https://emberjs.com/releases/lts/