### PR TITLE
removes fast-forward/backwards controls if pagination runs in "limitless" mode

### DIFF
--- a/addon/components/pagedlist-controls.hbs
+++ b/addon/components/pagedlist-controls.hbs
@@ -11,17 +11,17 @@
       >
         <FaIcon @icon="backward-fast" class={{if this.firstPage "disabled"}} />
       </button>
-      <button
-        class="link-button backward"
-        type="button"
-        title={{t "general.previous"}}
-        disabled={{this.firstPage}}
-        data-test-go-to-previous
-        {{on "click" this.goBack}}
-      >
-        <FaIcon @icon="play" @flip="horizontal" class={{if this.firstPage "disabled"}} />
-      </button>
     {{/unless}}
+    <button
+      class="link-button backward"
+      type="button"
+      title={{t "general.previous"}}
+      disabled={{this.firstPage}}
+      data-test-go-to-previous
+      {{on "click" this.goBack}}
+    >
+      <FaIcon @icon="play" @flip="horizontal" class={{if this.firstPage "disabled"}} />
+    </button>
     {{#if @limitless}}
       <select aria-labelledby="per-page-{{templateId}}" {{on "change" (pick "target.value" this.setLimit)}} data-test-limits>
         {{#each this.offsetOptions as |o|}}
@@ -36,17 +36,17 @@
         {{t "general.pagedResultsCount" start=this.start end=this.end total=this.total}}
       </span>
     {{/if}}
+    <button
+      class="link-button forward"
+      type="button"
+      title={{t "general.next"}}
+      disabled={{this.lastPage}}
+      data-test-go-to-next
+      {{on "click" this.goForward}}
+    >
+      <FaIcon @icon="play" class={{if this.lastPage "disabled"}} />
+    </button>
     {{#unless @limitless}}
-      <button
-        class="link-button forward"
-        type="button"
-        title={{t "general.next"}}
-        disabled={{this.lastPage}}
-        data-test-go-to-next
-        {{on "click" this.goForward}}
-      >
-        <FaIcon @icon="play" class={{if this.lastPage "disabled"}} />
-      </button>
       <button
         class="link-button forward"
         type="button"
@@ -57,8 +57,6 @@
       >
         <FaIcon @icon="fast-forward" class={{if this.lastPage "disabled"}}/>
       </button>
-    {{/unless}}
-    {{#unless @limitless}}
       <select aria-labelledby="per-page-{{templateId}}" {{on "change" (pick "target.value" this.setLimit)}} data-test-limits>
         {{#each this.offsetOptions as |o|}}
           <option value={{o}} selected={{is-equal o this.limit}} data-test-limit>

--- a/tests/integration/components/pagedlist-controls-test.js
+++ b/tests/integration/components/pagedlist-controls-test.js
@@ -34,6 +34,8 @@ module('Integration | Component | pagedlist controls', function (hooks) {
     assert.strictEqual(component.limit.options[5].text, '400');
     assert.strictEqual(component.limit.options[6].text, '1000');
     assert.notOk(component.pagerDetails.isPresent);
+    assert.notOk(component.firstPage.isPresent);
+    assert.notOk(component.lastPage.isPresent);
   });
 
   test('first page', async function (assert) {


### PR DESCRIPTION
limitless really means data loading callbacks get fired when pagination
is used. so while fast-backwards would work, fast-forward won't (we
don't know the total number of records in advance).

this fixes a regression that was introduced with release v66.0.1 and manifested itself in the frontend's user admin view.