### PR TITLE
Improve Query Params on MyMaterials Controller

### DIFF
--- a/addon/controllers/mymaterials.js
+++ b/addon/controllers/mymaterials.js
@@ -1,9 +1,38 @@
 import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 
-export default Controller.extend({
-  queryParams: ['course', 'filter', 'sortBy'],
+export default class MyMaterialsController extends Controller {
+  queryParams = [{ courseParam: 'course' }, { filterParam: 'filter' }, { sortByParam: 'sortBy' }];
 
-  course: '',
-  filter: '',
-  sortBy: 'firstOfferingDate:desc',
-});
+  @tracked courseParam = null;
+  @tracked filterParam = null;
+  @tracked sortByParam = null;
+
+  get course() {
+    return this.courseParam ?? '';
+  }
+
+  get filter() {
+    return this.filterParam ?? '';
+  }
+
+  get sortBy() {
+    return this.sortByParam ?? 'firstOfferingDate:desc';
+  }
+
+  @action
+  setCourse(value) {
+    this.courseParam = value === '' ? null : value;
+  }
+
+  @action
+  setFilter(value) {
+    this.filterParam = value === '' ? null : value;
+  }
+
+  @action
+  setSortBy(value) {
+    this.sortByParam = value === 'firstOfferingDate:desc' ? null : value;
+  }
+}

--- a/addon/templates/mymaterials.hbs
+++ b/addon/templates/mymaterials.hbs
@@ -4,7 +4,7 @@
   @filter={{this.filter}}
   @materials={{await @model.materials}}
   @sortBy={{this.sortBy}}
-  @setCourseIdFilter={{set this.course}}
-  @setFilter={{set this.filter}}
-  @setSortBy={{set this.sortBy}}
+  @setCourseIdFilter={{this.setCourse}}
+  @setFilter={{this.setFilter}}
+  @setSortBy={{this.setSortBy}}
 />


### PR DESCRIPTION
Instead of empty strings this uses null for the defaults making it
easier to work with the public router service and to migrate later when
ember makes changes.