### PR TITLE
Silence super noisy ember global deprecation

### DIFF
--- a/tests/dummy/config/deprecation-workflow.js
+++ b/tests/dummy/config/deprecation-workflow.js
@@ -4,5 +4,6 @@ window.deprecationWorkflow = window.deprecationWorkflow || {};
 window.deprecationWorkflow.config = {
   workflow: [
     { handler: 'silence', matchId: 'manager-capabilities.modifiers-3-13' }, //https://github.com/emberjs/ember-render-modifiers/issues/32
+    { handler: 'silence', matchId: 'ember-global' },
   ],
 };


### PR DESCRIPTION
This finally has an id and can be silenced! Yay! We'll still need to fix
it, but at least our tests are more readable now.