### PR TITLE
Don't push <title> in the build

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,12 +119,8 @@ module.exports = {
       const links = fonts.map((font) => {
         return `<link rel="preload" href="${rootUrl}/assets/fonts/${font}" as="font" type="font/woff2" crossorigin="anonymous">`;
       });
-      const linkText = links.join('\n');
 
-      return `
-        <title>Ilios</title>
-        ${linkText}
-      `;
+      return links.join('\n');
     }
   },
 };

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Ilios</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/tests/index.html
+++ b/tests/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Ilios</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 


### PR DESCRIPTION
This is included in the ember blueprints now for index.html and pushing
our own title into the app causes issues with ember page title.

Also got rid of the old IE compatible tag as this was a lie! We don't support IE 😀 