### PR TITLE
use a different CSS property to break text in tables.

### DIFF
--- a/app/styles/ilios-common/mixins/ilios-table.scss
+++ b/app/styles/ilios-common/mixins/ilios-table.scss
@@ -18,7 +18,7 @@
 
   th,
   td {
-    word-break: break-all;
+    overflow-wrap: break-word;
     &.text-left,
     &.align-left {
       text-align: left;


### PR DESCRIPTION
the problem was introduced with https://github.com/ilios/common/pull/2676

![image](https://user-images.githubusercontent.com/1410427/155818715-2ba21d14-8b96-4b18-913d-1c7bc2666a8b.png)

using `overflow-wrap` seems to be a better way to break text. 

![image](https://user-images.githubusercontent.com/1410427/155818847-36ccf12e-eb2f-4148-8e9c-606e7b6736ac.png)



see https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap