### PR TITLE
Return the promise before it is resolved

### DIFF
--- a/addon/classes/async-process.js
+++ b/addon/classes/async-process.js
@@ -11,6 +11,8 @@ export default class AsyncProcessResource extends Resource {
     const fn = this.args.positional[0];
 
     //pass any remaining arguments directly to the processor function
-    this.data = await fn(...this.args.positional.slice(1));
+    const promise = fn(...this.args.positional.slice(1));
+    this.data = promise;
+    this.data = await promise;
   }
 }


### PR DESCRIPTION
AsyncProcess was returning undefined until the promise is resolved, but
we can return the promise itself and maybe make this more usable.