### PR TITLE
Add github actions to dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,3 +35,7 @@ updates:
   - dependency-name: eslint-plugin-node
   - dependency-name: loader.js
   - dependency-name: qunit-dom
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily


### PR DESCRIPTION
This will ensure our actions are running on the latest versions.