### PR TITLE
re-layouts offering list items grid.

### DIFF
--- a/addon-test-support/ilios-common/page-objects/components/session-details.js
+++ b/addon-test-support/ilios-common/page-objects/components/session-details.js
@@ -51,8 +51,8 @@ export default create({
       hasStartTime: isVisible('.offering-block-time-time-starttime'),
       endTime: text('.offering-block-time-time-endtime'),
       hasEndTime: isVisible('.offering-block-time-time-endtime'),
-      multiDay: text('.multiday-offering-block-time-time'),
-      hasMultiDay: isVisible('.multiday-offering-block-time-time'),
+      multiDayStart: text('.offering-block-time-time-starts'),
+      multiDayEnd: text('.offering-block-time-time-ends'),
       offerings: collection('[data-test-offerings] [data-test-offering-manager]', {
         learnerGroups: collection('.offering-manager-learner-groups li', {
           title: text(),

--- a/addon/components/session-offerings-list.hbs
+++ b/addon/components/session-offerings-list.hbs
@@ -17,18 +17,19 @@
       {{#each block.offeringTimeBlocks as |offeringTimeBlock|}}
         <div class="offering-block-time">
           {{#if offeringTimeBlock.isMultiDay}}
-            <div class="multiday-offering-block-time-time">
-              <span class="multiday-offering-block-time-time-description">
-                {{t "general.multiday"}}
-              </span>
-              <span class="multiday-offering-block-time-time-starts">
-                {{t "general.starts"}}
+            <div class="offering-block-time-time">
+              <div class="offering-block-time-time-starts">
+                <label class="offering-block-time-time-starts-label">
+                  {{t "general.starts"}}:
+                </label>
                 {{offeringTimeBlock.longStartText}}
-              </span>
-              <span class="multiday-offering-block-time-time-ends">
-                {{t "general.ends"}}
+              </div>
+              <div class="offering-block-time-time-ends">
+                <label class="offering-block-time-time-ends-label">
+                  {{t "general.ends"}}:
+                </label>
                 {{offeringTimeBlock.longEndText}}
-              </span>
+              </div>
             </div>
           {{else}}
             <div class="offering-block-time-time">

--- a/app/styles/ilios-common/components/offering-manager.scss
+++ b/app/styles/ilios-common/components/offering-manager.scss
@@ -1,15 +1,11 @@
 .offering-manager {
-  border-bottom: 1px dotted $dark-grey;
-  display: grid;
   @include font-size('small');
-  grid-column: 1 / -1;
-  grid-template-columns: repeat(5, 1fr);
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
   margin-bottom: .5rem;
   padding-bottom: .5rem;
 
   .offering-manager-learner-groups {
-    grid-column-start: 2;
-
     ul {
       @include ilios-list-reset;
     }
@@ -18,7 +14,6 @@
   .offering-manager-location {
     display: flex;
     flex-direction: column;
-    grid-column-start: 3;
     overflow-wrap: anywhere;
     .copy-btn {
       @include ilios-link-button;
@@ -30,16 +25,12 @@
   }
 
   .offering-manager-instructors {
-    grid-column-start: 4;
-
     ul {
       @include ilios-list-reset;
     }
   }
 
   .offering-manager-actions {
-    grid-column-start: 5;
-
     .remove {
       padding-left: .5rem;
     }

--- a/app/styles/ilios-common/components/session-offerings-list.scss
+++ b/app/styles/ilios-common/components/session-offerings-list.scss
@@ -27,10 +27,30 @@
       }
 
     .offering-block-time {
+      border-bottom: 1px dotted $dark-grey;
+      display: grid;
       grid-column: 1 / -1;
+      grid-template-columns: repeat(5, 1fr);
       margin-top: 1rem;
 
+      .offering-block-time-time {
+        grid-column: 1;
+      }
+
+      .offering-block-time-offerings {
+        grid-column: 2 / -1;
+      }
+
+      .offering-manager {
+        border-bottom: 1px dotted $dark-grey;
+        &:last-of-type {
+          border-bottom: 0;
+        }
+      }
+
+      .offering-block-time-time-starts,
       .offering-block-time-time-starttime,
+      .offering-block-time-time-ends,
       .offering-block-time-time-endtime {
         color: $medium-grey;
         display: block;
@@ -41,11 +61,12 @@
       .offering-block-time-time-endtime-label {
         font-weight: normal;
       }
+
+      .offering-block-time-time-starts-label,
+      .offering-block-time-time-ends-label {
+        display: block;
+        font-weight: normal;
+      }
     }
   }
-
-  .multiday-offering-block-time-time {
-    margin-bottom: .5rem;
-  }
-
 }

--- a/tests/acceptance/course/session/offerings-test.js
+++ b/tests/acceptance/course/session/offerings-test.js
@@ -85,7 +85,6 @@ module('Acceptance | Session - Offerings', function (hooks) {
   });
 
   test('offering dates', async function (assert) {
-    assert.expect(23);
     await page.visit({ courseId: 1, sessionId: 1 });
 
     const blocks = page.details.offerings.dateBlocks;
@@ -103,7 +102,6 @@ module('Acceptance | Session - Offerings', function (hooks) {
 
     assert.ok(blocks[1].hasStartTime);
     assert.ok(blocks[1].hasEndTime);
-    assert.notOk(blocks[1].hasMultiDay);
     assert.strictEqual(blocks[1].dayOfWeek, moment(this.offering2.startDate).format('dddd'));
     assert.strictEqual(blocks[1].dayOfMonth, moment(this.offering2.startDate).format('MMMM Do'));
     assert.strictEqual(
@@ -115,18 +113,17 @@ module('Acceptance | Session - Offerings', function (hooks) {
 
     assert.notOk(blocks[2].hasStartTime);
     assert.notOk(blocks[2].hasEndTime);
-    assert.ok(blocks[2].hasMultiDay);
     assert.strictEqual(blocks[2].dayOfWeek, moment(this.offering3.startDate).format('dddd'));
     assert.strictEqual(blocks[2].dayOfMonth, moment(this.offering3.startDate).format('MMMM Do'));
-    const expectedText =
-      'Multiday ' +
-      'Starts ' +
-      moment(this.offering3.startDate).format('dddd MMMM Do [@] LT') +
-      ' Ends ' +
-      moment(this.offering3.endDate).format('dddd MMMM Do [@] LT');
     assert.strictEqual(blocks[2].offerings.length, 1);
-
-    assert.strictEqual(blocks[2].multiDay, expectedText);
+    assert.strictEqual(
+      blocks[2].multiDayStart,
+      'Starts: ' + moment(this.offering3.startDate).format('dddd MMMM Do [@] LT')
+    );
+    assert.strictEqual(
+      blocks[2].multiDayEnd,
+      'Ends: ' + moment(this.offering3.endDate).format('dddd MMMM Do [@] LT')
+    );
   });
 
   test('offering details', async function (assert) {
@@ -303,14 +300,10 @@ module('Acceptance | Session - Offerings', function (hooks) {
 
     assert.notOk(block.hasStartTime);
     assert.notOk(block.hasEndTime);
-    assert.ok(block.hasMultiDay);
     assert.strictEqual(block.dayOfWeek, 'Sunday');
     assert.strictEqual(block.dayOfMonth, 'September 11th');
-    const expectedText =
-      'Multiday ' +
-      'Starts Sunday September 11th @ 2:15 AM' +
-      ' Ends Monday September 12th @ 5:30 PM';
-    assert.strictEqual(block.multiDay, expectedText);
+    assert.strictEqual(block.multiDayStart, 'Starts: Sunday September 11th @ 2:15 AM');
+    assert.strictEqual(block.multiDayEnd, 'Ends: Monday September 12th @ 5:30 PM');
     assert.strictEqual(block.offerings.length, 1);
 
     assert.strictEqual(block.offerings[0].learnerGroups.length, 2);


### PR DESCRIPTION
brings details and timing info up to the same vertical level rather than
stacking
puts more emphasis onto start/end of multiday events and drops
"multiday" label since this seems kinda redundant.

![image](https://user-images.githubusercontent.com/1410427/167178680-2512b5da-acf9-4770-8573-4817072de019.png)

![image](https://user-images.githubusercontent.com/1410427/167178751-5c362851-8fe1-45e1-9256-f1e8812c11fb.png)

fixes https://github.com/ilios/common/issues/2842

