### PR TITLE
MeSH search refactoring.

### DIFF
--- a/addon-test-support/ilios-common/page-objects/components/mesh-manager.js
+++ b/addon-test-support/ilios-common/page-objects/components/mesh-manager.js
@@ -1,13 +1,17 @@
 import {
+  attribute,
   clickable,
   collection,
   create,
+  fillable,
   hasClass,
   isVisible,
   notHasClass,
   text,
+  triggerable,
+  value,
 } from 'ember-cli-page-object';
-import search from './search-box';
+import { hasFocus } from 'ilios-common';
 
 const definition = {
   scope: '.mesh-manager',
@@ -15,7 +19,15 @@ const definition = {
     title: text('.term-title'),
     remove: clickable('button'),
   }),
-  search,
+  search: {
+    scope: '[data-test-mesh-search]',
+    label: text('label'),
+    set: fillable('input'),
+    value: value('input'),
+    inputHasFocus: hasFocus('input'),
+    placeholder: attribute('placeholder', 'input'),
+    esc: triggerable('keyup', 'input', { eventProperties: { key: 'Escape' } }),
+  },
   searchResults: collection('[data-test-search-results] [data-test-search-result]', {
     title: text('.descriptor-name'),
     isDisabled: hasClass('disabled'),

--- a/addon/components/mesh-manager.hbs
+++ b/addon/components/mesh-manager.hbs
@@ -2,118 +2,132 @@
   class="mesh-manager"
   data-test-mesh-manager
 >
-  {{#if @targetItemTitle}}
-    <h2>
-      {{t "general.selectMeshFor" title=@targetItemTitle}}
-    </h2>
-  {{/if}}
-  <ul class="selected-terms">
-    {{#each this.sortedTerms as |term|}}
-      <li>
-        {{#if @editable}}
-          <button
-            type="button"
-            {{on "click" (fn @remove term)}}
-          >
+  {{#let (unique-id) as |templateId|}}
+    {{#if @targetItemTitle}}
+      <h2>
+        {{t "general.selectMeshFor" title=@targetItemTitle}}
+      </h2>
+    {{/if}}
+    <ul class="selected-terms">
+      {{#each this.sortedTerms as |term|}}
+        <li>
+          {{#if @editable}}
+            <button
+              type="button"
+              {{on "click" (fn @remove term)}}
+            >
+              <span class="term-title">
+                {{term.name}}
+              </span>
+              <span class="term-details">
+                {{term.id}}
+                {{#if term.deleted}}
+                  - <span class="deprecated">({{t "general.deprecatedAbbreviation"}})</span>
+                {{else if term.trees}}
+                  - {{term.trees.lastObject.treeNumber}}
+                {{/if}}
+              </span>
+              <FaIcon @icon="xmark" class="remove" />
+            </button>
+          {{else}}
             <span class="term-title">
               {{term.name}}
             </span>
             <span class="term-details">
-              {{term.id}}
+            {{term.id}}
               {{#if term.deleted}}
                 - <span class="deprecated">({{t "general.deprecatedAbbreviation"}})</span>
               {{else if term.trees}}
                 - {{term.trees.lastObject.treeNumber}}
               {{/if}}
             </span>
-            <FaIcon @icon="xmark" class="remove" />
-          </button>
-        {{else}}
-          <span class="term-title">
-            {{term.name}}
-          </span>
-          <span class="term-details">
-          {{term.id}}
-            {{#if term.deleted}}
-              - <span class="deprecated">({{t "general.deprecatedAbbreviation"}})</span>
-            {{else if term.trees}}
-              - {{term.trees.lastObject.treeNumber}}
-            {{/if}}
-          </span>
-        {{/if}}
-      </li>
-    {{/each}}
-  </ul>
-  {{#if @editable}}
-    <SearchBox
-      placeholder={{t "general.meshSearchPlaceholder"}}
-      @liveSearch={{false}}
-      @search={{perform this.search}}
-      @clear={{this.clear}}
-    />
-  {{/if}}
-  {{#if this.search.isRunning}}
-    <ul class="results">
-      <li>
-        {{t "general.currentlySearchingPrompt"}}
-      </li>
-    </ul>
-  {{else if this.searchResults.length}}
-    <ul class="mesh-search-results" data-test-search-results>
-      {{#each this.searchResults as |term|}}
-        <li
-          class={{if (includes term.id (map-by "id" this.terms)) "disabled"}}
-          data-test-search-result
-        >
-          <button
-            type="button"
-            {{on "click" (fn this.add term)}}
-          >
-            <span class="descriptor-name" data-test-name>
-              {{term.name}}
-            </span>
-            <span class="descriptor-id">
-              {{term.id}}
-              {{#if term.trees}}
-                -{{term.trees.lastObject.treeNumber}}
-              {{/if}}
-            </span>
-            <ul class="mesh-concepts">
-              {{#each term.concepts as |concept|}}
-                {{#if concept.scopeNote}}
-                  <li
-                    class="{{unless term.isActive "disabled"}}
-
-                      {{if concept.hasTruncatedScopeNote "truncated"}}"
-                  >
-                    {{concept.truncatedScopeNote}}
-                  </li>
-                {{/if}}
-              {{/each}}
-            </ul>
-          </button>
+          {{/if}}
         </li>
       {{/each}}
     </ul>
-    {{#if this.hasMoreSearchResults}}
-      <button
-        disabled={{if this.searchMore.isRunning true}}
-        type="button"
-        {{on "click" (perform this.searchMore)}}
-        data-test-show-more
-      >
-        <FaIcon
-          @icon={{if this.searchMore.isRunning "spinner"}}
-          @spin={{if this.searchMore.isRunning true false}}
-        />
-        {{t "general.showMore"}}
-      </button>
+    {{#if @editable}}
+      <div class="mesh-search" data-test-mesh-search>
+        <label for="mesh-search-{{templateId}}">{{t "general.searchMesh"}}:</label>
+        <input
+          id="mesh-search-{{templateId}}"
+          autocomplete="off"
+          class="search-input"
+          type="search"
+          value={{this.query}}
+          placeholder={{t "general.search"}}
+          {{on "input" this.update}}
+          {{on "keyup" this.keyUp}}
+          {{did-insert (set this.searchInput)}}
+        >
+      </div>
     {{/if}}
-  {{else if this.search.lastSuccessful}}
-    <ul class="results">
-      <li>
-        {{t "general.noSearchResultsPrompt"}}
-      </li>
-    </ul>
-  {{/if}}
+    <div {{on-click-outside this.clear}} data-test-search-results-container>
+      {{#if this.search.isRunning}}
+        <ul class="mesh-search-results">
+          <li>
+            {{t "general.currentlySearchingPrompt"}}
+          </li>
+        </ul>
+      {{else if this.searchResults.length}}
+        <ul class="mesh-search-results"
+            data-test-search-results
+        >
+          {{#each this.searchResults as |term|}}
+            <li
+              class={{if (includes term.id (map-by "id" this.terms)) "disabled"}}
+              data-test-search-result
+            >
+              <button
+                type="button"
+                {{on "click" (fn this.add term)}}
+              >
+                <span class="descriptor-name" data-test-name>
+                  {{term.name}}
+                </span>
+                <span class="descriptor-id">
+                  {{term.id}}
+                  {{#if term.trees}}
+                    -{{term.trees.lastObject.treeNumber}}
+                  {{/if}}
+                </span>
+                <ul class="mesh-concepts">
+                  {{#each term.concepts as |concept|}}
+                    {{#if concept.scopeNote}}
+                      <li
+                        class="{{unless term.isActive "disabled"}}
+
+                          {{if concept.hasTruncatedScopeNote "truncated"}}"
+                      >
+                        {{concept.truncatedScopeNote}}
+                      </li>
+                    {{/if}}
+                  {{/each}}
+                </ul>
+              </button>
+            </li>
+          {{/each}}
+        </ul>
+        {{#if this.hasMoreSearchResults}}
+          <button
+            disabled={{if this.searchMore.isRunning true}}
+            type="button"
+            {{on "click" (perform this.searchMore)}}
+            data-test-show-more
+          >
+            <FaIcon
+              @icon={{if this.searchMore.isRunning "spinner"}}
+              @spin={{if this.searchMore.isRunning true false}}
+            />
+            {{t "general.showMore"}}
+          </button>
+        {{/if}}
+      {{else if (and this.hasSearchQuery this.search.lastSuccessful)}}
+        <ul class="mesh-search-results">
+          <li>
+            {{t "general.noSearchResultsPrompt"}}
+          </li>
+        </ul>
+      {{/if}}
+    </div>
+  {{/let}}
 </section>

--- a/addon/components/mesh-manager.hbs
+++ b/addon/components/mesh-manager.hbs
@@ -68,10 +68,14 @@
             {{t "general.currentlySearchingPrompt"}}
           </li>
         </ul>
+      {{else if (and this.hasSearchQuery (lte this.query.length 2))}}
+        <ul class="mesh-search-results" data-test-search-results>
+          <li data-test-search-result>
+            {{t "general.moreInputRequiredPrompt"}}
+          </li>
+        </ul>
       {{else if this.searchResults.length}}
-        <ul class="mesh-search-results"
-            data-test-search-results
-        >
+        <ul class="mesh-search-results" data-test-search-results>
           {{#each this.searchResults as |term|}}
             <li
               class={{if (includes term.id (map-by "id" this.terms)) "disabled"}}
@@ -121,9 +125,9 @@
             {{t "general.showMore"}}
           </button>
         {{/if}}
-      {{else if (and this.hasSearchQuery this.search.lastSuccessful)}}
-        <ul class="mesh-search-results">
-          <li>
+     {{else if (and this.hasSearchQuery this.search.lastSuccessful)}}
+        <ul class="mesh-search-results" data-test-search-results>
+          <li data-test-search-result>
             {{t "general.noSearchResultsPrompt"}}
           </li>
         </ul>

--- a/addon/components/mesh-manager.js
+++ b/addon/components/mesh-manager.js
@@ -1,9 +1,10 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import { dropTask, restartableTask } from 'ember-concurrency';
+import { dropTask, restartableTask, timeout } from 'ember-concurrency';
 import { action } from '@ember/object';
 
+const DEBOUNCE_TIMEOUT = 250;
 const SEARCH_RESULTS_PER_PAGE = 50;
 
 export default class MeshManagerComponent extends Component {
@@ -13,9 +14,14 @@ export default class MeshManagerComponent extends Component {
   @tracked searchResults = [];
   @tracked searchPage = 0;
   @tracked hasMoreSearchResults = false;
+  @tracked searchInput;
 
   get terms() {
     return this.args.terms ?? [];
+  }
+
+  get hasSearchQuery() {
+    return this.query.trim() !== '';
   }
 
   get sortedTerms() {
@@ -24,17 +30,54 @@ export default class MeshManagerComponent extends Component {
     }
     return this.args.terms.sortBy('name');
   }
-  @restartableTask
-  *search(query) {
-    this.searching = true;
-    this.query = query;
 
+  @action
+  clear() {
+    this.searchResults = [];
+    this.searchPage = 0;
+    this.hasMoreSearchResults = false;
+    this.query = '';
+  }
+
+  @action
+  add(term) {
+    if (!this.args.editable) {
+      return;
+    }
+
+    if (this.terms.mapBy('id').includes(term.id)) {
+      return;
+    }
+    this.args.add(term);
+  }
+
+  @action
+  keyUp({ key }) {
+    if ('Escape' === key) {
+      this.clear();
+    }
+  }
+
+  @action
+  update(event) {
+    this.query = event.target.value;
+    this.search.perform();
+  }
+
+  @action
+  moveFocus() {
+    // place focus into the search box when search icon is clicked
+    this?.searchInput.focus();
+  }
+
+  @restartableTask
+  *search() {
+    yield timeout(DEBOUNCE_TIMEOUT);
     const descriptors = (yield this.store.query('mesh-descriptor', {
-      q: query,
+      q: this.query,
       limit: SEARCH_RESULTS_PER_PAGE + 1,
     })).toArray();
 
-    this.searching = false;
     this.searchPage = 1;
     this.hasMoreSearchResults = descriptors.length > SEARCH_RESULTS_PER_PAGE;
     if (this.hasMoreSearchResults) {
@@ -56,26 +99,5 @@ export default class MeshManagerComponent extends Component {
       descriptors.pop();
     }
     this.searchResults = [...this.searchResults, ...descriptors];
-  }
-
-  @action
-  clear() {
-    this.searchResults = [];
-    this.searching = false;
-    this.searchPage = 0;
-    this.hasMoreSearchResults = false;
-    this.query = '';
-  }
-
-  @action
-  add(term) {
-    if (!this.args.editable) {
-      return;
-    }
-
-    if (this.terms.mapBy('id').includes(term.id)) {
-      return;
-    }
-    this.args.add(term);
   }
 }

--- a/addon/components/mesh-manager.js
+++ b/addon/components/mesh-manager.js
@@ -5,6 +5,7 @@ import { dropTask, restartableTask, timeout } from 'ember-concurrency';
 import { action } from '@ember/object';
 
 const DEBOUNCE_TIMEOUT = 250;
+const MIN_INPUT = 3;
 const SEARCH_RESULTS_PER_PAGE = 50;
 
 export default class MeshManagerComponent extends Component {
@@ -72,6 +73,10 @@ export default class MeshManagerComponent extends Component {
 
   @restartableTask
   *search() {
+    if (this.query.length < MIN_INPUT) {
+      this.searchResults = [];
+      return; // don't linger around return right away
+    }
     yield timeout(DEBOUNCE_TIMEOUT);
     const descriptors = (yield this.store.query('mesh-descriptor', {
       q: this.query,

--- a/app/styles/ilios-common/components/mesh-manager.scss
+++ b/app/styles/ilios-common/components/mesh-manager.scss
@@ -1,4 +1,5 @@
 .mesh-manager {
+
   .deprecated {
     color: $ilios-red;
     font-weight: bolder;
@@ -66,6 +67,16 @@
 
     .term-details {
       font-style: italic;
+    }
+  }
+
+  .mesh-search {
+    input[type='search'] {
+      @include ilios-input;
+    }
+
+    label {
+      @include ilios-label;
     }
   }
 }

--- a/tests/acceptance/course/learningmaterials-test.js
+++ b/tests/acceptance/course/learningmaterials-test.js
@@ -496,7 +496,6 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
         'descriptor 2'
       );
       await page.details.learningMaterials.manager.meshManager.search.set('descriptor');
-      await page.details.learningMaterials.manager.meshManager.search.submit();
       assert.strictEqual(
         page.details.learningMaterials.manager.meshManager.searchResults.length,
         6
@@ -513,22 +512,22 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
       assert.notOk(page.details.learningMaterials.manager.meshManager.searchResults[3].isDisabled);
       assert.notOk(page.details.learningMaterials.manager.meshManager.searchResults[4].isDisabled);
       assert.notOk(page.details.learningMaterials.manager.meshManager.searchResults[5].isDisabled);
-
-      await page.details.learningMaterials.manager.meshManager.selectedTerms[0].remove();
       await page.details.learningMaterials.manager.meshManager.searchResults[0].add();
       assert.ok(page.details.learningMaterials.manager.meshManager.searchResults[0].isDisabled);
-      assert.notOk(page.details.learningMaterials.manager.meshManager.searchResults[1].isDisabled);
       assert.strictEqual(
         page.details.learningMaterials.manager.meshManager.selectedTerms.length,
-        2
+        3
       );
-
       assert.strictEqual(
         page.details.learningMaterials.manager.meshManager.selectedTerms[0].title,
         'descriptor 0'
       );
       assert.strictEqual(
         page.details.learningMaterials.manager.meshManager.selectedTerms[1].title,
+        'descriptor 1'
+      );
+      assert.strictEqual(
+        page.details.learningMaterials.manager.meshManager.selectedTerms[2].title,
         'descriptor 2'
       );
     });
@@ -543,11 +542,9 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
         page.details.learningMaterials.manager.meshManager.selectedTerms.length,
         2
       );
-      await page.details.learningMaterials.manager.meshManager.search.set('descriptor');
-      await page.details.learningMaterials.manager.meshManager.search.submit();
       await page.details.learningMaterials.manager.meshManager.selectedTerms[0].remove();
+      await page.details.learningMaterials.manager.meshManager.search.set('descriptor');
       await page.details.learningMaterials.manager.meshManager.searchResults[0].add();
-
       assert.strictEqual(
         page.details.learningMaterials.manager.meshManager.selectedTerms[0].title,
         'descriptor 0'
@@ -556,7 +553,6 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
         page.details.learningMaterials.manager.meshManager.selectedTerms[1].title,
         'descriptor 2'
       );
-
       await page.details.learningMaterials.manager.save();
       assert.strictEqual(
         page.details.learningMaterials.current[0].mesh,
@@ -574,11 +570,9 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
         page.details.learningMaterials.manager.meshManager.selectedTerms.length,
         2
       );
-      await page.details.learningMaterials.manager.meshManager.search.set('descriptor');
-      await page.details.learningMaterials.manager.meshManager.search.submit();
       await page.details.learningMaterials.manager.meshManager.selectedTerms[0].remove();
+      await page.details.learningMaterials.manager.meshManager.search.set('descriptor');
       await page.details.learningMaterials.manager.meshManager.searchResults[0].add();
-
       assert.strictEqual(
         page.details.learningMaterials.manager.meshManager.selectedTerms[0].title,
         'descriptor 0'
@@ -587,7 +581,6 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
         page.details.learningMaterials.manager.meshManager.selectedTerms[1].title,
         'descriptor 2'
       );
-
       await page.details.learningMaterials.manager.cancel();
       assert.strictEqual(
         page.details.learningMaterials.current[0].mesh,

--- a/tests/acceptance/course/mesh-test.js
+++ b/tests/acceptance/course/mesh-test.js
@@ -55,7 +55,6 @@ module('Acceptance | Course - Mesh Terms', function (hooks) {
     assert.strictEqual(page.details.meshTerms.meshManager.selectedTerms[1].title, 'descriptor 1');
     assert.strictEqual(page.details.meshTerms.meshManager.selectedTerms[2].title, 'descriptor 2');
     await page.details.meshTerms.meshManager.search.set('descriptor');
-    await page.details.meshTerms.meshManager.search.submit();
     assert.strictEqual(page.details.meshTerms.meshManager.searchResults.length, 6);
     for (let i = 0; i < 6; i++) {
       assert.strictEqual(
@@ -69,16 +68,13 @@ module('Acceptance | Course - Mesh Terms', function (hooks) {
     assert.ok(page.details.meshTerms.meshManager.searchResults[3].isEnabled);
     assert.ok(page.details.meshTerms.meshManager.searchResults[4].isEnabled);
     assert.ok(page.details.meshTerms.meshManager.searchResults[5].isEnabled);
-
-    await page.details.meshTerms.meshManager.selectedTerms[0].remove();
     await page.details.meshTerms.meshManager.searchResults[3].add();
     assert.ok(page.details.meshTerms.meshManager.searchResults[3].isDisabled);
-    assert.ok(page.details.meshTerms.meshManager.searchResults[0].isEnabled);
-    assert.strictEqual(page.details.meshTerms.meshManager.selectedTerms.length, 3);
-
-    assert.strictEqual(page.details.meshTerms.meshManager.selectedTerms[0].title, 'descriptor 1');
-    assert.strictEqual(page.details.meshTerms.meshManager.selectedTerms[1].title, 'descriptor 2');
-    assert.strictEqual(page.details.meshTerms.meshManager.selectedTerms[2].title, 'descriptor 3');
+    assert.strictEqual(page.details.meshTerms.meshManager.selectedTerms.length, 4);
+    assert.strictEqual(page.details.meshTerms.meshManager.selectedTerms[0].title, 'descriptor 0');
+    assert.strictEqual(page.details.meshTerms.meshManager.selectedTerms[1].title, 'descriptor 1');
+    assert.strictEqual(page.details.meshTerms.meshManager.selectedTerms[2].title, 'descriptor 2');
+    assert.strictEqual(page.details.meshTerms.meshManager.selectedTerms[3].title, 'descriptor 3');
   });
 
   test('save terms', async function (assert) {
@@ -89,10 +85,8 @@ module('Acceptance | Course - Mesh Terms', function (hooks) {
     await page.details.meshTerms.manage();
 
     assert.strictEqual(page.details.meshTerms.meshManager.selectedTerms.length, 3);
-    await page.details.meshTerms.meshManager.search.set('descriptor');
-    await page.details.meshTerms.meshManager.search.submit();
-
     await page.details.meshTerms.meshManager.selectedTerms[0].remove();
+    await page.details.meshTerms.meshManager.search.set('descriptor');
     await page.details.meshTerms.meshManager.searchResults[3].add();
 
     assert.strictEqual(page.details.meshTerms.meshManager.selectedTerms[0].title, 'descriptor 1');
@@ -118,9 +112,8 @@ module('Acceptance | Course - Mesh Terms', function (hooks) {
     await page.details.meshTerms.manage();
     assert.strictEqual(page.details.meshTerms.meshManager.selectedTerms.length, 3);
 
-    await page.details.meshTerms.meshManager.search.set('descriptor');
-    await page.details.meshTerms.meshManager.search.submit();
     await page.details.meshTerms.meshManager.selectedTerms[0].remove();
+    await page.details.meshTerms.meshManager.search.set('descriptor');
     await page.details.meshTerms.meshManager.searchResults[3].add();
 
     assert.strictEqual(page.details.meshTerms.meshManager.selectedTerms[0].title, 'descriptor 1');

--- a/tests/acceptance/course/objectivemesh-test.js
+++ b/tests/acceptance/course/objectivemesh-test.js
@@ -86,21 +86,20 @@ module('Acceptance | Course - Objective Mesh Descriptors', function (hooks) {
     assert.strictEqual(m.selectedTerms[2].title, 'descriptor 3');
     assert.strictEqual(m.selectedTerms[3].title, 'descriptor 4');
     assert.strictEqual(m.selectedTerms[4].title, 'descriptor 5');
+    await m.selectedTerms[0].remove();
     await m.search.set('descriptor');
-    await m.search.submit();
 
     assert.strictEqual(m.searchResults.length, 6);
     for (let i = 0; i < 6; i++) {
       assert.strictEqual(m.searchResults[i].title, `descriptor ${i}`);
     }
     assert.ok(m.searchResults[0].isEnabled);
-    assert.ok(m.searchResults[1].isDisabled);
+    assert.ok(m.searchResults[1].isEnabled);
     assert.ok(m.searchResults[2].isDisabled);
     assert.ok(m.searchResults[3].isDisabled);
     assert.ok(m.searchResults[4].isDisabled);
     assert.ok(m.searchResults[5].isDisabled);
 
-    await m.selectedTerms[0].remove();
     await m.searchResults[0].add();
     assert.ok(m.searchResults[0].isDisabled);
     assert.ok(m.searchResults[1].isEnabled);
@@ -134,10 +133,9 @@ module('Acceptance | Course - Objective Mesh Descriptors', function (hooks) {
 
     const m = page.details.objectives.objectiveList.objectives[1].meshManager.meshManager;
     assert.strictEqual(m.selectedTerms.length, 5);
-    await m.search.set('descriptor');
-    await m.search.submit();
 
     await m.selectedTerms[0].remove();
+    await m.search.set('descriptor');
     await m.searchResults[0].add();
 
     assert.strictEqual(m.selectedTerms.length, 5);
@@ -195,10 +193,9 @@ module('Acceptance | Course - Objective Mesh Descriptors', function (hooks) {
 
     const m = page.details.objectives.objectiveList.objectives[1].meshManager.meshManager;
     assert.strictEqual(m.selectedTerms.length, 5);
-    await m.search.set('descriptor');
-    await m.search.submit();
 
     await m.selectedTerms[0].remove();
+    await m.search.set('descriptor');
     await m.searchResults[0].add();
 
     assert.strictEqual(m.selectedTerms.length, 5);

--- a/tests/acceptance/course/session/learningmaterials-test.js
+++ b/tests/acceptance/course/session/learningmaterials-test.js
@@ -493,7 +493,6 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
         'descriptor 2'
       );
       await page.details.learningMaterials.manager.meshManager.search.set('descriptor');
-      await page.details.learningMaterials.manager.meshManager.search.submit();
       assert.strictEqual(
         page.details.learningMaterials.manager.meshManager.searchResults.length,
         6
@@ -510,22 +509,22 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
       assert.notOk(page.details.learningMaterials.manager.meshManager.searchResults[3].isDisabled);
       assert.notOk(page.details.learningMaterials.manager.meshManager.searchResults[4].isDisabled);
       assert.notOk(page.details.learningMaterials.manager.meshManager.searchResults[5].isDisabled);
-
-      await page.details.learningMaterials.manager.meshManager.selectedTerms[0].remove();
       await page.details.learningMaterials.manager.meshManager.searchResults[0].add();
       assert.ok(page.details.learningMaterials.manager.meshManager.searchResults[0].isDisabled);
-      assert.notOk(page.details.learningMaterials.manager.meshManager.searchResults[1].isDisabled);
       assert.strictEqual(
         page.details.learningMaterials.manager.meshManager.selectedTerms.length,
-        2
+        3
       );
-
       assert.strictEqual(
         page.details.learningMaterials.manager.meshManager.selectedTerms[0].title,
         'descriptor 0'
       );
       assert.strictEqual(
         page.details.learningMaterials.manager.meshManager.selectedTerms[1].title,
+        'descriptor 1'
+      );
+      assert.strictEqual(
+        page.details.learningMaterials.manager.meshManager.selectedTerms[2].title,
         'descriptor 2'
       );
     });
@@ -540,9 +539,8 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
         page.details.learningMaterials.manager.meshManager.selectedTerms.length,
         2
       );
-      await page.details.learningMaterials.manager.meshManager.search.set('descriptor');
-      await page.details.learningMaterials.manager.meshManager.search.submit();
       await page.details.learningMaterials.manager.meshManager.selectedTerms[0].remove();
+      await page.details.learningMaterials.manager.meshManager.search.set('descriptor');
       await page.details.learningMaterials.manager.meshManager.searchResults[0].add();
 
       assert.strictEqual(
@@ -571,9 +569,8 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
         page.details.learningMaterials.manager.meshManager.selectedTerms.length,
         2
       );
-      await page.details.learningMaterials.manager.meshManager.search.set('descriptor');
-      await page.details.learningMaterials.manager.meshManager.search.submit();
       await page.details.learningMaterials.manager.meshManager.selectedTerms[0].remove();
+      await page.details.learningMaterials.manager.meshManager.search.set('descriptor');
       await page.details.learningMaterials.manager.meshManager.searchResults[0].add();
 
       assert.strictEqual(

--- a/tests/acceptance/course/session/mesh-test.js
+++ b/tests/acceptance/course/session/mesh-test.js
@@ -58,7 +58,6 @@ module('Acceptance | Session - Mesh Terms', function (hooks) {
     assert.strictEqual(page.details.meshTerms.meshManager.selectedTerms[1].title, 'descriptor 1');
     assert.strictEqual(page.details.meshTerms.meshManager.selectedTerms[2].title, 'descriptor 2');
     await page.details.meshTerms.meshManager.search.set('descriptor');
-    await page.details.meshTerms.meshManager.search.submit();
     assert.strictEqual(page.details.meshTerms.meshManager.searchResults.length, 6);
     for (let i = 0; i < 6; i++) {
       assert.strictEqual(
@@ -72,16 +71,13 @@ module('Acceptance | Session - Mesh Terms', function (hooks) {
     assert.ok(page.details.meshTerms.meshManager.searchResults[3].isEnabled);
     assert.ok(page.details.meshTerms.meshManager.searchResults[4].isEnabled);
     assert.ok(page.details.meshTerms.meshManager.searchResults[5].isEnabled);
-
-    await page.details.meshTerms.meshManager.selectedTerms[0].remove();
     await page.details.meshTerms.meshManager.searchResults[3].add();
     assert.ok(page.details.meshTerms.meshManager.searchResults[3].isDisabled);
-    assert.ok(page.details.meshTerms.meshManager.searchResults[0].isEnabled);
-    assert.strictEqual(page.details.meshTerms.meshManager.selectedTerms.length, 3);
-
-    assert.strictEqual(page.details.meshTerms.meshManager.selectedTerms[0].title, 'descriptor 1');
-    assert.strictEqual(page.details.meshTerms.meshManager.selectedTerms[1].title, 'descriptor 2');
-    assert.strictEqual(page.details.meshTerms.meshManager.selectedTerms[2].title, 'descriptor 3');
+    assert.strictEqual(page.details.meshTerms.meshManager.selectedTerms.length, 4);
+    assert.strictEqual(page.details.meshTerms.meshManager.selectedTerms[0].title, 'descriptor 0');
+    assert.strictEqual(page.details.meshTerms.meshManager.selectedTerms[1].title, 'descriptor 1');
+    assert.strictEqual(page.details.meshTerms.meshManager.selectedTerms[2].title, 'descriptor 2');
+    assert.strictEqual(page.details.meshTerms.meshManager.selectedTerms[3].title, 'descriptor 3');
   });
 
   test('save terms', async function (assert) {
@@ -92,9 +88,8 @@ module('Acceptance | Session - Mesh Terms', function (hooks) {
     await page.details.meshTerms.manage();
 
     assert.strictEqual(page.details.meshTerms.meshManager.selectedTerms.length, 3);
-    await page.details.meshTerms.meshManager.search.set('descriptor');
-    await page.details.meshTerms.meshManager.search.submit();
     await page.details.meshTerms.meshManager.selectedTerms[0].remove();
+    await page.details.meshTerms.meshManager.search.set('descriptor');
     await page.details.meshTerms.meshManager.searchResults[3].add();
 
     assert.strictEqual(page.details.meshTerms.meshManager.selectedTerms[0].title, 'descriptor 1');
@@ -120,9 +115,8 @@ module('Acceptance | Session - Mesh Terms', function (hooks) {
     await page.details.meshTerms.manage();
     assert.strictEqual(page.details.meshTerms.meshManager.selectedTerms.length, 3);
 
-    await page.details.meshTerms.meshManager.search.set('descriptor');
-    await page.details.meshTerms.meshManager.search.submit();
     await page.details.meshTerms.meshManager.selectedTerms[0].remove();
+    await page.details.meshTerms.meshManager.search.set('descriptor');
     await page.details.meshTerms.meshManager.searchResults[3].add();
 
     assert.strictEqual(page.details.meshTerms.meshManager.selectedTerms[0].title, 'descriptor 1');

--- a/tests/acceptance/course/session/objectivemesh-test.js
+++ b/tests/acceptance/course/session/objectivemesh-test.js
@@ -82,21 +82,20 @@ module('Acceptance | Session - Objective Mesh Descriptors', function (hooks) {
     assert.strictEqual(m.selectedTerms[2].title, 'descriptor 3');
     assert.strictEqual(m.selectedTerms[3].title, 'descriptor 4');
     assert.strictEqual(m.selectedTerms[4].title, 'descriptor 5');
+    await m.selectedTerms[0].remove();
     await m.search.set('descriptor');
-    await m.search.submit();
 
     assert.strictEqual(m.searchResults.length, 6);
     for (let i = 0; i < 6; i++) {
       assert.strictEqual(m.searchResults[i].title, `descriptor ${i}`);
     }
     assert.ok(m.searchResults[0].isEnabled);
-    assert.ok(m.searchResults[1].isDisabled);
+    assert.ok(m.searchResults[1].isEnabled);
     assert.ok(m.searchResults[2].isDisabled);
     assert.ok(m.searchResults[3].isDisabled);
     assert.ok(m.searchResults[4].isDisabled);
     assert.ok(m.searchResults[5].isDisabled);
 
-    await m.selectedTerms[0].remove();
     await m.searchResults[0].add();
     assert.ok(m.searchResults[0].isDisabled);
     assert.ok(m.searchResults[1].isEnabled);
@@ -130,10 +129,9 @@ module('Acceptance | Session - Objective Mesh Descriptors', function (hooks) {
 
     const m = page.details.objectives.objectiveList.objectives[1].meshManager.meshManager;
     assert.strictEqual(m.selectedTerms.length, 5);
-    await m.search.set('descriptor');
-    await m.search.submit();
 
     await m.selectedTerms[0].remove();
+    await m.search.set('descriptor');
     await m.searchResults[0].add();
 
     assert.strictEqual(m.selectedTerms.length, 5);
@@ -191,10 +189,9 @@ module('Acceptance | Session - Objective Mesh Descriptors', function (hooks) {
 
     const m = page.details.objectives.objectiveList.objectives[1].meshManager.meshManager;
     assert.strictEqual(m.selectedTerms.length, 5);
-    await m.search.set('descriptor');
-    await m.search.submit();
 
     await m.selectedTerms[0].remove();
+    await m.search.set('descriptor');
     await m.searchResults[0].add();
 
     assert.strictEqual(m.selectedTerms.length, 5);

--- a/tests/integration/components/course/manage-objective-descriptors-test.js
+++ b/tests/integration/components/course/manage-objective-descriptors-test.js
@@ -28,7 +28,6 @@ module('Integration | Component | course/manage-objective-descriptors', function
     assert.strictEqual(m.selectedTerms.length, 1);
     assert.strictEqual(m.selectedTerms[0].title, 'descriptor 0');
     await m.search.set('descriptor');
-    await m.search.submit();
     assert.strictEqual(m.searchResults.length, 4);
     assert.strictEqual(m.searchResults[0].title, `descriptor 0`);
     assert.ok(m.searchResults[0].isDisabled);
@@ -62,7 +61,6 @@ module('Integration | Component | course/manage-objective-descriptors', function
     assert.strictEqual(m.selectedTerms.length, 1);
     assert.strictEqual(m.selectedTerms[0].title, 'descriptor 0');
     await m.search.set('descriptor');
-    await m.search.submit();
     assert.strictEqual(m.searchResults.length, 2);
     assert.strictEqual(m.searchResults[0].title, `descriptor 0`);
     assert.ok(m.searchResults[0].isDisabled);
@@ -103,7 +101,6 @@ module('Integration | Component | course/manage-objective-descriptors', function
     assert.strictEqual(m.selectedTerms.length, 1);
     assert.strictEqual(m.selectedTerms[0].title, 'descriptor 0');
     await m.search.set('descriptor');
-    await m.search.submit();
     assert.strictEqual(m.searchResults.length, 2);
     assert.strictEqual(m.searchResults[0].title, `descriptor 0`);
     assert.ok(m.searchResults[0].isDisabled);
@@ -111,6 +108,7 @@ module('Integration | Component | course/manage-objective-descriptors', function
     assert.ok(m.searchResults[1].isEnabled);
     await m.selectedTerms[0].remove();
 
+    await m.search.set('descriptor');
     assert.strictEqual(m.selectedTerms.length, 0);
     assert.strictEqual(m.searchResults.length, 2);
     assert.strictEqual(m.searchResults[0].title, `descriptor 0`);

--- a/tests/integration/components/mesh-manager-test.js
+++ b/tests/integration/components/mesh-manager-test.js
@@ -43,7 +43,6 @@ module('Integration | Component | mesh-manager', function (hooks) {
     assert.strictEqual(component.selectedTerms[0].title, 'descriptor 2');
     assert.strictEqual(component.selectedTerms[1].title, 'descriptor 4');
     await component.search.set('descriptor');
-    await component.search.submit();
 
     assert.strictEqual(component.searchResults.length, 5);
     for (let i = 0; i < 5; i++) {
@@ -68,7 +67,6 @@ module('Integration | Component | mesh-manager', function (hooks) {
       @remove={{(noop)}}
     />`);
     await component.search.set('descriptor');
-    await component.search.submit();
 
     assert.strictEqual(component.searchResults.length, 50);
     for (let i = 0; i < 50; i++) {
@@ -96,7 +94,6 @@ module('Integration | Component | mesh-manager', function (hooks) {
       @remove={{(noop)}}
     />`);
     await component.search.set('descriptor');
-    await component.search.submit();
     assert.ok(component.searchResults[1].isEnabled);
     assert.strictEqual(component.searchResults[1].title, 'descriptor 1');
     await component.searchResults[1].add();
@@ -117,7 +114,6 @@ module('Integration | Component | mesh-manager', function (hooks) {
       @remove={{(noop)}}
     />`);
     await component.search.set('descriptor');
-    await component.search.submit();
     assert.ok(component.searchResults[0].isDisabled);
     await component.searchResults[0].add();
   });
@@ -126,9 +122,25 @@ module('Integration | Component | mesh-manager', function (hooks) {
     this.server.createList('meshDescriptor', 3);
     await render(hbs`<MeshManager @editable={{true}} @add={{(noop)}} @remove={{(noop)}} />`);
     await component.search.set('descriptor');
-    await component.search.submit();
     assert.ok(component.searchResults[1].isEnabled);
     assert.strictEqual(component.searchResults[1].title, 'descriptor 1');
     await component.searchResults[1].add();
+  });
+
+  test('clicking outside of search results dismissed them.', async function (assert) {
+    assert.expect(3);
+    const descriptors = this.server.createList('meshDescriptor', 3);
+    this.set('terms', [descriptors[0], descriptors[2]]);
+    await render(hbs`<MeshManager
+      @editable={{true}}
+      @terms={{this.terms}}
+      @add={{(noop)}}
+      @remove={{(noop)}}
+    />`);
+    await component.search.set('descriptor');
+    assert.strictEqual(component.searchResults.length, 3);
+    await component.search.click(); // click on anything outside the search results area, doesn't matter what.
+    assert.strictEqual(component.search.value, '');
+    assert.strictEqual(component.searchResults.length, 0);
   });
 });

--- a/tests/integration/components/mesh-manager-test.js
+++ b/tests/integration/components/mesh-manager-test.js
@@ -127,6 +127,22 @@ module('Integration | Component | mesh-manager', function (hooks) {
     await component.searchResults[1].add();
   });
 
+  test('search term less than 3 characters', async function (assert) {
+    this.server.createList('meshDescriptor', 3);
+    await render(hbs`<MeshManager @editable={{true}} @add={{(noop)}} @remove={{(noop)}} />`);
+    await component.search.set('ab');
+    assert.strictEqual(component.searchResults.length, 1);
+    assert.strictEqual(component.searchResults[0].text, 'keep typing...');
+  });
+
+  test('no search results', async function (assert) {
+    this.server.createList('meshDescriptor', 3);
+    await render(hbs`<MeshManager @editable={{true}} @add={{(noop)}} @remove={{(noop)}} />`);
+    await component.search.set('geflarknik');
+    assert.strictEqual(component.searchResults.length, 1);
+    assert.strictEqual(component.searchResults[0].text, 'no results');
+  });
+
   test('clicking outside of search results dismissed them.', async function (assert) {
     assert.expect(3);
     const descriptors = this.server.createList('meshDescriptor', 3);

--- a/tests/integration/components/session/manage-objective-descriptors-test.js
+++ b/tests/integration/components/session/manage-objective-descriptors-test.js
@@ -28,7 +28,6 @@ module('Integration | Component | session/manage-objective-descriptors', functio
     assert.strictEqual(m.selectedTerms.length, 1);
     assert.strictEqual(m.selectedTerms[0].title, 'descriptor 0');
     await m.search.set('descriptor');
-    await m.search.submit();
     assert.strictEqual(m.searchResults.length, 4);
     assert.strictEqual(m.searchResults[0].title, `descriptor 0`);
     assert.ok(m.searchResults[0].isDisabled);
@@ -62,7 +61,6 @@ module('Integration | Component | session/manage-objective-descriptors', functio
     assert.strictEqual(m.selectedTerms.length, 1);
     assert.strictEqual(m.selectedTerms[0].title, 'descriptor 0');
     await m.search.set('descriptor');
-    await m.search.submit();
     assert.strictEqual(m.searchResults.length, 2);
     assert.strictEqual(m.searchResults[0].title, `descriptor 0`);
     assert.ok(m.searchResults[0].isDisabled);
@@ -103,7 +101,6 @@ module('Integration | Component | session/manage-objective-descriptors', functio
     assert.strictEqual(m.selectedTerms.length, 1);
     assert.strictEqual(m.selectedTerms[0].title, 'descriptor 0');
     await m.search.set('descriptor');
-    await m.search.submit();
     assert.strictEqual(m.searchResults.length, 2);
     assert.strictEqual(m.searchResults[0].title, `descriptor 0`);
     assert.ok(m.searchResults[0].isDisabled);
@@ -111,6 +108,7 @@ module('Integration | Component | session/manage-objective-descriptors', functio
     assert.ok(m.searchResults[1].isEnabled);
     await m.selectedTerms[0].remove();
 
+    await m.search.set('descriptor');
     assert.strictEqual(m.selectedTerms.length, 0);
     assert.strictEqual(m.searchResults.length, 2);
     assert.strictEqual(m.searchResults[0].title, `descriptor 0`);

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -176,7 +176,6 @@ general:
   mesh: MeSH
   meshCount: "{count, plural, =1 {1 has MeSH} other {# have MesH}}"
   meshManageTitle: "Manage MeSH"
-  meshSearchPlaceholder: "Search MeSH"
   meshTerms: "MeSH Terms"
   minute: Minute
   minutes: Minutes
@@ -273,6 +272,7 @@ general:
   schools: Schools
   search: Search
   searchForIliosUsers: "Find Ilios Users..."
+  searchMesh: "Search MeSH"
   searchPlaceholder: "Find Learning Material"
   selectCohortsToAttach: "Select the cohort of students you wish to attach to the new course"
   selectCourse: "Select a Course"

--- a/translations/es.yaml
+++ b/translations/es.yaml
@@ -176,7 +176,6 @@ general:
   mesh: MeSH
   meshCount: "{count, plural, =1 {1 tiene MeSH} other {# tienen MeSH}}"
   meshManageTitle: "Administrar MeSH"
-  meshSearchPlaceholder: "Buscar MeSH"
   meshTerms: "Terminos de MeSH"
   minute: Minuto
   minutes: Minutos
@@ -273,6 +272,7 @@ general:
   schools: Escuelas
   search: Buscar
   searchForIliosUsers: "Encuentre Usuarios de Ilios..."
+  searchMesh: "Buscar MeSH"
   searchPlaceholder: "encontrar material de aprendizaje"
   selectCohortsToAttach: "Seleccione la cohorte de estudiantes que desea adjuntar al nuevo curso"
   selectCourse: "Seleccionar un curso"

--- a/translations/fr.yaml
+++ b/translations/fr.yaml
@@ -176,7 +176,6 @@ general:
   mesh: MeSH
   meshCount:  "{count, plural, =1 {1 a des MeSH} other {# ont MeSH}}"
   meshManageTitle: "Manager MeSH"
-  meshSearchPlaceholder: "Rechercher MeSH"
   meshTerms: "Termes de MeSH"
   minute: Minute
   minutes: Minutes
@@ -273,6 +272,7 @@ general:
   schools: "Écôles"
   search: Rechercher
   searchForIliosUsers: "Trouver des utilisateurs..."
+  searchMesh: "Rechercher MeSH"
   searchPlaceholder: "Trouver matériels d'étude"
   selectCohortsToAttach: "Choisissez le cohorte d'étudiants que vous voulez attacher au cours nouveau"
   selectCourse: "Choisi cours"


### PR DESCRIPTION
- close search results and reset search value if user clicks outside of
search results
- enables live search, our backend can handle it.
- rm obsolete submit search button
- adds text label
- corrects styles of loading indicator and no search results found.

fixes #1907 