### PR TITLE
Break table columns with no spaces

### DIFF
--- a/app/styles/ilios-common/mixins/ilios-table.scss
+++ b/app/styles/ilios-common/mixins/ilios-table.scss
@@ -18,6 +18,7 @@
 
   th,
   td {
+    word-break: break-all;
     &.text-left,
     &.align-left {
       text-align: left;


### PR DESCRIPTION
Otherwise long names with underscores break the layout.

Fixes https://github.com/ilios/frontend/issues/3415