### PR TITLE
Don't create empty agenda room link

### DIFF
--- a/addon/components/dashboard-agenda.hbs
+++ b/addon/components/dashboard-agenda.hbs
@@ -92,9 +92,11 @@
                     {{event.name}}
                   </td>
                   <td colspan="2">
-                    <LinkTo @route="events" @model={{event.slug}}>
-                      {{event.location}}
-                    </LinkTo>
+                    {{#if event.location}}
+                      <LinkTo @route="events" @model={{event.slug}}>
+                        {{event.location}}
+                      </LinkTo>
+                    {{/if}}
                   </td>
                   <td colspan="1">
                     {{#if event.attireRequired}}


### PR DESCRIPTION
If we don't have a location for an event just leave this cell blank
instead of creating an empty link that is not accessible.