### PR TITLE
Session type filter visualizations

### DIFF
--- a/addon-test-support/ilios-common/page-objects/components/course-visualize-session-types.js
+++ b/addon-test-support/ilios-common/page-objects/components/course-visualize-session-types.js
@@ -1,8 +1,18 @@
-import { create, text } from 'ember-cli-page-object';
+import { collection, create, fillable, text, value } from 'ember-cli-page-object';
 
 const definition = create({
   scope: '[data-test-course-visualize-session-types]',
   title: text('[data-test-title]'),
+  filter: {
+    scope: '[data-test-filter]',
+    value: value('input'),
+    set: fillable('input'),
+  },
+  chart: {
+    scope: '.simple-chart-horz-bar',
+    bars: collection('.bars rect'),
+    labels: collection('.bars text'),
+  },
 });
 
 export default definition;

--- a/addon/components/course-visualize-instructors.js
+++ b/addon/components/course-visualize-instructors.js
@@ -6,6 +6,7 @@ import { restartableTask } from 'ember-concurrency';
 export default class CourseVisualizeInstructorsComponent extends Component {
   @service iliosConfig;
   @tracked academicYearCrossesCalendarYearBoundaries = false;
+  @tracked name;
 
   @restartableTask
   *load() {

--- a/addon/components/course-visualize-session-type.js
+++ b/addon/components/course-visualize-session-type.js
@@ -6,6 +6,7 @@ import { restartableTask } from 'ember-concurrency';
 export default class CourseVisualizeSessionTypeComponent extends Component {
   @service iliosConfig;
   @tracked academicYearCrossesCalendarYearBoundaries = false;
+  @tracked title;
 
   @restartableTask
   *load() {

--- a/addon/components/course-visualize-session-types.hbs
+++ b/addon/components/course-visualize-session-types.hbs
@@ -22,6 +22,15 @@
         {{/if}}
       </LinkTo>
     </h3>
-    <VisualizerCourseSessionTypes @course={{@model}} />
+    <div class="filter" data-test-filter>
+      <input
+        aria-label={{t "general.filterChartPlaceholder"}}
+        type="search"
+        value={{this.title}}
+        placeholder={{t "general.filterPlaceholder"}}
+        {{on "input" (pick "target.value" (set this.title))}}
+      >
+    </div>
+    <VisualizerCourseSessionTypes @filter={{this.title}} @course={{@model}} />
   {{/unless}}
 </section>

--- a/addon/components/visualizer-course-instructors.js
+++ b/addon/components/visualizer-course-instructors.js
@@ -6,6 +6,7 @@ import { restartableTask, timeout } from 'ember-concurrency';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import { cleanQuery } from 'ilios-common/utils/query-utils';
 
 export default class VisualizerCourseInstructors extends Component {
   @service router;
@@ -24,8 +25,9 @@ export default class VisualizerCourseInstructors extends Component {
     }
 
     let data = this.data;
-    if (this.args.filter) {
-      const exp = new RegExp(this.args.filter, 'gi');
+    const q = cleanQuery(this.args.filter);
+    if (q) {
+      const exp = new RegExp(q, 'gi');
       data = this.data.filter(({ label }) => label.match(exp));
     }
 

--- a/addon/components/visualizer-course-session-types.hbs
+++ b/addon/components/visualizer-course-session-types.hbs
@@ -8,7 +8,7 @@
       <SimpleChart
         @name={{this.chartType}}
         @isIcon={{@isIcon}}
-        @data={{this.data}}
+        @data={{this.filteredData}}
         @onClick={{this.barClick}}
         @hover={{perform this.barHover}}
         @leave={{perform this.barHover}} as |chart|

--- a/addon/components/visualizer-course-session-types.js
+++ b/addon/components/visualizer-course-session-types.js
@@ -18,6 +18,22 @@ export default class VisualizerCourseSessionTypes extends Component {
     return this.args.chartType || 'horz-bar';
   }
 
+  get filteredData() {
+    if (!this.data) {
+      return [];
+    }
+
+    let data = this.data;
+    if (this.args.filter) {
+      const exp = new RegExp(this.args.filter, 'gi');
+      data = this.data.filter(({ label }) => label.match(exp));
+    }
+
+    return data.sort((first, second) => {
+      return first.data - second.data;
+    });
+  }
+
   @restartableTask
   *load(element, [course]) {
     const sessions = yield course.get('sessions');

--- a/addon/components/visualizer-course-session-types.js
+++ b/addon/components/visualizer-course-session-types.js
@@ -6,6 +6,7 @@ import { restartableTask, timeout } from 'ember-concurrency';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import { cleanQuery } from 'ilios-common/utils/query-utils';
 
 export default class VisualizerCourseSessionTypes extends Component {
   @service router;
@@ -24,11 +25,11 @@ export default class VisualizerCourseSessionTypes extends Component {
     }
 
     let data = this.data;
-    if (this.args.filter) {
-      const exp = new RegExp(this.args.filter, 'gi');
+    const q = cleanQuery(this.args.filter);
+    if (q) {
+      const exp = new RegExp(q, 'gi');
       data = this.data.filter(({ label }) => label.match(exp));
     }
-
     return data.sort((first, second) => {
       return first.data - second.data;
     });

--- a/app/styles/ilios-common/components/course-visualize-session-types.scss
+++ b/app/styles/ilios-common/components/course-visualize-session-types.scss
@@ -10,4 +10,16 @@
     margin-bottom: 1rem;
     text-align: center;
   }
+
+  .filter {
+    display: flex;
+    justify-content: flex-end;
+    margin: 1rem 0 .5rem;
+    padding-right: 5rem;
+
+    input {
+      @include ilios-input;
+      width: 25rem;
+    }
+  }
 }

--- a/tests/integration/components/course-visualize-session-types-test.js
+++ b/tests/integration/components/course-visualize-session-types-test.js
@@ -9,12 +9,47 @@ module('Integration | Component | course-visualize-session-types', function (hoo
   setupRenderingTest(hooks);
   setupMirage(hooks);
 
-  test('it renders', async function (assert) {
+  hooks.beforeEach(async function () {
     const school = this.server.create('school');
+    const sessionType1 = this.server.create('session-type', {
+      title: 'Standalone',
+      school,
+    });
+    const sessionType2 = this.server.create('session-type', {
+      title: 'Campaign',
+      school,
+    });
     const course = this.server.create('course', { year: 2021, school });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
-    this.set('course', courseModel);
+    const session1 = this.server.create('session', {
+      title: 'Berkeley Investigations',
+      course,
+      sessionType: sessionType1,
+    });
+    const session2 = this.server.create('session', {
+      title: 'The San Leandro Horror',
+      course,
+      sessionType: sessionType2,
+    });
+    this.server.create('offering', {
+      session: session1,
+      startDate: new Date('2019-12-08T12:00:00'),
+      endDate: new Date('2019-12-08T17:00:00'),
+    });
+    this.server.create('offering', {
+      session: session1,
+      startDate: new Date('2019-12-21T12:00:00'),
+      endDate: new Date('2019-12-21T17:30:00'),
+    });
+    this.server.create('offering', {
+      session: session2,
+      startDate: new Date('2019-12-05T18:00:00'),
+      endDate: new Date('2019-12-05T21:00:00'),
+    });
+    this.courseModel = await this.owner.lookup('service:store').find('course', course.id);
+  });
 
+  test('it renders', async function (assert) {
+    this.set('course', this.courseModel);
     await render(hbs`<CourseVisualizeSessionTypes @model={{this.course}} />`);
     assert.equal(component.title, 'course 0 2021');
   });
@@ -27,13 +62,19 @@ module('Integration | Component | course-visualize-session-types', function (hoo
         },
       };
     });
-    const school = this.server.create('school');
-    const course = this.server.create('course', { year: 2021, school });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
-    this.set('course', courseModel);
-
+    this.set('course', this.courseModel);
     await render(hbs`<CourseVisualizeSessionTypes @model={{this.course}} />`);
-
     assert.equal(component.title, 'course 0 2021 - 2022');
+  });
+
+  test('filter works', async function (assert) {
+    this.set('course', this.courseModel);
+    await render(hbs`<CourseVisualizeSessionTypes @model={{this.course}} />`);
+    assert.equal(component.title, 'course 0 2021');
+    assert.equal(component.chart.bars.length, 2);
+    assert.equal(component.chart.labels.length, 2);
+    await component.filter.set('Campaign');
+    assert.equal(component.chart.bars.length, 1);
+    assert.equal(component.chart.labels.length, 1);
   });
 });

--- a/tests/integration/components/visualizer-course-session-types-test.js
+++ b/tests/integration/components/visualizer-course-session-types-test.js
@@ -50,7 +50,7 @@ module('Integration | Component | visualizer-course-session-types', function (ho
 
     this.set('course', this.courseModel);
 
-    await render(hbs`<VisualizerCourseSessionTypes @course={{course}} @isIcon={{false}} />`);
+    await render(hbs`<VisualizerCourseSessionTypes @course={{this.course}} @isIcon={{false}} />`);
 
     const chartLabels = 'svg .bars text';
     assert.dom(chartLabels).exists({ count: 2 });
@@ -64,12 +64,24 @@ module('Integration | Component | visualizer-course-session-types', function (ho
     this.set('course', this.courseModel);
 
     await render(
-      hbs`<VisualizerCourseSessionTypes @course={{course}} @isIcon={{false}} @chartType="donut" />`
+      hbs`<VisualizerCourseSessionTypes @course={{this.course}} @isIcon={{false}} @chartType="donut" />`
     );
 
     const chartLabels = 'svg .slice text';
     assert.dom(chartLabels).exists({ count: 2 });
     assert.dom(findAll(chartLabels)[0]).hasText('Campaign 22.2%');
     assert.dom(findAll(chartLabels)[1]).hasText('Standalone 77.8%');
+  });
+
+  test('filter applies', async function (assert) {
+    this.set('title', 'Campaign');
+    this.set('course', this.courseModel);
+
+    await render(
+      hbs`<VisualizerCourseSessionTypes @course={{this.course}} @filter={{this.title}} @isIcon={{false}} />`
+    );
+    const chartLabels = 'svg .bars text';
+    assert.dom(chartLabels).exists({ count: 1 });
+    assert.dom(findAll(chartLabels)[0]).hasText('Campaign 22.2%');
   });
 });


### PR DESCRIPTION
fixes #2227 

this adds the filter box to the course/session-type visualizations that already exists for course/instructors.