### PR TITLE
converts paragraph to link.

### DIFF
--- a/addon/components/week-glance-event.hbs
+++ b/addon/components/week-glance-event.hbs
@@ -23,7 +23,7 @@
     </span>
   </h3>
   {{#if @event.prerequisites.length}}
-    <p class="pre-work" data-test-pre-work>
+    <div class="pre-work" data-test-pre-work>
       <strong>
         {{t "general.preWork"}}:
       </strong>
@@ -36,7 +36,7 @@
           </li>
         {{/each}}
       </ol>
-    </p>
+    </div>
   {{/if}}
   <p>
     <span class="sessiontype" data-test-session-type>


### PR DESCRIPTION
links in paragraph are styled as underlined, changing the container
gets rid of that.

fixes #2795 