### PR TITLE
Add pronouns to user model and component

### DIFF
--- a/addon-test-support/ilios-common/page-objects/components/user-name-info.js
+++ b/addon-test-support/ilios-common/page-objects/components/user-name-info.js
@@ -4,6 +4,8 @@ const definition = {
   scope: '[data-test-user-name-info]',
   fullName: text('[data-test-fullname]'),
   hasAdditionalInfo: isVisible('[data-test-info]'),
+  hasPronouns: isVisible('[data-test-pronouns]'),
+  pronouns: text('[data-test-pronouns]'),
   infoIconLabel: attribute('aria-label', '[data-test-info] svg'),
   id: attribute('id'),
   expandTooltip: triggerable('mouseover', '[data-test-info] .info'),

--- a/addon/components/user-name-info.hbs
+++ b/addon/components/user-name-info.hbs
@@ -1,12 +1,13 @@
 <span
   class="user-name-info"
   data-test-user-name-info
-  {{did-insert this.load}}
-  {{did-update this.load @user}}
   ...attributes
 >
-  <span data-test-fullname>{{this.fullName}}</span>
-  {{#if this.hasDifferentCampusNameOfRecord}}
+  <span data-test-fullname>{{@user.fullName}}</span>
+  {{#if @user.pronouns}}
+    <span data-test-pronouns>({{@user.pronouns}})</span>
+  {{/if}}
+  {{#if @user.hasDifferentDisplayName}}
     <span
       data-test-info
       {{did-insert (set this.theElement)}}
@@ -20,7 +21,7 @@
       {{#if this.isHoveringOverUsernameInfo}}
         <IliosTooltip @target={{this.theElement}}>
           <strong>{{t "general.campusNameOfRecord"}}:</strong>
-          {{this.campusNameOfRecord}}
+          {{@user.fullNameFromFirstMiddleLastName}}
         </IliosTooltip>
       {{/if}}
     </span>

--- a/addon/components/user-name-info.js
+++ b/addon/components/user-name-info.js
@@ -4,19 +4,7 @@ import { action } from '@ember/object';
 
 export default class UserNameInfoComponent extends Component {
   @tracked isHoveringOverUsernameInfo = false;
-  @tracked fullName;
-  @tracked campusNameOfRecord;
-  @tracked hasDifferentCampusNameOfRecord = false;
-
-  @action
-  load() {
-    if (!this.args.user) {
-      return false;
-    }
-    this.fullName = this.args.user.get('fullName');
-    this.hasDifferentCampusNameOfRecord = this.args.user.get('hasDifferentDisplayName');
-    this.campusNameOfRecord = this.args.user.get('fullNameFromFirstMiddleLastName');
-  }
+  @tracked element;
 
   @action
   toggleUsernameInfoHover(isHovering) {

--- a/addon/models/user.js
+++ b/addon/models/user.js
@@ -18,6 +18,9 @@ export default class User extends Model {
   displayName;
 
   @attr('string')
+  pronouns;
+
+  @attr('string')
   phone;
 
   @attr('string')

--- a/config/api-version.js
+++ b/config/api-version.js
@@ -1,3 +1,3 @@
 /* eslint-env node */
 
-module.exports = 'v3.5';
+module.exports = 'v3.6';

--- a/tests/integration/components/user-name-info-test.js
+++ b/tests/integration/components/user-name-info-test.js
@@ -17,6 +17,7 @@ module('Integration | Component | user-name-info', function (hooks) {
     this.set('user', userModel);
     await render(hbs`<UserNameInfo @user={{this.user}} />`);
     assert.notOk(component.hasAdditionalInfo);
+    assert.notOk(component.hasPronouns);
     assert.strictEqual(component.fullName, '0 guy M. Mc0son');
   });
 
@@ -42,5 +43,17 @@ module('Integration | Component | user-name-info', function (hooks) {
     this.set('user', userModel);
     await render(hbs`<UserNameInfo id="test-id" @user={{this.user}} />`);
     assert.strictEqual(component.id, 'test-id');
+  });
+
+  test('pronouns display if present', async function (assert) {
+    const user = this.server.create('user', {
+      pronouns: 'they/them/tay',
+    });
+    const userModel = await this.owner.lookup('service:store').find('user', user.id);
+    this.set('user', userModel);
+    await render(hbs`<UserNameInfo @user={{this.user}} />`);
+    assert.ok(component.hasPronouns);
+    assert.strictEqual(component.fullName, '0 guy M. Mc0son');
+    assert.strictEqual(component.pronouns, '(they/them/tay)');
   });
 });


### PR DESCRIPTION
Pronouns will be available in the API and should be reflected in both
the user model and the component we use to display detailed name
information.

Refs ilios/ilios#4020