### PR TITLE
de-emphasize timed-release information on dashboard-related screens

### DIFF
--- a/app/styles/ilios-common/components.scss
+++ b/app/styles/ilios-common/components.scss
@@ -104,6 +104,7 @@
 @import 'components/single-event-objective-list';
 @import 'components/taxonomy-manager';
 @import 'components/time-picker';
+@import 'components/timed-release-schedule';
 @import 'components/toggle-buttons';
 @import 'components/toggle-yesno';
 @import 'components/truncate-text';

--- a/app/styles/ilios-common/components/dashboard-materials.scss
+++ b/app/styles/ilios-common/components/dashboard-materials.scss
@@ -35,7 +35,6 @@
   }
 
   .timed-release-info {
-    color: $ilios-red;
     font-size: smaller;
   }
 }

--- a/app/styles/ilios-common/components/learningmaterial-manager.scss
+++ b/app/styles/ilios-common/components/learningmaterial-manager.scss
@@ -40,11 +40,6 @@
     margin: 2rem 0;
   }
 
-  .timed-release-schedule {
-    font-style: italic;
-    margin: 1rem .5rem;
-  }
-
   .timed-release {
     margin-bottom: 2rem;
     padding-left: 1rem;

--- a/app/styles/ilios-common/components/my-materials.scss
+++ b/app/styles/ilios-common/components/my-materials.scss
@@ -25,7 +25,6 @@
   }
 
   .timed-release-info {
-    color: $ilios-red;
     font-size: smaller;
   }
 

--- a/app/styles/ilios-common/components/single-event-learningmaterial-list.scss
+++ b/app/styles/ilios-common/components/single-event-learningmaterial-list.scss
@@ -8,7 +8,6 @@
   }
 
   .single-event-learningmaterial-item-timing-info {
-    color: $ilios-red;
     font-size: smaller;
     font-weight: normal;
 

--- a/app/styles/ilios-common/components/timed-release-schedule.scss
+++ b/app/styles/ilios-common/components/timed-release-schedule.scss
@@ -1,0 +1,4 @@
+.timed-release-schedule {
+  font-style: italic;
+  margin: 1rem .5rem;
+}

--- a/app/styles/ilios-common/components/week-glance.scss
+++ b/app/styles/ilios-common/components/week-glance.scss
@@ -81,7 +81,6 @@
       }
 
       .timed-release-info {
-        color: $ilios-red;
         font-size: smaller;
       }
     }


### PR DESCRIPTION
fixes #2252 

affects:
- my materials
- week at a glance
- dashboard materials
- single event details