### PR TITLE
Prework events as list items

### DIFF
--- a/addon/components/ilios-calendar-pre-work-event.hbs
+++ b/addon/components/ilios-calendar-pre-work-event.hbs
@@ -1,4 +1,4 @@
-<div
+<li
   class="ilios-calendar-pre-work-event"
   data-test-ilios-calendar-pre-work-event
 >
@@ -22,4 +22,4 @@
       {{/if}}
     </span>
   </h4>
-</div>
+</li>

--- a/app/styles/ilios-common/components/ilios-calendar-pre-work-events.scss
+++ b/app/styles/ilios-common/components/ilios-calendar-pre-work-events.scss
@@ -11,5 +11,6 @@
 
   ul {
     margin-left: 1em;
+    list-style-type: none;
   }
 }


### PR DESCRIPTION
These components are contained in a UL tag and so they have to be list
items.