### PR TITLE
adds multiday events display to monthly calendar view.

### DIFF
--- a/addon-test-support/ilios-common/page-objects/components/ilios-calendar-month.js
+++ b/addon-test-support/ilios-common/page-objects/components/ilios-calendar-month.js
@@ -1,0 +1,13 @@
+import { create } from 'ember-cli-page-object';
+import calendar from './monthly-calendar';
+import prework from './ilios-calendar-pre-work-events';
+import multiday from './ilios-calendar-multiday-events';
+
+const definition = {
+  calendar,
+  prework,
+  multiday,
+};
+
+export default definition;
+export const component = create(definition);

--- a/addon-test-support/ilios-common/page-objects/components/ilios-calendar-multiday-event.js
+++ b/addon-test-support/ilios-common/page-objects/components/ilios-calendar-multiday-event.js
@@ -1,0 +1,11 @@
+import { clickable, create, property, text } from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-ilios-calendar-multiday-event]',
+  name: text('[data-test-event-name]'),
+  isDisabled: property('disabled', 'button'),
+  click: clickable('button'),
+};
+
+export default definition;
+export const component = create(definition);

--- a/addon-test-support/ilios-common/page-objects/components/ilios-calendar-multiday-events.js
+++ b/addon-test-support/ilios-common/page-objects/components/ilios-calendar-multiday-events.js
@@ -1,0 +1,13 @@
+import { collection, create, text } from 'ember-cli-page-object';
+import item from './ilios-calendar-multiday-event';
+
+const definition = {
+  scope: '[data-test-ilios-calendar-multiday-events]',
+  title: text('[data-test-title]'),
+  events: collection('[data-test-ilios-calendar-multiday-event]', {
+    item,
+  }),
+};
+
+export default definition;
+export const component = create(definition);

--- a/addon-test-support/ilios-common/page-objects/components/ilios-calendar-pre-work-events.js
+++ b/addon-test-support/ilios-common/page-objects/components/ilios-calendar-pre-work-events.js
@@ -1,0 +1,13 @@
+import { collection, create, text } from 'ember-cli-page-object';
+import item from './ilios-calendar-pre-work-event';
+
+const definition = {
+  scope: '[data-test-ilios-calendar-prework-events]',
+  title: text('[data-test-title]'),
+  events: collection('[data-test-ilios-calendar-pre-work-event]', {
+    item,
+  }),
+};
+
+export default definition;
+export const component = create(definition);

--- a/addon-test-support/ilios-common/page-objects/components/monthly-calendar.js
+++ b/addon-test-support/ilios-common/page-objects/components/monthly-calendar.js
@@ -2,6 +2,7 @@ import { create, clickable, collection, hasClass, isPresent, text } from 'ember-
 
 const definition = {
   scope: '[data-test-monthly-calendar]',
+  monthYear: text('[data-test-month-year]'),
   days: collection('[data-test-day]', {
     number: text('[data-test-number]'),
     selectDay: clickable('button', { scope: '[data-test-number]' }),
@@ -15,10 +16,11 @@ const definition = {
     isFirstWeek: hasClass('week-1'),
     isSecondWeek: hasClass('week-2'),
     isThirdWeek: hasClass('week-3'),
-    events: collection('[data-test-ilios-calendar-event]', {}),
+    events: collection('[data-test-ilios-calendar-event]'),
     hasShowMore: isPresent('[data-test-show-more-button]'),
     showMore: clickable('[data-test-show-more-button]'),
   }),
+  events: collection('[data-test-ilios-calendar-event-month]'),
 };
 
 export default definition;

--- a/addon/components/ilios-calendar-month.hbs
+++ b/addon/components/ilios-calendar-month.hbs
@@ -2,7 +2,7 @@
   <div class="ilios-calendar-month">
     <MonthlyCalendar
       @date={{@date}}
-      @events={{this.nonIlmPreWorkEvents}}
+      @events={{this.singleDayEvents}}
       @changeToDayView={{this.changeToDayView}}
       @selectEvent={{@selectEvent}}
     />
@@ -10,6 +10,11 @@
     <IliosCalendarPreWorkEvents
       @events={{this.ilmPreWorkEvents}}
       @areEventsSelectable={{@areEventsSelectable}}
+    />
+    <IliosCalendarMultidayEvents
+      @events={{this.multiDayEventsList}}
+      @selectEvent={{@selectEvent}}
+      @areEventsSelectable={{@areDaysSelectable}}
     />
   </div>
 {{/if}}

--- a/addon/components/ilios-calendar-month.js
+++ b/addon/components/ilios-calendar-month.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import { action } from '@ember/object';
 
 export default class IliosCalendarMonthComponent extends Component {
@@ -26,13 +26,13 @@ export default class IliosCalendarMonthComponent extends Component {
 
   get singleDayEvents() {
     return this.nonIlmPreWorkEvents.filter((event) =>
-      moment(event.startDate).isSame(moment(event.endDate), 'day')
+      DateTime.fromISO(event.startDate).hasSame(DateTime.fromISO(event.endDate), 'day')
     );
   }
 
   get multiDayEventsList() {
     return this.nonIlmPreWorkEvents.filter(
-      (event) => !moment(event.startDate).isSame(moment(event.endDate), 'day')
+      (event) => !DateTime.fromISO(event.startDate).hasSame(DateTime.fromISO(event.endDate), 'day')
     );
   }
 

--- a/addon/components/ilios-calendar-month.js
+++ b/addon/components/ilios-calendar-month.js
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+import moment from 'moment';
 import { action } from '@ember/object';
 
 export default class IliosCalendarMonthComponent extends Component {
@@ -21,6 +22,18 @@ export default class IliosCalendarMonthComponent extends Component {
     return this.args.calendarEvents.filter((ev) => {
       return ev.postrequisites.length === 0 || !ev.ilmSession;
     });
+  }
+
+  get singleDayEvents() {
+    return this.nonIlmPreWorkEvents.filter((event) =>
+      moment(event.startDate).isSame(moment(event.endDate), 'day')
+    );
+  }
+
+  get multiDayEventsList() {
+    return this.nonIlmPreWorkEvents.filter(
+      (event) => !moment(event.startDate).isSame(moment(event.endDate), 'day')
+    );
   }
 
   @action

--- a/addon/components/ilios-calendar-multiday-events.hbs
+++ b/addon/components/ilios-calendar-multiday-events.hbs
@@ -1,5 +1,5 @@
 {{#if @events.length}}
-  <div class="ilios-calendar-multiday-events">
+  <div class="ilios-calendar-multiday-events" data-test-ilios-calendar-multiday-events>
     <h3 class="title" data-test-title>
       {{t "general.multidayEvents"}}
     </h3>

--- a/addon/components/ilios-calendar-pre-work-events.hbs
+++ b/addon/components/ilios-calendar-pre-work-events.hbs
@@ -1,6 +1,6 @@
 {{#if @events.length}}
-  <div class="ilios-calendar-pre-work-events">
-    <h3 class="title">
+  <div class="ilios-calendar-pre-work-events" data-test-ilios-calendar-prework-events>
+    <h3 class="title" data-test-title>
       {{t "general.preWork"}}
     </h3>
     <ul>

--- a/addon/components/monthly-calendar.hbs
+++ b/addon/components/monthly-calendar.hbs
@@ -1,5 +1,7 @@
 <section class="monthly-calendar" data-test-monthly-calendar>
-  <h2 class="month-year">{{format-date this.firstDayOfMonth month="long" year="numeric"}}</h2>
+  <h2 class="month-year" data-test-month-year>
+    {{format-date this.firstDayOfMonth month="long" year="numeric"}}
+  </h2>
   <div class="calendar">
     {{#each this.days as |day|}}
       <div class="day week-{{day.weekOfMonth}} day-{{day.dayOfWeek}}" data-test-day>

--- a/tests/integration/components/ilios-calendar-month-test.js
+++ b/tests/integration/components/ilios-calendar-month-test.js
@@ -3,28 +3,28 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import moment from 'moment';
 import { component } from 'ilios-common/page-objects/components/ilios-calendar-month';
+import { DateTime } from 'luxon';
 
 module('Integration | Component | ilios calendar month', function (hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks, 'en-us');
 
   test('month displays with three events', async function (assert) {
-    const date = moment(new Date('2015-09-30T12:00:00'));
-    this.set('date', date.toDate());
+    const date = DateTime.fromISO('2015-09-30T12:00:00');
+    this.set('date', date.toISO());
     const firstEvent = createUserEventObject();
     firstEvent.name = 'Some new thing';
-    firstEvent.startDate = date.clone();
-    firstEvent.endDate = date.clone().add(1, 'hour');
+    firstEvent.startDate = date.toISO();
+    firstEvent.endDate = date.plus({ hour: 1 }).toISO();
     const secondEvent = createUserEventObject();
     secondEvent.name = 'Second new thing';
-    secondEvent.startDate = date.clone().add(1, 'hour');
-    secondEvent.endDate = date.clone().add(3, 'hour');
+    secondEvent.startDate = date.plus({ hour: 1 }).toISO();
+    secondEvent.endDate = date.plus({ hour: 3 }).toISO();
     const thirdEvent = createUserEventObject();
     thirdEvent.name = 'Third new thing';
-    thirdEvent.startDate = date.clone().add(3, 'hour');
-    thirdEvent.endDate = date.clone().add(4, 'hour');
+    thirdEvent.startDate = date.plus({ hour: 3 }).toISO();
+    thirdEvent.endDate = date.plus({ hour: 4 }).toISO();
     this.set('events', [firstEvent, secondEvent, thirdEvent]);
     await render(hbs`<IliosCalendarMonth
       @date={{this.date}}
@@ -37,16 +37,16 @@ module('Integration | Component | ilios calendar month', function (hooks) {
   });
 
   test('month displays with two events', async function (assert) {
-    const date = moment(new Date('2015-09-30T12:00:00'));
-    this.set('date', date.toDate());
+    const date = new DateTime.fromISO('2015-09-30T12:00:00');
+    this.set('date', date.toISO());
     const firstEvent = createUserEventObject();
     firstEvent.name = 'Some new thing';
-    firstEvent.startDate = date.clone();
-    firstEvent.endDate = date.clone().add(1, 'hour');
+    firstEvent.startDate = date.toISO();
+    firstEvent.endDate = date.plus({ hour: 1 }).toISO();
     const secondEvent = createUserEventObject();
     secondEvent.name = 'Second new thing';
-    secondEvent.startDate = date.clone().add(1, 'hour');
-    secondEvent.endDate = date.clone().add(3, 'hour');
+    secondEvent.startDate = date.plus({ hour: 1 }).toISO();
+    secondEvent.endDate = date.plus({ hour: 3 }).toISO();
     this.set('events', [firstEvent, secondEvent]);
     await render(hbs`<IliosCalendarMonth
       @date={{this.date}}
@@ -60,8 +60,8 @@ module('Integration | Component | ilios calendar month', function (hooks) {
 
   test('clicking on a day fires the correct event', async function (assert) {
     assert.expect(3);
-    const date = new Date('2015-09-30T12:00:00');
-    this.set('date', date);
+    const date = DateTime.fromISO('2015-09-30T12:00:00');
+    this.set('date', date.toISO());
     this.set('changeDate', (newDate) => {
       assert.ok(newDate instanceof Date);
       assert.ok(newDate.toString().includes('Tue Sep 01'));
@@ -80,15 +80,16 @@ module('Integration | Component | ilios calendar month', function (hooks) {
   });
 
   test('prework', async function (assert) {
-    const date = moment(new Date('2015-09-30T12:00:00'));
+    const date = DateTime.fromISO('2015-09-30T12:00:00');
     const event = createUserEventObject();
-    event.startDate = date.clone();
-    event.endDate = date.clone().add(1, 'hour');
+    const now = DateTime.now();
+    event.startDate = date.toISO();
+    event.endDate = date.plus({ hour: 1 }).toISO();
     event.prerequisites = [
       {
         name: 'prework 1',
-        startDate: moment().format(),
-        endDate: moment().format(),
+        startDate: now.toISO(),
+        endDate: now.toISO(),
         ilmSession: true,
         slug: 'whatever',
         postrequisiteSlug: 'something',
@@ -99,8 +100,8 @@ module('Integration | Component | ilios calendar month', function (hooks) {
       },
       {
         name: 'prework 2',
-        startDate: moment().format(),
-        endDate: moment().format(),
+        startDate: now.toISO(),
+        endDate: now.toISO(),
         location: 'room 111',
         ilmSession: true,
         slug: 'whatever',
@@ -112,8 +113,8 @@ module('Integration | Component | ilios calendar month', function (hooks) {
       },
       {
         name: 'blanked prework',
-        startDate: moment().format(),
-        endDate: moment().format(),
+        startDate: now.toISO(),
+        endDate: now.toISO(),
         location: 'room 111',
         ilmSession: true,
         slug: 'whatever',
@@ -125,8 +126,8 @@ module('Integration | Component | ilios calendar month', function (hooks) {
       },
       {
         name: 'scheduled prework',
-        startDate: moment().format(),
-        endDate: moment().format(),
+        startDate: now.toISO(),
+        endDate: now.toISO(),
         location: 'room 111',
         ilmSession: true,
         slug: 'whatever',
@@ -138,8 +139,8 @@ module('Integration | Component | ilios calendar month', function (hooks) {
       },
       {
         name: 'unpublished prework',
-        startDate: moment().format(),
-        endDate: moment().format(),
+        startDate: now.toISO(),
+        endDate: now.toISO(),
         location: 'room 111',
         ilmSession: true,
         slug: 'whatever',
@@ -150,7 +151,7 @@ module('Integration | Component | ilios calendar month', function (hooks) {
         isBlanked: false,
       },
     ];
-    this.set('date', date.toDate());
+    this.set('date', date.toISO());
     this.set('events', [event]);
     await render(hbs`<IliosCalendarMonth
       @date={{this.date}}
@@ -158,16 +159,23 @@ module('Integration | Component | ilios calendar month', function (hooks) {
       @selectEvent={{(noop)}}
     />`);
     assert.strictEqual(component.prework.events.length, 2);
-    assert.strictEqual(component.prework.events[0].text, 'prework 1 Due Before third (1/7/2022)');
-    assert.strictEqual(component.prework.events[1].text, 'prework 2 Due Before first (1/7/2022)');
+    assert.strictEqual(
+      component.prework.events[0].text,
+      `prework 1 Due Before third (${now.toFormat('D')})`
+    );
+    assert.strictEqual(
+      component.prework.events[1].text,
+      `prework 2 Due Before first (${now.toFormat('D')})`
+    );
   });
 
   test('prework to unpublished/scheduled/blanked events is not visible', async function (assert) {
-    const date = moment(new Date('2015-09-30T12:00:00'));
+    const date = DateTime.fromISO('2015-09-30T12:00:00');
+    const now = DateTime.now();
     const publishedPrework = {
       name: 'published prework',
-      startDate: moment().format(),
-      endDate: moment().format(),
+      startDate: now.toISO(),
+      endDate: now.toISO(),
       ilmSession: true,
       slug: 'whatever',
       postrequisiteSlug: 'something',
@@ -194,12 +202,12 @@ module('Integration | Component | ilios calendar month', function (hooks) {
     const events = [unpublishedEvent, scheduledEvent, blankedEvent];
 
     events.forEach((event) => {
-      event.startDate = date.clone();
-      event.endDate = date.clone().add(1, 'hour');
+      event.startDate = date.toISO();
+      event.endDate = date.plus({ hour: 1 }).toISO();
       event.prerequisites = [publishedPrework];
     });
 
-    this.set('date', date.toDate());
+    this.set('date', date.toISO());
     this.set('events', events);
     await render(hbs`<IliosCalendarMonth
       @date={{this.date}}
@@ -227,14 +235,14 @@ module('Integration | Component | ilios calendar month', function (hooks) {
   };
 
   test('multiday events', async function (assert) {
-    const date = moment(new Date('2015-09-20T12:00:00'));
+    const date = DateTime.fromISO('2015-09-20T12:00:00');
     const event = createUserEventObject();
-    event.startDate = date.clone();
-    event.endDate = date.clone().add(24, 'hour');
+    event.startDate = date.toISO();
+    event.endDate = date.plus({ hour: 24 }).toISO();
     const event2 = createUserEventObject();
-    event2.startDate = date.clone().add(48, 'hour');
-    event2.endDate = date.clone().add(72, 'hour');
-    this.set('date', date.toDate());
+    event2.startDate = date.plus({ hour: 48 }).toISO();
+    event2.endDate = date.plus({ hour: 72 }).toISO();
+    this.set('date', date.toISO());
     this.set('events', [event, event2]);
     await render(hbs`<IliosCalendarMonth
       @date={{this.date}}

--- a/tests/integration/components/ilios-calendar-multiday-event-test.js
+++ b/tests/integration/components/ilios-calendar-multiday-event-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import hbs from 'htmlbars-inline-precompile';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { component } from 'ilios-common/page-objects/components/ilios-calendar-multiday-event';
@@ -13,8 +13,8 @@ module('Integration | Component | ilios calendar multiday event', function (hook
 
   hooks.beforeEach(function () {
     this.ev = {
-      startDate: moment('1984-11-11').toDate(),
-      endDate: moment('1984-11-12').toDate(),
+      startDate: DateTime.fromISO('1984-11-11').toISO(),
+      endDate: DateTime.fromISO('1984-11-12').toISO(),
       name: 'Cheramie is born',
       location: 'Lancaster, CA',
     };

--- a/tests/integration/components/ilios-calendar-multiday-events-test.js
+++ b/tests/integration/components/ilios-calendar-multiday-events-test.js
@@ -5,13 +5,14 @@ import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { DateTime } from 'luxon';
+import { component } from 'ilios-common/page-objects/components/ilios-calendar-multiday-events';
 
 module('Integration | Component | ilios calendar multiday events', function (hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks, 'en-us');
 
-  const getEvents = function () {
-    return [
+  hooks.beforeEach(function () {
+    this.events = [
       {
         startDate: DateTime.fromISO('1984-11-11').toJSDate(),
         endDate: DateTime.fromISO('1984-11-12').toJSDate(),
@@ -25,14 +26,12 @@ module('Integration | Component | ilios calendar multiday events', function (hoo
         location: 'Lancaster, CA',
       },
     ];
-  };
+  });
 
   test('it renders', async function (assert) {
-    this.set('events', getEvents());
     await render(hbs`<IliosCalendarMultidayEvents @events={{this.events}} />`);
-
-    assert.dom('[data-test-title]').containsText('Multiday Events');
-    assert.dom('li').exists({ count: 2 });
+    assert.strictEqual(component.title, 'Multiday Events');
+    assert.strictEqual(component.events.length, 2);
     await a11yAudit(this.element);
   });
 });

--- a/tests/integration/components/ilios-calendar-pre-work-event-test.js
+++ b/tests/integration/components/ilios-calendar-pre-work-event-test.js
@@ -3,9 +3,9 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import { component } from 'ilios-common/page-objects/components/ilios-calendar-pre-work-event';
-const today = moment();
+const today = DateTime.now();
 
 module('Integration | Component | ilios-calendar-pre-work-event', function (hooks) {
   setupRenderingTest(hooks);
@@ -16,7 +16,7 @@ module('Integration | Component | ilios-calendar-pre-work-event', function (hook
     this.set('event', {
       name: 'Learn to Learn',
       slug: 'abc',
-      startDate: today.format(),
+      startDate: today.toISO(),
       location: 'Room 123',
       sessionTypeTitle: 'Lecture',
       courseExternalId: 'C1',
@@ -66,7 +66,7 @@ module('Integration | Component | ilios-calendar-pre-work-event', function (hook
     />`);
     assert.strictEqual(component.title, 'Learn to Learn');
     assert.strictEqual(component.titleUrl, '/events/abc');
-    assert.strictEqual(component.date, `Due Before reading to read (${today.format('M/D/Y')})`);
+    assert.strictEqual(component.date, `Due Before reading to read (${today.toFormat('D')})`);
     assert.strictEqual(component.url, '/events/123');
   });
 
@@ -78,7 +78,7 @@ module('Integration | Component | ilios-calendar-pre-work-event', function (hook
     />`);
     assert.strictEqual(component.title, 'Learn to Learn');
     assert.notOk(component.titleUrlIsPresent);
-    assert.strictEqual(component.date, `Due Before reading to read (${today.format('M/D/Y')})`);
+    assert.strictEqual(component.date, `Due Before reading to read (${today.toFormat('D')})`);
     assert.notOk(component.urlIsPresent);
   });
 });

--- a/tests/integration/components/ilios-calendar-pre-work-event-test.js
+++ b/tests/integration/components/ilios-calendar-pre-work-event-test.js
@@ -4,9 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import moment from 'moment';
-
 import { component } from 'ilios-common/page-objects/components/ilios-calendar-pre-work-event';
-
 const today = moment();
 
 module('Integration | Component | ilios-calendar-pre-work-event', function (hooks) {

--- a/tests/integration/components/ilios-calendar-pre-work-events-test.js
+++ b/tests/integration/components/ilios-calendar-pre-work-events-test.js
@@ -3,9 +3,9 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import { component } from 'ilios-common/page-objects/components/ilios-calendar-pre-work-events';
-const today = moment();
+const today = DateTime.now();
 
 module('Integration | Component | ilios-calendar-pre-work-events', function (hooks) {
   setupRenderingTest(hooks);
@@ -17,7 +17,7 @@ module('Integration | Component | ilios-calendar-pre-work-events', function (hoo
       {
         name: 'Learn to Learn',
         slug: 'abc',
-        startDate: today.format(),
+        startDate: today.toISO(),
         location: 'Room 123',
         sessionTypeTitle: 'Lecture',
         courseExternalId: 'C1',
@@ -66,7 +66,7 @@ module('Integration | Component | ilios-calendar-pre-work-events', function (hoo
     assert.strictEqual(component.events.length, 1);
     assert.strictEqual(
       component.events[0].text,
-      'Learn to Learn Due Before reading to read (1/7/2022)'
+      `Learn to Learn Due Before reading to read (${today.toFormat('D')})`
     );
   });
 });

--- a/tests/integration/components/ilios-calendar-pre-work-events-test.js
+++ b/tests/integration/components/ilios-calendar-pre-work-events-test.js
@@ -3,14 +3,70 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import moment from 'moment';
+import { component } from 'ilios-common/page-objects/components/ilios-calendar-pre-work-events';
+const today = moment();
 
 module('Integration | Component | ilios-calendar-pre-work-events', function (hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks, 'en-us');
 
-  test('it renders', async function (assert) {
-    await render(hbs`<IliosCalendarPreWorkEvents />`);
+  hooks.beforeEach(function () {
+    this.owner.setupRouter();
+    this.events = [
+      {
+        name: 'Learn to Learn',
+        slug: 'abc',
+        startDate: today.format(),
+        location: 'Room 123',
+        sessionTypeTitle: 'Lecture',
+        courseExternalId: 'C1',
+        sessionDescription:
+          'Best <strong>Session</strong>For Sure' +
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur',
+        isBlanked: false,
+        isPublished: true,
+        isScheduled: false,
+        learningMaterials: [
+          {
+            title: 'Citation LM',
+            type: 'citation',
+            required: true,
+            publicNotes: 'This is cool.',
+            citation: 'citationtext',
+          },
+          {
+            title: 'Link LM',
+            type: 'link',
+            required: false,
+            link: 'http://myhost.com/url2',
+          },
+          {
+            title: 'File LM',
+            type: 'file',
+            filename: 'This is a PDF',
+            mimetype: 'application/pdf',
+            required: true,
+            absoluteFileUri: 'http://myhost.com/url1',
+          },
+        ],
+        attireRequired: true,
+        equipmentRequired: true,
+        attendanceRequired: true,
+        supplemental: true,
+        postrequisiteName: 'reading to read',
+        postrequisiteSlug: '123',
+      },
+    ];
+  });
 
-    assert.dom(this.element).hasText('');
+  test('it renders', async function (assert) {
+    await render(hbs`<IliosCalendarPreWorkEvents @events={{this.events}}/>`);
+    assert.strictEqual(component.title, 'Pre-work');
+    assert.strictEqual(component.events.length, 1);
+    assert.strictEqual(
+      component.events[0].text,
+      'Learn to Learn Due Before reading to read (1/7/2022)'
+    );
   });
 });


### PR DESCRIPTION
this is the quick- and easy fix getting multi-day events on the display, it's also consistent on how it's handled on other calendar displays (month and day view).

refs #2524

todo:
- [x] update test coverage
