### PR TITLE
Implement a type scale system for font-size and line-height

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,5 +1,6 @@
 {
   "extends": "stylelint-config-recommended-scss",
   "rules": {
+    "property-disallowed-list": ["font-size", "line-height"],
   }
 }

--- a/app/styles/ilios-common/components/api-version-notice.scss
+++ b/app/styles/ilios-common/components/api-version-notice.scss
@@ -9,7 +9,6 @@
   }
 
   .details {
-    line-height: 1em;
     button {
       background-color: $text-grey;
       border: 0;

--- a/app/styles/ilios-common/components/body.scss
+++ b/app/styles/ilios-common/components/body.scss
@@ -54,12 +54,19 @@ select {
   font-family: 'Nunito Sans', sans-serif;
 }
 
-ul li {
-  margin-bottom: 1rem;
+ul {
+  li {
+    margin-bottom: 1rem;
+
+    &:last-of-type {
+      margin-bottom: 0;
+    }
+  }
 }
 
 p {
   margin-bottom: 1rem;
+  @include paragraph-line-height;
   
   a {
     text-decoration: underline;

--- a/app/styles/ilios-common/components/body.scss
+++ b/app/styles/ilios-common/components/body.scss
@@ -56,7 +56,7 @@ select {
 
 ul {
   li {
-    margin-bottom: 1rem;
+    margin-bottom: .5rem;
 
     &:last-of-type {
       margin-bottom: 0;

--- a/app/styles/ilios-common/components/body.scss
+++ b/app/styles/ilios-common/components/body.scss
@@ -1,10 +1,5 @@
 html {
   box-sizing: border-box;
-  font-size: 16px;
-  line-height: $base-line-height;
-  @include for-desktop-and-up {
-    font-size: 20px;
-  }
 }
 
 *,
@@ -59,7 +54,13 @@ select {
   font-family: 'Nunito Sans', sans-serif;
 }
 
+ul li {
+  margin-bottom: 1rem;
+}
+
 p {
+  margin-bottom: 1rem;
+  
   a {
     text-decoration: underline;
   }

--- a/app/styles/ilios-common/components/breadcrumbs.scss
+++ b/app/styles/ilios-common/components/breadcrumbs.scss
@@ -15,6 +15,7 @@
   margin: .75rem;
   text-align: left;
 
+  /* stylelint-disable property-disallowed-list */
   span {
     background-color: $breadcrumb-background;
     border: $breadcrumb-border;

--- a/app/styles/ilios-common/components/course-header.scss
+++ b/app/styles/ilios-common/components/course-header.scss
@@ -37,7 +37,7 @@
       @include for-laptop-and-up {
         display: inline;
       }
-      font-size: 1.5rem;
+      @include font-size('large');
     }
 
     .editinplace.is-editing {

--- a/app/styles/ilios-common/components/course-overview.scss
+++ b/app/styles/ilios-common/components/course-overview.scss
@@ -13,7 +13,7 @@
     @include ilios-overview-actions;
 
     a, span {
-      font-size: 1.2rem;
+      @include font-size('medium');
       margin-right: .5rem;
     }
 

--- a/app/styles/ilios-common/components/course-publicationcheck.scss
+++ b/app/styles/ilios-common/components/course-publicationcheck.scss
@@ -11,6 +11,6 @@
 
   .fa-unlink {
     color: $black;
-    font-size: .75rem;
+    @include font-size('small');
   }
 }

--- a/app/styles/ilios-common/components/course-rollover.scss
+++ b/app/styles/ilios-common/components/course-rollover.scss
@@ -42,7 +42,6 @@
     }
 
     .include {
-      line-height: 1rem;
       margin-left: 1rem;
 
       input {

--- a/app/styles/ilios-common/components/course-summary-header.scss
+++ b/app/styles/ilios-common/components/course-summary-header.scss
@@ -15,7 +15,7 @@
       text-align: right;
 
       a {
-        font-size: 1.2rem;
+        @include font-size('medium');
         margin-right: .5rem;
       }
     }

--- a/app/styles/ilios-common/components/course/manage-objective-parents.scss
+++ b/app/styles/ilios-common/components/course/manage-objective-parents.scss
@@ -5,7 +5,6 @@
   .parent-picker {
     @include ilios-list-reset;
     height: auto;
-    line-height: 1.3rem;
 
     .competency {
       border-left: 10px solid transparent;

--- a/app/styles/ilios-common/components/daily-calendar-event.scss
+++ b/app/styles/ilios-common/components/daily-calendar-event.scss
@@ -6,7 +6,7 @@
   flex-direction: column;
   justify-content: start;
   color: $text-grey;
-  font-size: .8rem;
+  @include font-size('small');
   border: 1px solid $white;
   margin: 1px;
   padding: .25rem;
@@ -21,7 +21,7 @@
   .ilios-calendar-event-time {
     color: $maroon;
     display: block;
-    font-size: .7rem;
+    @include font-size('small');
     font-weight: bold;
     padding-bottom: .5em;
   }

--- a/app/styles/ilios-common/components/dashboard-calendar.scss
+++ b/app/styles/ilios-common/components/dashboard-calendar.scss
@@ -31,7 +31,7 @@
     .calendar-filter-list {
       border: 1px solid $ilios-blue;
       float: left;
-      font-size: .8rem;
+      @include font-size('small');
       margin-bottom: 1em;
       width: 33%;
 
@@ -97,7 +97,7 @@
 
     .filters-header {
       border-bottom: 1px solid $dark-grey;
-      font-size: 10px;
+      @include font-size('small');
     }
 
     .filter-tags {
@@ -105,7 +105,7 @@
         border-radius: 3px;
         cursor: pointer;
         display: inline-block;
-        font-size: 10px;
+        @include font-size('small');
         padding: 2px 5px;
       }
 
@@ -136,7 +136,7 @@
       .filters-clear-filters {
         color: $ilios-blue;
         cursor: pointer;
-        font-size: 10px;
+        @include font-size('small');
       }
     }
   }

--- a/app/styles/ilios-common/components/dashboard-materials.scss
+++ b/app/styles/ilios-common/components/dashboard-materials.scss
@@ -30,6 +30,6 @@
   }
 
   .timed-release-info {
-    font-size: smaller;
+    @include font-size('small');
   }
 }

--- a/app/styles/ilios-common/components/dashboard-view-picker.scss
+++ b/app/styles/ilios-common/components/dashboard-view-picker.scss
@@ -25,6 +25,7 @@
     padding: .25rem .5rem;
 
     @include for-phone-only {
+      /* stylelint-disable property-disallowed-list */
       font-size: 3vw;
     }
 

--- a/app/styles/ilios-common/components/dashboard-view-picker.scss
+++ b/app/styles/ilios-common/components/dashboard-view-picker.scss
@@ -24,11 +24,6 @@
     @include ilios-button;
     padding: .25rem .5rem;
 
-    @include for-phone-only {
-      /* stylelint-disable property-disallowed-list */
-      font-size: 3vw;
-    }
-
     &.active {
       background-color: $ilios-green;
     }

--- a/app/styles/ilios-common/components/detail-learningmaterials.scss
+++ b/app/styles/ilios-common/components/detail-learningmaterials.scss
@@ -58,12 +58,12 @@
       .learning-material-description {
         color: $dark-grey;
         display: block;
-        font-size: .75rem;
+        @include font-size('small');
       }
 
       .learning-material-status {
         color: $ilios-red;
-        font-size: .75rem;
+        @include font-size('small');
         position: absolute;
         right: 5px;
         top: 0;
@@ -76,7 +76,7 @@
           color: $darker-grey;
           cursor: inherit;
           display: list-item;
-          font-size: .75rem;
+          @include font-size('small');
           margin: 0;
           min-height: 0;
           padding: 0 0 0 .75rem;

--- a/app/styles/ilios-common/components/flatpickr.scss
+++ b/app/styles/ilios-common/components/flatpickr.scss
@@ -12,7 +12,7 @@
 
   .flatpickr-current-month {
     display: flex;
-    font-size: 1.2rem;
+    @include font-size('medium');
     justify-content: center;
     .flatpickr-monthDropdown-months {
       appearance: none;

--- a/app/styles/ilios-common/components/ilios-calendar-multiday-events.scss
+++ b/app/styles/ilios-common/components/ilios-calendar-multiday-events.scss
@@ -4,7 +4,7 @@
   padding: 1em 0;
 
   h4 {
-    font-size: 1.25em;
+    @include font-size('medium');
     font-weight: bold;
     margin-top: 0;
     padding-left: 1rem;

--- a/app/styles/ilios-common/components/ilios-calendar-pre-work-events.scss
+++ b/app/styles/ilios-common/components/ilios-calendar-pre-work-events.scss
@@ -4,7 +4,7 @@
   padding: 1em 0;
 
   h4 {
-    font-size: 1.25em;
+    @include font-size('medium');
     font-weight: bold;
     margin-top: 0;
   }

--- a/app/styles/ilios-common/components/ilios-calendar.scss
+++ b/app/styles/ilios-common/components/ilios-calendar.scss
@@ -22,7 +22,7 @@
 
     .highlight {
       color: $ilios-orange;
-      font-size: 1.25em;
+      @include font-size('medium');
     }
 
     .on {

--- a/app/styles/ilios-common/components/learning-material-uploader.scss
+++ b/app/styles/ilios-common/components/learning-material-uploader.scss
@@ -6,7 +6,7 @@
     color: $text-grey;
     cursor: pointer;
     display: inline-block;
-    font-size: 1rem;
+    @include font-size('base');
     padding: .3em 1em;
     &:hover {
       background-color: $dark-grey;

--- a/app/styles/ilios-common/components/learningmaterial-manager.scss
+++ b/app/styles/ilios-common/components/learningmaterial-manager.scss
@@ -32,7 +32,7 @@
   h2 {
     @include ilios-heading;
     color: $text-grey;
-    font-size: 1rem;
+    @include font-size('base');
     font-weight: bold;
   }
 

--- a/app/styles/ilios-common/components/mesh-manager.scss
+++ b/app/styles/ilios-common/components/mesh-manager.scss
@@ -26,7 +26,7 @@
 
     .descriptor-id {
       display: block;
-      font-size: smaller;
+      @include font-size('small');
     }
 
     .mesh-concepts {

--- a/app/styles/ilios-common/components/monthly-calendar.scss
+++ b/app/styles/ilios-common/components/monthly-calendar.scss
@@ -79,7 +79,7 @@
 
         span {
           background-color: transparent;
-          font-size: .5em;
+          @include font-size('smallest');
           font-weight: normal;
         }
 
@@ -98,7 +98,7 @@
         @include ilios-link-button;
         display: block;
         width: 100%;
-        font-size: .8rem;
+        @include font-size('small');
         text-align: right;
         margin-top: .5rem;
 

--- a/app/styles/ilios-common/components/my-materials.scss
+++ b/app/styles/ilios-common/components/my-materials.scss
@@ -25,7 +25,7 @@
   }
 
   .timed-release-info {
-    font-size: smaller;
+    @include font-size('small');
   }
 
   table {

--- a/app/styles/ilios-common/components/objective-manager.scss
+++ b/app/styles/ilios-common/components/objective-manager.scss
@@ -19,7 +19,6 @@
     ul {
       @include ilios-list-reset;
       height: auto;
-      line-height: 1.3rem;
     }
 
     li {
@@ -38,7 +37,7 @@
   }
 
   h5 {
-    font-size: .9rem;
+    @include font-size('small');
     font-weight: bold;
     margin: .8rem;
     padding: .2rem .5rem;

--- a/app/styles/ilios-common/components/offering-calendar.scss
+++ b/app/styles/ilios-common/components/offering-calendar.scss
@@ -9,7 +9,7 @@
   position: relative;
 
   h2 {
-    font-size: 1.25rem;
+    @include font-size('medium');
     margin-bottom: 1rem;
     text-align: center;
     width: 100%;

--- a/app/styles/ilios-common/components/offering-form.scss
+++ b/app/styles/ilios-common/components/offering-form.scss
@@ -158,7 +158,7 @@
     .validation-error-message {
       color: $ilios-red;
       display: block;
-      font-size: 12px;
+      @include font-size('small');
       font-style: italic;
       margin-top: .5rem;
     }

--- a/app/styles/ilios-common/components/offering-manager.scss
+++ b/app/styles/ilios-common/components/offering-manager.scss
@@ -1,7 +1,7 @@
 .offering-manager {
   border-bottom: 1px dotted $dark-grey;
   display: grid;
-  font-size: .9rem;
+  @include font-size('small');
   grid-column: 1 / -1;
   grid-template-columns: repeat(5, 1fr);
   margin-bottom: .5rem;

--- a/app/styles/ilios-common/components/progress-bar.scss
+++ b/app/styles/ilios-common/components/progress-bar.scss
@@ -34,7 +34,6 @@
 
   p {
     color: $progress-color;
-    line-height: $base-line-height;
     margin: 0;
     padding: .1rem .5rem;
     text-shadow: 0 0 1px $black;

--- a/app/styles/ilios-common/components/publish-all-sessions.scss
+++ b/app/styles/ilios-common/components/publish-all-sessions.scss
@@ -34,19 +34,19 @@
   .publish-all-sessions-review {
     border: 1px solid $ilios-green;
     clear: both;
-    font-size: 1.5rem;
+    @include font-size('large');
     margin: 1rem;
     padding: 1rem;
     text-align: center;
 
     .unlinked-warning {
       color: $ilios-yellow;
-      font-size: 1rem;
+      @include font-size('base');
     }
 
     .fa-chart-bar {
       color: $ilios-blue;
-      font-size: .8rem;
+      @include font-size('small');
     }
 
     p {
@@ -64,6 +64,6 @@
 
   .fa-unlink {
     color: $black;
-    font-size: .75rem;
+    @include font-size('small');
   }
 }

--- a/app/styles/ilios-common/components/session-copy.scss
+++ b/app/styles/ilios-common/components/session-copy.scss
@@ -45,7 +45,6 @@
     }
 
     .include {
-      line-height: 1rem;
       margin-left: 1rem;
 
       input {

--- a/app/styles/ilios-common/components/session-offerings-list.scss
+++ b/app/styles/ilios-common/components/session-offerings-list.scss
@@ -15,7 +15,7 @@
       .offering-block-date-dayofweek {
         color: $ilios-orange;
         display: block;
-        font-size: 1.2rem;
+        @include font-size('medium');
         font-weight: bold;
         width: 100%;
       }

--- a/app/styles/ilios-common/components/session-overview.scss
+++ b/app/styles/ilios-common/components/session-overview.scss
@@ -49,7 +49,7 @@
       @include ilios-overview-actions;
 
       a {
-        font-size: 1.2rem;
+        @include font-size('medium');
         margin-right: .5rem;
       }
     }

--- a/app/styles/ilios-common/components/session-publicationcheck.scss
+++ b/app/styles/ilios-common/components/session-publicationcheck.scss
@@ -26,6 +26,6 @@
 
   .fa-unlink {
     color: $black;
-    font-size: .75rem;
+    @include font-size('small');
   }
 }

--- a/app/styles/ilios-common/components/session/manage-objective-parents.scss
+++ b/app/styles/ilios-common/components/session/manage-objective-parents.scss
@@ -5,7 +5,6 @@
   .parent-picker {
     @include ilios-list-reset;
     height: auto;
-    line-height: 1.3rem;
     padding-left: .5rem;
 
     .selected {

--- a/app/styles/ilios-common/components/sessions-grid-header.scss
+++ b/app/styles/ilios-common/components/sessions-grid-header.scss
@@ -3,7 +3,7 @@
   background-color: $dark-blue;
   border-bottom: 1px solid $dark-grey;
   color: $white;
-  font-size: .8rem;
+  @include font-size('small');
   font-weight: normal;
   position: sticky;
   top: 0;

--- a/app/styles/ilios-common/components/sessions-grid-offering-table.scss
+++ b/app/styles/ilios-common/components/sessions-grid-offering-table.scss
@@ -12,7 +12,7 @@
     top: 2rem;
 
     th {
-      font-size: .8rem;
+      @include font-size('small');
       font-weight: normal;
       padding: .2rem .5rem;
     }

--- a/app/styles/ilios-common/components/single-event-learningmaterial-list.scss
+++ b/app/styles/ilios-common/components/single-event-learningmaterial-list.scss
@@ -4,20 +4,20 @@
   }
 
   .single-event-learningmaterial-item-timing-info {
-    font-size: smaller;
+    @include font-size('small');
     font-weight: normal;
 
   }
   .single-event-learningmaterial-item-notes {
     i {
       display: inline;
-      font-size: .85em;
+      @include font-size('small');
       margin-right: 5px;
     }
 
     p {
       display: inline;
-      font-size: .85em;
+      @include font-size('small');
       font-style: italic;
     }
   }

--- a/app/styles/ilios-common/components/single-event-objective-list.scss
+++ b/app/styles/ilios-common/components/single-event-objective-list.scss
@@ -43,7 +43,7 @@
     }
 
     .details {
-      font-size: smaller;
+      @include font-size('small');
       font-weight: bold;
     }
   }

--- a/app/styles/ilios-common/components/single-event.scss
+++ b/app/styles/ilios-common/components/single-event.scss
@@ -7,7 +7,7 @@
     margin: 1em 0;
 
     .fa-archive {
-      font-size: 1rem;
+      @include font-size('base');
     }
   }
 
@@ -85,7 +85,7 @@
   }
 
   .single-event-learningmaterial-filesize {
-    font-size: .8em;
+    @include font-size('small');
     font-style: italic;
   }
 }

--- a/app/styles/ilios-common/components/toggle-buttons.scss
+++ b/app/styles/ilios-common/components/toggle-buttons.scss
@@ -10,7 +10,7 @@
     color: $ilios-green;
     border: 1px solid rgba($black, .2);
     display: inline-block;
-    font-size: .8rem;
+    @include font-size('small');
     min-width: 3em;
     padding: .25em .5em;
     text-align: center;

--- a/app/styles/ilios-common/components/toggle-yesno.scss
+++ b/app/styles/ilios-common/components/toggle-yesno.scss
@@ -16,7 +16,7 @@
     border-radius: inherit;
     box-shadow: inset 0 1px 2px $almost-visible-black, inset 0 0 2px $almost-visible-black;
     display: block;
-    font-size: 10px;
+    @include font-size('small');
     font-weight: bold;
     height: inherit;
     position: relative;
@@ -28,7 +28,6 @@
 
   .switch-label::before,
   .switch-label::after {
-    line-height: 1;
     margin-top: -.5em;
     position: absolute;
     top: 50%;

--- a/app/styles/ilios-common/components/visualizer-course-objectives.scss
+++ b/app/styles/ilios-common/components/visualizer-course-objectives.scss
@@ -8,22 +8,8 @@
       margin-top: .5rem;
     }
 
-    @media phone {
-      .meh {
-        font-size: 15rem;
-      }
-    }
-
-    @include for-tablet-and-up {
-      .meh {
-        font-size: 25rem;
-      }
-    }
-
-    @include for-laptop-and-up {
-      .meh {
-        font-size: 30rem;
-      }
+    .meh {
+      @include font-size("huge");
     }
   }
 

--- a/app/styles/ilios-common/components/week-glance.scss
+++ b/app/styles/ilios-common/components/week-glance.scss
@@ -5,18 +5,18 @@
 
     &.collapsible {
       @include ilios-button-reset;
-      font-size: 1.75rem;
+      @include font-size('xl');
       &.collapsed {
         &::after {
           content: '\25BA';
-          font-size: 1.25rem;
+          @include font-size('medium');
         }
       }
 
       &.expanded {
         &::after {
           content: '\25BC';
-          font-size: 1.25rem;
+          @include font-size('medium');
         }
       }
     }
@@ -25,7 +25,6 @@
 
 
   .event {
-    line-height: 1.5;
     margin-bottom: 1em;
 
     p {
@@ -69,7 +68,7 @@
 
       .fa-external-link-square {
         color: $ilios-orange;
-        font-size: .8rem;
+        @include font-size('small');
       }
 
       .public-notes {
@@ -77,7 +76,7 @@
       }
 
       .timed-release-info {
-        font-size: smaller;
+        @include font-size('small');
       }
     }
 

--- a/app/styles/ilios-common/components/weekly-calendar-event.scss
+++ b/app/styles/ilios-common/components/weekly-calendar-event.scss
@@ -6,7 +6,7 @@
   flex-direction: column;
   justify-content: start;
   color: $text-grey;
-  font-size: .8rem;
+  @include font-size('small');
   border: 1px solid $white;
   margin: 1px;
   padding: .25rem;
@@ -21,7 +21,7 @@
   .ilios-calendar-event-time {
     color: $maroon;
     display: block;
-    font-size: .7rem;
+    @include font-size('small');
     font-weight: bold;
     padding-bottom: .5em;
   }

--- a/app/styles/ilios-common/mixins.scss
+++ b/app/styles/ilios-common/mixins.scss
@@ -2,6 +2,7 @@
 @import 'mixins/collapsed-container';
 @import 'mixins/critical-notice';
 @import 'mixins/detail-container';
+@import 'mixins/font-size';
 @import 'mixins/icon';
 @import 'mixins/ilios-button';
 @import 'mixins/ilios-form';

--- a/app/styles/ilios-common/mixins/collapsed-container.scss
+++ b/app/styles/ilios-common/mixins/collapsed-container.scss
@@ -27,7 +27,7 @@
 @mixin collapsed-container-table () {
   @include ilios-table-structure;
   @include ilios-table-colors;
-  font-size: .8rem;
+  @include font-size('small');
 
   table,
   tr,

--- a/app/styles/ilios-common/mixins/critical-notice.scss
+++ b/app/styles/ilios-common/mixins/critical-notice.scss
@@ -2,7 +2,6 @@
   background-color: $background-color;
   color: $color;
   display: block;
-  line-height: $height;
   margin: 0;
   min-height: $height;
   padding: 0;

--- a/app/styles/ilios-common/mixins/font-size.scss
+++ b/app/styles/ilios-common/mixins/font-size.scss
@@ -1,0 +1,47 @@
+/* stylelint-disable property-disallowed-list */
+:root {
+  --fs-smallest: 0.5rem;
+  --calc-line-height-smallest: 2.8ex;
+
+  --fs-small: 0.833rem;
+  --calc-line-height-small: 2.8ex;
+
+  --fs-base: 1rem;
+  --calc-line-height-base: 2.8ex;
+
+  --fs-medium: 1.2rem;
+  --calc-line-height-medium: 2.8ex;
+
+  --fs-large: 1.44rem;
+  --calc-line-height-large: 2.8ex;
+
+  --fs-xl: 1.728rem;
+  --calc-line-height-xl: 2.2ex;
+
+  --fs-xxl: 2.074rem;
+  --calc-line-height-xxl: 2.2ex;
+
+  --fs-xxxl: 2.488rem;
+  --calc-line-height-xxxl: 2.2ex;
+
+
+  --fs-huge: 15rem;
+  --calc-line-height-huge: 1;
+  @include for-tablet-and-up {
+    --fs-huge: 25rem;
+  }
+  @include for-laptop-and-up {
+    --fs-huge: 30rem;
+  }
+
+  font-size: 16px;
+  line-height: calc(4px + 2.8ex);
+  @include for-desktop-and-up {
+    font-size: 20px;
+  }
+}
+
+@mixin font-size($step) {
+  font-size: var(--fs-#{$step});
+  line-height: calc(4px + var(--calc-line-height-#{$step}));
+}

--- a/app/styles/ilios-common/mixins/font-size.scss
+++ b/app/styles/ilios-common/mixins/font-size.scss
@@ -24,7 +24,6 @@
   --fs-xxxl: 2.488rem;
   --calc-line-height-xxxl: 2.2ex;
 
-
   --fs-huge: 15rem;
   --calc-line-height-huge: 1;
   @include for-tablet-and-up {
@@ -34,9 +33,14 @@
     --fs-huge: 30rem;
   }
 
-  font-size: 16px;
   line-height: calc(4px + 2.8ex);
-  @include for-desktop-and-up {
+  
+  font-size: 16px;
+  //scale based on viewport width between 16px and 20px
+  @include for-phone-and-up {
+    font-size: calc(14px + .5vw);
+  }
+  @include for-laptop-and-up {
     font-size: 20px;
   }
 }

--- a/app/styles/ilios-common/mixins/font-size.scss
+++ b/app/styles/ilios-common/mixins/font-size.scss
@@ -1,31 +1,14 @@
 /* stylelint-disable property-disallowed-list */
 :root {
   --fs-smallest: 0.5rem;
-  --calc-line-height-smallest: 2.8ex;
-
   --fs-small: 0.833rem;
-  --calc-line-height-small: 2.8ex;
-
   --fs-base: 1rem;
-  --calc-line-height-base: 2.8ex;
-
   --fs-medium: 1.2rem;
-  --calc-line-height-medium: 2.8ex;
-
   --fs-large: 1.44rem;
-  --calc-line-height-large: 2.8ex;
-
   --fs-xl: 1.728rem;
-  --calc-line-height-xl: 2.2ex;
-
   --fs-xxl: 2.074rem;
-  --calc-line-height-xxl: 2.2ex;
-
   --fs-xxxl: 2.488rem;
-  --calc-line-height-xxxl: 2.2ex;
-
   --fs-huge: 15rem;
-  --calc-line-height-huge: 1;
   @include for-tablet-and-up {
     --fs-huge: 25rem;
   }
@@ -33,7 +16,7 @@
     --fs-huge: 30rem;
   }
 
-  line-height: calc(4px + 2.8ex);
+  line-height: calc(4px + 2ex);
   
   font-size: 16px;
   //scale based on viewport width between 16px and 20px
@@ -47,5 +30,9 @@
 
 @mixin font-size($step) {
   font-size: var(--fs-#{$step});
-  line-height: calc(4px + var(--calc-line-height-#{$step}));
+  line-height: calc(4px + 2ex);
+}
+
+@mixin paragraph-line-height() {
+  line-height: calc(1px + 3ex);
 }

--- a/app/styles/ilios-common/mixins/ilios-button.scss
+++ b/app/styles/ilios-common/mixins/ilios-button.scss
@@ -7,10 +7,17 @@
   color: $white;
   cursor: pointer;
   display: inline-block;
-  @include font-size('base');
   padding: .3em 1em;
   vertical-align: middle;
   white-space: nowrap;
+
+  @include font-size('base');
+  //at small sizes scale to keep button text in the button
+  @include for-phone-only {
+    /* stylelint-disable property-disallowed-list */
+    font-size: 3vw;
+  }
+
 }
 
 @mixin ilios-button-reset {

--- a/app/styles/ilios-common/mixins/ilios-button.scss
+++ b/app/styles/ilios-common/mixins/ilios-button.scss
@@ -7,7 +7,7 @@
   color: $white;
   cursor: pointer;
   display: inline-block;
-  font-size: 1rem;
+  @include font-size('base');
   padding: .3em 1em;
   vertical-align: middle;
   white-space: nowrap;
@@ -21,7 +21,6 @@
   color: inherit;
   background-color: transparent;
   cursor: pointer;
-  line-height: $base-line-height;
   white-space: normal;
 }
 

--- a/app/styles/ilios-common/mixins/ilios-form.scss
+++ b/app/styles/ilios-common/mixins/ilios-form.scss
@@ -101,7 +101,7 @@
   font-weight: bold;
 
   .label-description {
-    font-size: smaller;
+    @include font-size('small');
     font-weight: normal;
 
   }
@@ -110,7 +110,7 @@
 @mixin ilios-form-error {
   .validation-error-message {
     color: $ilios-red;
-    font-size: .8rem;
+    @include font-size('small');
   }
 
   input {

--- a/app/styles/ilios-common/mixins/ilios-heading.scss
+++ b/app/styles/ilios-common/mixins/ilios-heading.scss
@@ -8,30 +8,30 @@
 
 @mixin ilios-heading-h1() {
   @include ilios-heading;
-  font-size: 2.25rem;
+  @include font-size('xxxl');
 }
 
 @mixin ilios-heading-h2() {
   @include ilios-heading;
-  font-size: 2rem;
+  @include font-size('xxl');
 }
 
 @mixin ilios-heading-h3() {
   @include ilios-heading;
-  font-size: 1.75rem;
+  @include font-size('xl');
 }
 
 @mixin ilios-heading-h4() {
   @include ilios-heading;
-  font-size: 1.5rem;
+  @include font-size('large');
 }
 
 @mixin ilios-heading-h5() {
   @include ilios-heading;
-  font-size: 1.25rem;
+  @include font-size('medium');
 }
 
 @mixin ilios-heading-h6() {
   @include ilios-heading;
-  font-size: 1rem;
+  @include font-size('base');
 }

--- a/app/styles/ilios-common/mixins/ilios-overview.scss
+++ b/app/styles/ilios-common/mixins/ilios-overview.scss
@@ -24,7 +24,7 @@
 
 @mixin ilios-overview-title () {
   color: $text-blue;
-  font-size: 1rem;
+  @include font-size('base');
   font-weight: bold;
 }
 

--- a/app/styles/ilios-common/mixins/ilios-select.scss
+++ b/app/styles/ilios-common/mixins/ilios-select.scss
@@ -1,7 +1,6 @@
 @mixin ilios-select () {
   box-sizing: border-box;
-  font-size: 1em;
+  @include font-size('base');
   height: 2em;
-  line-height: 1.1em;
   padding: 4px 4px 4px 8px;
 }

--- a/app/styles/ilios-common/mixins/ilios-table.scss
+++ b/app/styles/ilios-common/mixins/ilios-table.scss
@@ -1,19 +1,17 @@
-@use "sass:math";
-
 @mixin ilios-table-structure () {
   border-collapse: collapse;
-  margin: ($base-line-height * .5em) 0;
+  margin: .7rem 0;
   table-layout: fixed;
   width: 100%;
 
   th {
-    padding: math.div($base-line-height * .5em, 2) 0;
+    padding: .25rem 0;
     text-align: left;
   }
 
   td {
     border: 0;
-    padding: math.div($base-line-height * .5em, 2) 0;
+    padding: .25rem 0;
   }
 
   th,
@@ -54,7 +52,7 @@
   }
 
   &.condensed {
-    font-size: .8em;
+    @include font-size('small');
 
     tr,
     td,

--- a/app/styles/ilios-common/mixins/media.scss
+++ b/app/styles/ilios-common/mixins/media.scss
@@ -4,6 +4,12 @@
   }
 }
 
+@mixin for-phone-and-up {
+  @media screen and (min-width: 400px) {
+    @content;
+  }
+}
+
 @mixin for-tablet-and-up {
   @media screen and (min-width: 768px) {
     @content;

--- a/app/styles/ilios-common/mixins/sessions-grid.scss
+++ b/app/styles/ilios-common/mixins/sessions-grid.scss
@@ -8,7 +8,7 @@
   .session-grid-terms,
   .session-grid-first-offering,
   .session-grid-offerings,
-   {
+  {
     display: none;
   }
 
@@ -48,7 +48,7 @@
   }
 
   .expand-collapse-control {
-    font-size: 1.2rem;
+    @include font-size('medium');
     margin-left: .25rem;
 
     &>.active {
@@ -62,6 +62,6 @@
   }
 
   .fa-user-clock {
-    font-size: .875rem;
+    @include font-size('small');
   }
 }

--- a/app/styles/ilios-common/mixins/sort-manager.scss
+++ b/app/styles/ilios-common/mixins/sort-manager.scss
@@ -44,7 +44,7 @@
     display: inline-block;
 
     .details {
-      font-size: smaller;
+      @include font-size('small');
     }
 
     .title {

--- a/app/styles/ilios-common/mixins/user-search.scss
+++ b/app/styles/ilios-common/mixins/user-search.scss
@@ -50,7 +50,7 @@
     }
 
     .name i {
-      font-size: .8rem;
+      @include font-size('small');
     }
 
     .email {

--- a/app/styles/ilios-common/variables.scss
+++ b/app/styles/ilios-common/variables.scss
@@ -3,7 +3,6 @@ $black: #000;
 $grey: #eee;
 $maroon: #800;
 
-$base-line-height: 1.1; //line-height from normalize.css
 $base-border-radius: 3px;
 
 $ilios-orange: #c60;

--- a/tests/integration/components/daily-calendar-event-test.js
+++ b/tests/integration/components/daily-calendar-event-test.js
@@ -24,7 +24,7 @@ module('Integration | Component | daily-calendar-event', function (hooks) {
   this.getStyle = function (rowStart, minutes, columnSpan) {
     return {
       'background-color': 'rgb(0, 204, 101)',
-      'border-left-width': '4px',
+      'border-left-width': '5px',
       'border-left-style': 'solid',
       'border-left-color': 'rgb(0, 173, 86)',
       'grid-row-start': `${rowStart}`,

--- a/tests/integration/components/weekly-calendar-event-test.js
+++ b/tests/integration/components/weekly-calendar-event-test.js
@@ -24,7 +24,7 @@ module('Integration | Component | weekly-calendar-event', function (hooks) {
   this.getStyle = function (rowStart, minutes, columnSpan) {
     return {
       'background-color': 'rgb(0, 204, 101)',
-      'border-left-width': '4px',
+      'border-left-width': '5px',
       'border-left-style': 'solid',
       'border-left-color': 'rgb(0, 173, 86)',
       'grid-row-start': `${rowStart}`,


### PR DESCRIPTION
By replacing calls to font-size with a mixing `@include font-size('large');` we can standardize the type sizes across the site and also ensure that proper line-height is applied at each step.

Wip:
- [x] needs extensive visual review
- [x] Check with a11y experts if this meets the needs of AT, we're using a dynamic line height here which doesn't make Siteimprove happy, but should be good for real users.
- [x] Find a fix for extra `p` tags in session descriptions (and anywhere else)