### PR TITLE
Add attributes to UserNameInfo component

### DIFF
--- a/addon-test-support/ilios-common/page-objects/components/user-name-info.js
+++ b/addon-test-support/ilios-common/page-objects/components/user-name-info.js
@@ -5,6 +5,7 @@ const definition = {
   fullName: text('[data-test-fullname]'),
   hasAdditionalInfo: isVisible('[data-test-info]'),
   infoIconLabel: attribute('aria-label', '[data-test-info] svg'),
+  id: attribute('id'),
   expandTooltip: triggerable('mouseover', '[data-test-info] .info'),
   closeTooltip: triggerable('mouseout', '[data-test-info] .info'),
   tooltipContents: text('.ilios-tooltip', { resetScope: true }),

--- a/addon/components/user-name-info.hbs
+++ b/addon/components/user-name-info.hbs
@@ -3,6 +3,7 @@
   data-test-user-name-info
   {{did-insert this.load}}
   {{did-update this.load @user}}
+  ...attributes
 >
   <span data-test-fullname>{{this.fullName}}</span>
   {{#if this.hasDifferentCampusNameOfRecord}}

--- a/tests/integration/components/user-name-info-test.js
+++ b/tests/integration/components/user-name-info-test.js
@@ -33,4 +33,12 @@ module('Integration | Component | user-name-info', function (hooks) {
     await component.closeTooltip();
     assert.notOk(component.isTooltipVisible);
   });
+
+  test('passing in id as an attributes', async function (assert) {
+    const user = this.server.create('user');
+    const userModel = await this.owner.lookup('service:store').find('user', user.id);
+    this.set('user', userModel);
+    await render(hbs`<UserNameInfo id="test-id" @user={{this.user}} />`);
+    assert.equal(component.id, 'test-id');
+  });
 });


### PR DESCRIPTION
This allows passing id in particular so the component can be used as an
arial-labeledby property.