### PR TITLE
Restore node 14.x support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [14.x, 16.x]
 
     steps:
     - uses: actions/checkout@v2
@@ -38,11 +38,15 @@ jobs:
     name: Floating Dependencies
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        node-version: [14.x, 16.x]
+
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:
-        node-version: 16
+        node-version: ${{ matrix.node-version }}
     - name: install dependencies
       run: npm install --no-package-lock
     - name: test
@@ -60,7 +64,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:
-        node-version: 16
+        node-version: 14
     - name: install dependencies
       run: npm ci
     - name: test

--- a/.github/workflows/future-ci.yaml
+++ b/.github/workflows/future-ci.yaml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: 16
 
     steps:
     - uses: actions/checkout@v2
@@ -44,7 +44,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:
-        node-version: 16
+        node-version: 14
     - name: install dependencies
       run: npm ci
     - name: test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:
-        node-version: 16
+        node-version: 14
     - name: install dependencies
       run: npm ci
     - name: test
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 16
+          node-version: 14
           registry-url: https://registry.npmjs.org/
       - name: install dependencies
         run: npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -122,14 +122,14 @@
         "webpack": "^5.64.2"
       },
       "engines": {
-        "node": ">= 16",
-        "npm": ">= 8"
+        "node": ">= 14",
+        "npm": ">= 7"
       }
     },
     "node_modules/@ampproject/remapping": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.0.4.tgz",
-      "integrity": "sha512-zU3pj3pf//YhaoozRTYKaL20KopXrzuZFc/8Ylc49AuV8grYKH23TTq9JJoR70F8zQbil58KjSchZTWeX+jrIQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.0.tgz",
+      "integrity": "sha512-d5RysTlJ7hmw5Tw4UxgxcY3lkMe92n8sXCcuLPAyIAHK6j8DefDwtGnVVDgOnv+RnEosulDJ9NPKQL27bDId0g==",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.0"
       },
@@ -3691,9 +3691,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "0.0.50",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
-      "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
+      "version": "0.0.51",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
+      "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ=="
     },
     "node_modules/@types/express": {
       "version": "4.17.13",
@@ -7729,9 +7729,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001307",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001307.tgz",
-      "integrity": "sha512-+MXEMczJ4FuxJAUp0jvAl6Df0NI/OfW1RWEE61eSmzS7hw6lz4IKutbhbXendwq8BljfFuHtu26VWsg4afQ7Ng==",
+      "version": "1.0.30001309",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001309.tgz",
+      "integrity": "sha512-Pl8vfigmBXXq+/yUz1jUwULeq9xhMJznzdc/xwl4WclDAuebcTHVefpz8lE/bMI+UN7TOkSSe7B7RnZd6+dzjA==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
@@ -13875,9 +13875,9 @@
       }
     },
     "node_modules/ember-file-upload": {
-      "version": "5.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/ember-file-upload/-/ember-file-upload-5.0.0-beta.5.tgz",
-      "integrity": "sha512-Nb2dzhGewU2lQyKsrBnNPnyJjlO7vWy9ypdi54/txIdpZlbvrh/jfPQTc1KaIls8BUBk2HfbRpXFpTc74zvAzw==",
+      "version": "5.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/ember-file-upload/-/ember-file-upload-5.0.0-beta.6.tgz",
+      "integrity": "sha512-mvnTxJJ/AKPrcCjhxh3sfXD/c2URTUqtjJ2/srexylifeY3u1KGU1cZCybLu6FM2HXgS34hFha/GHRDv9sSdew==",
       "dependencies": {
         "@ember/test-waiters": "^3.0.0",
         "@embroider/macros": "^1.0.0",
@@ -21830,9 +21830,9 @@
       }
     },
     "node_modules/libphonenumber-js": {
-      "version": "1.9.47",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.47.tgz",
-      "integrity": "sha512-FIWFLJ2jUJi8SCztgd2k/isQHZedh7xuxOVifqFLwG/ogZtdH9TXFK92w/KWFj1lwoadqVedtLO3Jqp0q67PZw=="
+      "version": "1.9.48",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.48.tgz",
+      "integrity": "sha512-2aiDGkr5Ty7LZRhKhnMeV9tfRbzd2zahgF12I0v11AFwEelSdiu5t8/Npf3UejKcuoO4anqTdjnIW3dEtj1xYQ=="
     },
     "node_modules/line-column": {
       "version": "1.0.2",
@@ -22963,9 +22963,9 @@
       "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -26111,9 +26111,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.67.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.67.0.tgz",
-      "integrity": "sha512-W83AaERwvDiHwHEF/dfAfS3z1Be5wf7n+pO3ZAO5IQadCT2lBTr7WQ2MwZZe+nodbD+n3HtC4OCOAdsOPPcKZQ==",
+      "version": "2.67.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.67.1.tgz",
+      "integrity": "sha512-1Sbcs4OuW+aD+hhqpIRl+RqooIpF6uQcfzU/QSI7vGkwADY6cM4iLsBGRM2CGLXDTDN5y/yShohFmnKegSPWzg==",
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -29262,9 +29262,9 @@
       "dev": true
     },
     "node_modules/uglify-js": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.0.tgz",
-      "integrity": "sha512-x+xdeDWq7FiORDvyIJ0q/waWd4PhjBNOm5dQUOq2AKC0IEjxOS66Ha9tctiVDGcRQuh69K7fgU5oRuTK4cysSg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.1.tgz",
+      "integrity": "sha512-FAGKF12fWdkpvNJZENacOH0e/83eG6JyVQyanIJaBXCN1J11TUQv1T1/z8S+Z0CG0ZPk1nPcreF/c7lrTd0TEQ==",
       "optional": true,
       "bin": {
         "uglifyjs": "bin/uglifyjs"
@@ -30125,6 +30125,11 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/webpack/node_modules/@types/estree": {
+      "version": "0.0.50",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
+      "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
+    },
     "node_modules/webpack/node_modules/glob-to-regexp": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
@@ -30487,9 +30492,9 @@
   },
   "dependencies": {
     "@ampproject/remapping": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.0.4.tgz",
-      "integrity": "sha512-zU3pj3pf//YhaoozRTYKaL20KopXrzuZFc/8Ylc49AuV8grYKH23TTq9JJoR70F8zQbil58KjSchZTWeX+jrIQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.0.tgz",
+      "integrity": "sha512-d5RysTlJ7hmw5Tw4UxgxcY3lkMe92n8sXCcuLPAyIAHK6j8DefDwtGnVVDgOnv+RnEosulDJ9NPKQL27bDId0g==",
       "requires": {
         "@jridgewell/trace-mapping": "^0.3.0"
       }
@@ -33173,9 +33178,9 @@
       }
     },
     "@types/estree": {
-      "version": "0.0.50",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
-      "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
+      "version": "0.0.51",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
+      "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ=="
     },
     "@types/express": {
       "version": "4.17.13",
@@ -36670,9 +36675,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001307",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001307.tgz",
-      "integrity": "sha512-+MXEMczJ4FuxJAUp0jvAl6Df0NI/OfW1RWEE61eSmzS7hw6lz4IKutbhbXendwq8BljfFuHtu26VWsg4afQ7Ng=="
+      "version": "1.0.30001309",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001309.tgz",
+      "integrity": "sha512-Pl8vfigmBXXq+/yUz1jUwULeq9xhMJznzdc/xwl4WclDAuebcTHVefpz8lE/bMI+UN7TOkSSe7B7RnZd6+dzjA=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -41661,9 +41666,9 @@
       }
     },
     "ember-file-upload": {
-      "version": "5.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/ember-file-upload/-/ember-file-upload-5.0.0-beta.5.tgz",
-      "integrity": "sha512-Nb2dzhGewU2lQyKsrBnNPnyJjlO7vWy9ypdi54/txIdpZlbvrh/jfPQTc1KaIls8BUBk2HfbRpXFpTc74zvAzw==",
+      "version": "5.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/ember-file-upload/-/ember-file-upload-5.0.0-beta.6.tgz",
+      "integrity": "sha512-mvnTxJJ/AKPrcCjhxh3sfXD/c2URTUqtjJ2/srexylifeY3u1KGU1cZCybLu6FM2HXgS34hFha/GHRDv9sSdew==",
       "requires": {
         "@ember/test-waiters": "^3.0.0",
         "@embroider/macros": "^1.0.0",
@@ -47963,9 +47968,9 @@
       }
     },
     "libphonenumber-js": {
-      "version": "1.9.47",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.47.tgz",
-      "integrity": "sha512-FIWFLJ2jUJi8SCztgd2k/isQHZedh7xuxOVifqFLwG/ogZtdH9TXFK92w/KWFj1lwoadqVedtLO3Jqp0q67PZw=="
+      "version": "1.9.48",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.48.tgz",
+      "integrity": "sha512-2aiDGkr5Ty7LZRhKhnMeV9tfRbzd2zahgF12I0v11AFwEelSdiu5t8/Npf3UejKcuoO4anqTdjnIW3dEtj1xYQ=="
     },
     "line-column": {
       "version": "1.0.2",
@@ -48946,9 +48951,9 @@
       "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -51414,9 +51419,9 @@
       }
     },
     "rollup": {
-      "version": "2.67.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.67.0.tgz",
-      "integrity": "sha512-W83AaERwvDiHwHEF/dfAfS3z1Be5wf7n+pO3ZAO5IQadCT2lBTr7WQ2MwZZe+nodbD+n3HtC4OCOAdsOPPcKZQ==",
+      "version": "2.67.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.67.1.tgz",
+      "integrity": "sha512-1Sbcs4OuW+aD+hhqpIRl+RqooIpF6uQcfzU/QSI7vGkwADY6cM4iLsBGRM2CGLXDTDN5y/yShohFmnKegSPWzg==",
       "requires": {
         "fsevents": "~2.3.2"
       }
@@ -53915,9 +53920,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.0.tgz",
-      "integrity": "sha512-x+xdeDWq7FiORDvyIJ0q/waWd4PhjBNOm5dQUOq2AKC0IEjxOS66Ha9tctiVDGcRQuh69K7fgU5oRuTK4cysSg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.1.tgz",
+      "integrity": "sha512-FAGKF12fWdkpvNJZENacOH0e/83eG6JyVQyanIJaBXCN1J11TUQv1T1/z8S+Z0CG0ZPk1nPcreF/c7lrTd0TEQ==",
       "optional": true
     },
     "unbox-primitive": {
@@ -54609,6 +54614,11 @@
         "webpack-sources": "^3.2.3"
       },
       "dependencies": {
+        "@types/estree": {
+          "version": "0.0.50",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
+          "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
+        },
         "glob-to-regexp": {
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -140,8 +140,8 @@
     "webpack": "^5.64.2"
   },
   "engines": {
-    "node": ">= 16",
-    "npm": ">= 8"
+    "node": ">= 14",
+    "npm": ">= 7"
   },
   "ember": {
     "edition": "octane"
@@ -162,9 +162,6 @@
     "translations/",
     "vendor/"
   ],
-  "overrides": {
-    "@embroider/macros": "^1.0.0"
-  },
   "pre-commit": [
     "lint"
   ]


### PR DESCRIPTION
Now that embroider is better up to date across our dependencies we no
longer need the override option in package.json and can relax our
required node version.