### PR TITLE
applies correct "link button" style.

### DIFF
--- a/addon/components/detail-learning-materials.hbs
+++ b/addon/components/detail-learning-materials.hbs
@@ -105,6 +105,7 @@
               >
                 <button
                   type="button"
+                  class="link-button"
                   {{on "click" (fn (mut this.managingMaterial) lmProxy.content)}}
                 >
                   <LmTypeIcon


### PR DESCRIPTION
fixes #2570 

![image](https://user-images.githubusercontent.com/1410427/149568798-4965a549-07be-497d-9eca-d4e57b232260.png)
