### PR TITLE
Improve dashboard router transition

### DIFF
--- a/addon/routes/dashboard.js
+++ b/addon/routes/dashboard.js
@@ -5,6 +5,6 @@ export default class DashboardRoute extends Route {
   @service router;
 
   beforeModel() {
-    this.router.transitionTo('dashboard.week');
+    this.router.replaceWith('dashboard.week');
   }
 }


### PR DESCRIPTION
replaceWith changes to the new route without adding an entry in the
browser history, since this redirect happens without any interim content
it's the right API to use here.