### PR TITLE
Highlight Links in Paragraphs

### DIFF
--- a/app/styles/ilios-common/components/body.scss
+++ b/app/styles/ilios-common/components/body.scss
@@ -59,6 +59,12 @@ select {
   font-family: 'Nunito Sans', sans-serif;
 }
 
+p {
+  a {
+    text-decoration: underline;
+  }
+}
+
 .add,
 .yes {
   color: $ilios-green;


### PR DESCRIPTION
In order to distinguish links from surounding text it is required for
a11y to add some secondary visual identifier other than color.