### PR TITLE
Add link to session to single event details

### DIFF
--- a/addon-test-support/ilios-common/page-objects/components/single-event.js
+++ b/addon-test-support/ilios-common/page-objects/components/single-event.js
@@ -13,7 +13,10 @@ const definition = {
   scope: '[data-test-single-event]',
   summary: {
     scope: '[data-test-summary]',
-    title: text('[data-test-title]'),
+    title: {
+      scope: '[data-test-title]',
+      hasLink: isPresent('a'),
+    },
     offeredAt: text('[data-test-offered-at]'),
     offeredAtLink: attribute('href', '[data-test-offered-at] a'),
     preWork: collection('[data-test-pre-work] li', {

--- a/addon/components/single-event.hbs
+++ b/addon/components/single-event.hbs
@@ -12,7 +12,14 @@
         {{@event.courseTitle}}
         -
         <em>
-          {{@event.name}}
+          {{#if this.canViewSession}}
+            <LinkTo
+              @route="session"
+              @models={{array @event.course @event.session}}
+            >{{@event.name}}</LinkTo>
+          {{else}}
+            {{@event.name}}
+          {{/if}}
         </em>
       </h1>
       <div class="single-event-offered-at" data-test-offered-at>

--- a/addon/components/single-event.js
+++ b/addon/components/single-event.js
@@ -195,6 +195,14 @@ export default class SingleEvent extends Component {
     return '';
   }
 
+  get canViewCourse() {
+    return this.currentUser.performsNonLearnerFunction;
+  }
+
+  get canViewSession() {
+    return this.currentUser.performsNonLearnerFunction;
+  }
+
   @action
   transitionToMyMaterials() {
     const course = this.courseId;


### PR DESCRIPTION
This allows those with elevated privileges to navigate directly to the
session for an event from the single event details page.

Fixes #2362