### PR TITLE
Add explicit model hooks to course routes

### DIFF
--- a/addon/routes/course-materials.js
+++ b/addon/routes/course-materials.js
@@ -4,8 +4,13 @@ import { all } from 'rsvp';
 
 export default class CourseMaterialsRoute extends Route {
   @service session;
+  @service dataLoader;
 
   titleToken = 'general.coursesAndSessions';
+
+  async model(params) {
+    return this.dataLoader.loadCourse(params.course_id);
+  }
 
   afterModel(course) {
     return all([

--- a/addon/routes/course-visualizations.js
+++ b/addon/routes/course-visualizations.js
@@ -5,8 +5,13 @@ import { all } from 'rsvp';
 export default class CourseVisualizationsRoute extends Route {
   @service store;
   @service session;
+  @service dataLoader;
 
   titleToken = 'general.coursesAndSessions';
+
+  async model(params) {
+    return this.dataLoader.loadCourse(params.course_id);
+  }
 
   /**
    * Prefetch related data to limit network requests

--- a/addon/routes/course-visualize-instructors.js
+++ b/addon/routes/course-visualize-instructors.js
@@ -5,8 +5,13 @@ import { all, map } from 'rsvp';
 export default class CourseVisualizeInstructorsRoute extends Route {
   @service session;
   @service store;
+  @service dataLoader;
 
   titleToken = 'general.coursesAndSessions';
+
+  async model(params) {
+    return this.dataLoader.loadCourse(params.course_id);
+  }
 
   async afterModel(course) {
     const sessions = (await course.sessions).toArray();

--- a/addon/routes/course-visualize-objectives.js
+++ b/addon/routes/course-visualize-objectives.js
@@ -5,8 +5,13 @@ import { all, map } from 'rsvp';
 export default class CourseVisualizeObjectivesRoute extends Route {
   @service store;
   @service session;
+  @service dataLoader;
 
   titleToken = 'general.coursesAndSessions';
+
+  async model(params) {
+    return this.dataLoader.loadCourse(params.course_id);
+  }
 
   async afterModel(course) {
     const sessions = (await course.sessions).toArray();

--- a/addon/routes/course-visualize-session-types.js
+++ b/addon/routes/course-visualize-session-types.js
@@ -5,8 +5,13 @@ import { all, map } from 'rsvp';
 export default class CourseVisualizeSessionTypesRoute extends Route {
   @service session;
   @service store;
+  @service dataLoader;
 
   titleToken = 'general.coursesAndSessions';
+
+  async model(params) {
+    return this.dataLoader.loadCourse(params.course_id);
+  }
 
   async afterModel(course) {
     const sessions = (await course.sessions).toArray();

--- a/addon/routes/course-visualize-vocabularies.js
+++ b/addon/routes/course-visualize-vocabularies.js
@@ -5,8 +5,13 @@ import { all, map } from 'rsvp';
 export default class CourseVisualizeVocabulariesRoute extends Route {
   @service session;
   @service store;
+  @service dataLoader;
 
   titleToken = 'general.coursesAndSessions';
+
+  async model(params) {
+    return this.dataLoader.loadCourse(params.course_id);
+  }
 
   async afterModel(course) {
     const sessions = (await course.sessions).toArray();


### PR DESCRIPTION
We were relying on the automatic model hook here, but that will soon be
deprecated.