### PR TITLE
downgrade and pin ember-cli-dependency-checker to v3.2.0 due to issue with v3.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,7 @@
         "dotenv": "^16.0.0",
         "ember-a11y-testing": "^5.0.0",
         "ember-cli": "~3.28.1",
-        "ember-cli-dependency-checker": "^3.2.0",
+        "ember-cli-dependency-checker": "3.2.0",
         "ember-cli-dependency-lint": "^2.0.0",
         "ember-cli-deprecation-workflow": "^2.0.0",
         "ember-cli-inject-live-reload": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "dotenv": "^16.0.0",
     "ember-a11y-testing": "^5.0.0",
     "ember-cli": "~3.28.1",
-    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-checker": "3.2.0",
     "ember-cli-dependency-lint": "^2.0.0",
     "ember-cli-deprecation-workflow": "^2.0.0",
     "ember-cli-inject-live-reload": "^2.1.0",


### PR DESCRIPTION
see ticket number 132 in the dependency-checker issue queue.