### PR TITLE
Push @embroider/util to production dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@ember/render-modifiers": "^2.0.0",
+        "@embroider/util": "^1.0.0",
         "@formatjs/intl-locale": "^2.4.7",
         "@formatjs/intl-pluralrules": "^4.0.0",
         "@formatjs/intl-relativetimeformat": "^9.1.2",
@@ -78,7 +79,6 @@
         "@ember/optional-features": "^2.0.0",
         "@ember/test-helpers": "^2.4.2",
         "@embroider/test-setup": "^1.0.0",
-        "@embroider/util": "^1.0.0",
         "@ilios/ember-template-lint-plugin": "^3.0.0",
         "babel-eslint": "^10.1.0",
         "broccoli-asset-rev": "^3.0.0",
@@ -2866,7 +2866,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@embroider/util/-/util-1.0.0.tgz",
       "integrity": "sha512-WQ6Dg3K5MXRbGP7N8yl1x63djohB4rbBE4qQMriA5blg2cav/eiNT2Vgh//Ft9j+auz46o4lzGmWVtzqVLWgeg==",
-      "dev": true,
       "dependencies": {
         "@embroider/macros": "1.0.0",
         "broccoli-funnel": "^3.0.5",
@@ -36209,7 +36208,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@embroider/util/-/util-1.0.0.tgz",
       "integrity": "sha512-WQ6Dg3K5MXRbGP7N8yl1x63djohB4rbBE4qQMriA5blg2cav/eiNT2Vgh//Ft9j+auz46o4lzGmWVtzqVLWgeg==",
-      "dev": true,
       "requires": {
         "@embroider/macros": "1.0.0",
         "broccoli-funnel": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@ember/render-modifiers": "^2.0.0",
+    "@embroider/util": "^1.0.0",
     "@formatjs/intl-locale": "^2.4.7",
     "@formatjs/intl-pluralrules": "^4.0.0",
     "@formatjs/intl-relativetimeformat": "^9.1.2",
@@ -96,7 +97,6 @@
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.4.2",
     "@embroider/test-setup": "^1.0.0",
-    "@embroider/util": "^1.0.0",
     "@ilios/ember-template-lint-plugin": "^3.0.0",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",


### PR DESCRIPTION
This is used in the calendar and needs to be in dependencies in order to
be accessible by app consumers.Push @embroider/util to production
dependencies