### PR TITLE
Rework dashboard headings

### DIFF
--- a/addon/components/ilios-calendar-multiday-events.hbs
+++ b/addon/components/ilios-calendar-multiday-events.hbs
@@ -1,8 +1,8 @@
 {{#if @events.length}}
   <div class="ilios-calendar-multiday-events">
-    <h4 data-test-title>
+    <h3 class="title" data-test-title>
       {{t "general.multidayEvents"}}
-    </h4>
+    </h3>
     <ul>
       {{#each @events as |event|}}
         <IliosCalendarMultidayEvent

--- a/addon/components/ilios-calendar-pre-work-event.hbs
+++ b/addon/components/ilios-calendar-pre-work-event.hbs
@@ -2,24 +2,22 @@
   class="ilios-calendar-pre-work-event"
   data-test-ilios-calendar-pre-work-event
 >
-  <h4>
-    <span class="title" data-test-event-title>
-      {{#if @areEventsSelectable}}
-        <LinkTo @route="events" @model={{@event.slug}}>
-          {{@event.name}}
-        </LinkTo>
-      {{else}}
+  <span class="title" data-test-event-title>
+    {{#if @areEventsSelectable}}
+      <LinkTo @route="events" @model={{@event.slug}}>
         {{@event.name}}
-      {{/if}}
-    </span>
-    <span class="date" data-test-date>
-      {{#if @areEventsSelectable}}
-        {{t "general.dueBefore"}}
-        <a href={{this.postrequisiteLink}}>{{@event.postrequisiteName}}</a>
-        ({{format-date @event.startDate}})
-      {{else}}
-        {{t "general.dueBefore"}} {{@event.postrequisiteName}} ({{format-date @event.startDate}})
-      {{/if}}
-    </span>
-  </h4>
+      </LinkTo>
+    {{else}}
+      {{@event.name}}
+    {{/if}}
+  </span>
+  <span class="date" data-test-date>
+    {{#if @areEventsSelectable}}
+      {{t "general.dueBefore"}}
+      <a href={{this.postrequisiteLink}}>{{@event.postrequisiteName}}</a>
+      ({{format-date @event.startDate}})
+    {{else}}
+      {{t "general.dueBefore"}} {{@event.postrequisiteName}} ({{format-date @event.startDate}})
+    {{/if}}
+  </span>
 </li>

--- a/addon/components/ilios-calendar-pre-work-events.hbs
+++ b/addon/components/ilios-calendar-pre-work-events.hbs
@@ -1,8 +1,8 @@
 {{#if @events.length}}
   <div class="ilios-calendar-pre-work-events">
-    <h4>
+    <h3 class="title">
       {{t "general.preWork"}}
-    </h4>
+    </h3>
     <ul>
       {{#each @events as |event|}}
         <IliosCalendarPreWorkEvent

--- a/addon/components/week-glance-pre-work.hbs
+++ b/addon/components/week-glance-pre-work.hbs
@@ -1,19 +1,19 @@
 <div class="week-glance-pre-work" data-test-week-glance-pre-work>
-  <h4>
+  <h4 class="title">
     <LinkTo data-test-event-title @route="events" @model={{@events.firstObject.slug}}>
       {{@events.firstObject.name}}
     </LinkTo>
-    <span class="date" data-test-date>
-      {{t "general.dueBefore"}}
-      <a href={{concat "#event" @events.firstObject.postrequisiteSlug}}>
-        {{@events.firstObject.postrequisiteName}}
-      </a>
-      ({{format-date @events.firstObject.startDate}})
-    </span>
-    {{#if (gt @events.length 1)}}
-      <span data-test-more>
-        {{t "general.withXmoreOfferings" count=(sub @events.length 1)}}
-      </span>
-    {{/if}}
   </h4>
+  <span class="date" data-test-date>
+    {{t "general.dueBefore"}}
+    <a href={{concat "#event" @events.firstObject.postrequisiteSlug}}>
+      {{@events.firstObject.postrequisiteName}}
+    </a>
+    ({{format-date @events.firstObject.startDate}})
+  </span>
+  {{#if (gt @events.length 1)}}
+    <span data-test-more>
+      {{t "general.withXmoreOfferings" count=(sub @events.length 1)}}
+    </span>
+  {{/if}}
 </div>

--- a/app/styles/ilios-common/components/ilios-calendar-multiday-events.scss
+++ b/app/styles/ilios-common/components/ilios-calendar-multiday-events.scss
@@ -3,7 +3,7 @@
   margin-top: 1em;
   padding: 1em 0;
 
-  h4 {
+  .title {
     @include font-size('medium');
     font-weight: bold;
     margin-top: 0;

--- a/app/styles/ilios-common/components/ilios-calendar-pre-work-events.scss
+++ b/app/styles/ilios-common/components/ilios-calendar-pre-work-events.scss
@@ -3,14 +3,16 @@
   margin-top: 1em;
   padding: 1em 0;
 
-  h4 {
+  .title {
     @include font-size('medium');
     font-weight: bold;
     margin-top: 0;
+    padding-left: 1rem;
   }
 
   ul {
     margin-left: 1em;
+    padding-left: 0;
     list-style-type: none;
   }
 }

--- a/app/styles/ilios-common/components/week-glance-pre-work.scss
+++ b/app/styles/ilios-common/components/week-glance-pre-work.scss
@@ -1,8 +1,8 @@
 .week-glance-pre-work {
   margin-left: .5rem;
-  h4 {
+  .title {
     @include ilios-heading-h6;
-    margin-bottom: .25rem;
+    display: inline;
   }
 
   &:last-of-type {


### PR DESCRIPTION
Align the heading number and position so headings fall in order. Also
removed headings from several places where we were using them mainly for
styling and not content.