### PR TITLE
Fix learner group descendant users

### DIFF
--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -150,7 +150,7 @@ export default class LearnerGroup extends Model {
   async getAllDescendantUsers() {
     const users = await this.users;
     const descendantUsers = await this._getDescendantUsers();
-    return [...users.toArray(), ...descendantUsers];
+    return [...users.toArray(), ...descendantUsers].uniq();
   }
 
   async _getDescendantUsers() {

--- a/tests/unit/models/learner-group-test.js
+++ b/tests/unit/models/learner-group-test.js
@@ -94,7 +94,7 @@ module('Unit | Model | LearnerGroup', function (hooks) {
       users: [user5],
       children: [subSubGroup1],
     });
-    learnerGroup.get('users').pushObjects([user1, user4]);
+    learnerGroup.get('users').pushObjects([user1, user2, user3, user4, user5]);
     learnerGroup.get('children').pushObjects([subGroup1, subGroup2]);
 
     const allDescendantUsers = await waitForResource(learnerGroup, 'allDescendantUsers');


### PR DESCRIPTION
Our API always represents this as a set with users in subgroups also
existing in the parent. When we fetch this tree for all users in
subgroups we also have to call unique to avoid a lot of duplicates.

Fixes ilios/ilios#3936