### PR TITLE
adds collapser to truncated text

### DIFF
--- a/addon/components/editable-field.hbs
+++ b/addon/components/editable-field.hbs
@@ -20,7 +20,7 @@
               @renderHtml={{@renderHtml}}
               @text={{@value}}
               @onEdit={{set this.isEditing true}}
-              as |displayText expand isTruncated|
+              as |displayText expand collapse isTruncated expanded|
             >
               <span
                 class="clickable editable"
@@ -37,11 +37,25 @@
                   class="expand-text-button"
                   type="button"
                   aria-label={{t "general.expand"}}
+                  title={{t "general.expand"}}
                   data-test-expand
                   {{on "click" expand}}
                 >
-                  <FaIcon @icon="circle-info" />
+                  <FaIcon @icon="angles-down" />
                 </button>
+              {{else}}
+                {{#if expanded}}
+                  <button
+                    class="expand-text-button"
+                    aria-label={{t "general.collapse"}}
+                    title={{t "general.collapse"}}
+                    type="button"
+                    data-test-collapse
+                    {{on "click" collapse}}
+                  >
+                    <FaIcon @icon="angles-up" />
+                  </button>
+                {{/if}}
               {{/if}}
             </TruncateText>
           {{/if}}

--- a/addon/components/truncate-text.hbs
+++ b/addon/components/truncate-text.hbs
@@ -1,5 +1,5 @@
 {{#if (has-block)}}
-  {{yield this.displayText this.expand this.isTruncated}}
+  {{yield this.displayText this.expand this.collapse this.isTruncated this.expanded}}
 {{else}}
   <span class="truncate-text" ...attributes>
     {{this.displayText}}
@@ -8,12 +8,26 @@
       <button
         class="expand-buttons"
         aria-label={{t "general.expand"}}
+        title={{t "general.expand"}}
         type="button"
         data-test-expand
         {{on "click" this.expand}}
       >
-        <FaIcon @icon="circle-info" />
+        <FaIcon @icon="angles-down" />
       </button>
+    {{else}}
+      {{#if this.expanded}}
+        <button
+          class="expand-buttons"
+          aria-label={{t "general.collapse"}}
+          title={{t "general.collapse"}}
+          type="button"
+          data-test-collapse
+          {{on "click" this.collapse}}
+        >
+          <FaIcon @icon="angles-up" />
+        </button>
+      {{/if}}
     {{/if}}
   </span>
 {{/if}}

--- a/addon/components/truncate-text.js
+++ b/addon/components/truncate-text.js
@@ -47,8 +47,14 @@ export default class TruncateTextComponent extends Component {
       return this.displayText.toString() !== this.cleanText;
     }
   }
+
   @action
   expand() {
     this.expanded = true;
+  }
+
+  @action
+  collapse() {
+    this.expanded = false;
   }
 }

--- a/config/icons.js
+++ b/config/icons.js
@@ -4,6 +4,7 @@ module.exports = function () {
     'free-solid-svg-icons': [
       'angles-down',
       'angles-left',
+      'angles-up',
       'arrow-down19',
       'arrow-down91',
       'arrow-down-a-z',

--- a/tests/integration/components/editable-field-test.js
+++ b/tests/integration/components/editable-field-test.js
@@ -116,4 +116,16 @@ module('Integration | Component | editable field', function (hooks) {
 
     assert.dom('textarea', this.element).isFocused();
   });
+
+  test('expand/collapse overlong text', async function (assert) {
+    const text = 't'.repeat(400);
+    const abbreviatedText = 't'.repeat(200);
+    this.set('value', text);
+    await render(hbs`<EditableField @value={{this.value}} />`);
+    assert.dom(this.element).hasText(abbreviatedText);
+    await click('[data-test-expand]');
+    assert.dom(this.element).hasText(text);
+    await click('[data-test-collapse]');
+    assert.dom(this.element).hasText(abbreviatedText);
+  });
 });

--- a/tests/integration/components/truncate-text-test.js
+++ b/tests/integration/components/truncate-text-test.js
@@ -144,7 +144,7 @@ module('Integration | Component | truncate-text', function (hooks) {
   test('it yields isTruncated when not truncated', async function (assert) {
     this.set('text', 'abc');
     await render(hbs`
-      <TruncateText @text={{this.text}} as |displayText expand isTruncated|>
+      <TruncateText @text={{this.text}} as |displayText expand collapse isTruncated expanded|>
         {{isTruncated}}
         <button {{on "click" expand}}>Expand</button>
       </TruncateText>
@@ -155,7 +155,7 @@ module('Integration | Component | truncate-text', function (hooks) {
   test('it yields isTruncated when truncated', async function (assert) {
     this.set('longText', 't'.repeat(400));
     await render(hbs`
-      <TruncateText @text={{this.longText}} as |displayText expand isTruncated|>
+      <TruncateText @text={{this.longText}} as |displayText expand collapse isTruncated expanded|>
         {{isTruncated}}
         <button {{on "click" expand}}>Expand</button>
       </TruncateText>
@@ -163,5 +163,15 @@ module('Integration | Component | truncate-text', function (hooks) {
     assert.dom(this.element).includesText('true');
     await click('button');
     assert.dom(this.element).includesText('false');
+  });
+
+  test('expand/collapse', async function (assert) {
+    this.set('longText', 't'.repeat(400));
+    await render(hbs`<TruncateText @text={{this.longText}} />`);
+    assert.strictEqual(this.element.textContent.trim(), 't'.repeat(200));
+    await click('[data-test-expand]');
+    assert.strictEqual(this.element.textContent.trim(), 't'.repeat(400));
+    await click('[data-test-collapse]');
+    assert.strictEqual(this.element.textContent.trim(), 't'.repeat(200));
   });
 });

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -46,6 +46,7 @@ general:
   cohort: Cohort
   cohorts: Cohorts
   cohortsManageTitle: "Manage Cohorts"
+  collapse: collapse
   collapseDetail: "Hide Details"
   competencies: Competencies
   completeSessions: "Sessions Complete: ready to publish"

--- a/translations/es.yaml
+++ b/translations/es.yaml
@@ -46,6 +46,7 @@ general:
   cohort: "Clase de la Graduación"
   cohorts: "Clases de la Graduación"
   cohortsManageTitle: "Administrar Clases de La Graduación"
+  collapse: colapsar
   collapseDetail: "Esconder Detalles"
   competencies: Competencias
   completeSessions: "Sesiónes Completas: Listo a Publicar"

--- a/translations/fr.yaml
+++ b/translations/fr.yaml
@@ -46,6 +46,7 @@ general:
   cohort: Cohorte
   cohorts: Cohortes
   cohortsManageTitle: "Manager des Cohortes"
+  collapse: réduire
   collapseDetail: "Masquer Détails"
   competencies: "Compétences"
   completeSessions: "Séances complète: prêt à publier"


### PR DESCRIPTION
fixes https://github.com/ilios/common/issues/2748

should also be tested with edit-in-place components that can receive "overlong" text, like the session description editor.