### PR TITLE
Use explicit sortBy

### DIFF
--- a/tests/integration/components/sessions-grid-test.js
+++ b/tests/integration/components/sessions-grid-test.js
@@ -14,7 +14,7 @@ module('Integration | Component | sessions-grid', function (hooks) {
     this.set('setSortBy', () => {});
     await render(hbs`<SessionsGrid
       @sessions={{sessions}}
-      @sortBy={{sortBy}}
+      @sortBy={{this.sortBy}}
       @setSortBy={{action setSortBy}}
     />`);
 
@@ -38,7 +38,7 @@ module('Integration | Component | sessions-grid', function (hooks) {
     });
     await render(hbs`<SessionsGrid
       @sessions={{sessions}}
-      @sortBy={{sortBy}}
+      @sortBy={{this.sortBy}}
       @setSortBy={{action setSortBy}}
       @expandSession={{action expandSession}}
     />`);
@@ -64,7 +64,7 @@ module('Integration | Component | sessions-grid', function (hooks) {
     });
     await render(hbs`<SessionsGrid
       @sessions={{sessions}}
-      @sortBy={{sortBy}}
+      @sortBy={{this.sortBy}}
       @setSortBy={{action setSortBy}}
       @expandSession={{action expandSession}}
     />`);


### PR DESCRIPTION
Otherwise we get a console error that helper:sortBy can't be looked up.