### PR TITLE
Link a11y on WAAG

### DIFF
--- a/addon/components/week-glance-event.hbs
+++ b/addon/components/week-glance-event.hbs
@@ -5,9 +5,10 @@
       data-test-event-title
     >
       <LinkTo
+        id={{concat "event" @event.slug "link"}}
         @route="events"
         @model={{@event.slug}}
-        aria-labelledby="{{concat "event" @event.slug "title"}} {{concat "event" @event.slug "date"}}"
+        aria-labelledby="{{concat "event" @event.slug "title"}} {{concat "event" @event.slug "date"}} {{concat "event" @event.slug "link"}}"
       >
         {{@event.name}}
       </LinkTo>


### PR DESCRIPTION
We needed to include the link itself in the list of elements that label
it. Without this there is a mismatch between the visible and AT label.