### PR TITLE
Replace usage of is helper in EPO tests

### DIFF
--- a/addon-test-support/ilios-common/helpers/has-focus.js
+++ b/addon-test-support/ilios-common/helpers/has-focus.js
@@ -1,0 +1,16 @@
+import { findOne } from 'ember-cli-page-object/extend';
+
+export function hasFocus(selector, userOptions = {}) {
+  return {
+    isDescriptor: true,
+
+    get(key) {
+      let options = { pageObjectKey: key, ...userOptions };
+
+      const element = findOne(this, selector, options);
+
+      //check that the selected element is the "active" one (has focus)
+      return element === document.activeElement;
+    },
+  };
+}

--- a/addon-test-support/ilios-common/index.js
+++ b/addon-test-support/ilios-common/index.js
@@ -9,3 +9,4 @@ export {
   pageObjectFroalaEditorValue,
 } from './helpers/froala-editor';
 export { getText, getElementText } from './helpers/custom-helpers';
+export { hasFocus } from './helpers/has-focus';

--- a/addon-test-support/ilios-common/page-objects/components/search-box.js
+++ b/addon-test-support/ilios-common/page-objects/components/search-box.js
@@ -1,19 +1,12 @@
-import {
-  attribute,
-  create,
-  clickable,
-  fillable,
-  is,
-  triggerable,
-  value,
-} from 'ember-cli-page-object';
+import { attribute, create, clickable, fillable, triggerable, value } from 'ember-cli-page-object';
+import { hasFocus } from 'ilios-common';
 
 const definition = {
   scope: '[data-test-search-box]',
   submit: clickable('[data-test-submit-search]'),
   set: fillable('input'),
   value: value('input'),
-  inputHasFocus: is(':focus', 'input'),
+  inputHasFocus: hasFocus('input'),
   placeholder: attribute('placeholder', 'input'),
   esc: triggerable('keyup', 'input', { eventProperties: { key: 'Escape' } }),
 };

--- a/tests/dummy/config/deprecation-workflow.js
+++ b/tests/dummy/config/deprecation-workflow.js
@@ -14,6 +14,5 @@ window.deprecationWorkflow.config = {
     { handler: 'silence', matchId: 'deprecated-run-loop-and-computed-dot-access' },
     { handler: 'silence', matchId: 'ember-simple-auth.initializer.setup-session-restoration' },
     { handler: 'silence', matchId: 'routing.transition-methods' },
-    { handler: 'silence', matchId: 'ember-cli-page-object.is-property' },
   ],
 };


### PR DESCRIPTION
Ember page object deprecated the "is" helper. In our case, finding
focus, we need a custom helper to replace it.