### PR TITLE
Require embroider tests to pass

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,5 +66,4 @@ jobs:
     - name: test
       env:
         EMBER_TRY_SCENARIO: ${{ matrix.ember-try-scenario }}
-      continue-on-error: true
       run: node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO


### PR DESCRIPTION
Removing this line will start failing our builds when these tests fail.

Getting close, want to have a place to see build status officially as we close the last few gaps.