### PR TITLE
Add appVersion to config service

### DIFF
--- a/addon/services/ilios-config.js
+++ b/addon/services/ilios-config.js
@@ -35,6 +35,16 @@ export default class IliosConfigService extends Service {
     return this.itemFromConfig('apiVersion');
   }
 
+  async getAppVersion() {
+    const version = await this.itemFromConfig('appVersion');
+    //ignore this development and bad build version string
+    if (version === '0.1.0') {
+      return '';
+    } else {
+      return version ?? '';
+    }
+  }
+
   async getTrackingEnabled() {
     return this.itemFromConfig('trackingEnabled');
   }

--- a/tests/unit/services/ilios-config-test.js
+++ b/tests/unit/services/ilios-config-test.js
@@ -12,6 +12,7 @@ module('Unit | Service | ilios config', function (hooks) {
         config: {
           type: 'authenticationType-foo',
           apiVersion: '1',
+          appVersion: '3.3.3',
           userSearchType: 'userSearchType-foo',
           random: 'random-foo',
           maxUploadSize: 'maxUploadSize-foo',
@@ -47,6 +48,30 @@ module('Unit | Service | ilios config', function (hooks) {
   test('it gets apiVersion', async function (assert) {
     const service = this.owner.lookup('service:ilios-config');
     assert.strictEqual(await service.getApiVersion(), '1');
+  });
+  test('it gets appVersion', async function (assert) {
+    const service = this.owner.lookup('service:ilios-config');
+    assert.strictEqual(await service.getAppVersion(), '3.3.3');
+  });
+  test('it ignores empty appVersion', async function (assert) {
+    this.server.get('application/config', function () {
+      return {
+        config: {},
+      };
+    });
+    const service = this.owner.lookup('service:ilios-config');
+    assert.strictEqual(await service.getAppVersion(), '');
+  });
+  test('it ignores development appVersion', async function (assert) {
+    this.server.get('application/config', function () {
+      return {
+        config: {
+          appVersion: '0.1.0',
+        },
+      };
+    });
+    const service = this.owner.lookup('service:ilios-config');
+    assert.strictEqual(await service.getAppVersion(), '');
   });
   test('it gets trackingEnabled', async function (assert) {
     const service = this.owner.lookup('service:ilios-config');


### PR DESCRIPTION
Couple of gotchas with this value, the main one is I didn't want to bump
the API version so we can't guarantee the value, but that's OK because
depending on the build config it could be missing anyway so we gotta
account for that in any case.