### PR TITLE
Set a 9px minimum font size

### DIFF
--- a/app/styles/ilios-common/mixins/font-size.scss
+++ b/app/styles/ilios-common/mixins/font-size.scss
@@ -1,6 +1,6 @@
 /* stylelint-disable property-disallowed-list */
 :root {
-  --fs-smallest: 0.5rem;
+  --fs-smallest: max(0.5rem, 9px);
   --fs-small: 0.833rem;
   --fs-base: 1rem;
   --fs-medium: 1.2rem;


### PR DESCRIPTION
a11y rules require 9px to be the smallest size, our original step was
calculating to 8px, on most displays where we have a 16px body font
size. Using max ensures that we keep a minimum of 9px while allowing it
to grow at larger base size values.