### PR TITLE
Allow dependency lint to float for ember-get-config

### DIFF
--- a/tests/dummy/config/dependency-lint.js
+++ b/tests/dummy/config/dependency-lint.js
@@ -4,7 +4,7 @@
 module.exports = {
   allowedVersions: {
     'ember-in-element-polyfill': '*',
-    'ember-get-config': '0.2.4 || 0.3.0',
+    'ember-get-config': '0.3.0 || 0.4.0',
     '@embroider/util': '*',
     '@ember/test-waiters': '2.4.5 || 3.0.0',
   },


### PR DESCRIPTION
The 0.4 release doesn't have anything to change functionality, it's only
an issue because there isn't a 1.0 at this point.