### PR TITLE
style instructor lists in print course view without bullets.

### DIFF
--- a/addon/components/print-course.hbs
+++ b/addon/components/print-course.hbs
@@ -457,7 +457,7 @@
                     <td class="text-left">
                       {{offering.room}}
                     </td>
-                    <td class="text-left">
+                    <td class="text-left offering-instructors">
                       <ul>
                         {{#each (await offering.allInstructors) as |user|}}
                           <li>

--- a/app/styles/ilios-common/components/print-course.scss
+++ b/app/styles/ilios-common/components/print-course.scss
@@ -43,4 +43,8 @@
       @include ilios-static-list;
     }
   }
+
+  .offering-instructors {
+    @include ilios-list-reset;
+  }
 }


### PR DESCRIPTION
fixes https://github.com/ilios/frontend/issues/2391