### PR TITLE
Add title to dashboard materials

### DIFF
--- a/addon-test-support/ilios-common/page-objects/components/dashboard/materials.js
+++ b/addon-test-support/ilios-common/page-objects/components/dashboard/materials.js
@@ -17,6 +17,7 @@ import displayToggle from '../toggle-buttons';
 const definition = {
   scope: '[data-test-dashboard-materials]',
   dashboardViewPicker,
+  title: text('[data-test-materials-title]'),
   header: {
     scope: '[data-test-materials-header]',
     displayToggle,

--- a/addon/components/dashboard/materials.hbs
+++ b/addon/components/dashboard/materials.hbs
@@ -3,6 +3,9 @@
   data-test-dashboard-materials
 >
   <Dashboard::ViewPicker />
+  <h2 class="title" data-test-materials-title>
+    {{t "general.myMaterials"}}
+  </h2>
   <div class="dashboard-materials-content">
     <div class="header" data-test-materials-header>
       <ToggleButtons

--- a/app/styles/ilios-common/components/dashboard/materials.scss
+++ b/app/styles/ilios-common/components/dashboard/materials.scss
@@ -1,13 +1,18 @@
 .dashboard-materials {
   @include dashboard-component;
 
+  .title {
+    @include ilios-heading-h3;
+    margin-top: .5rem;
+    text-align: center;
+  }
   .dashboard-materials-content {
     max-height: 40em;
     overflow-y: scroll;
-    padding: .5em;
+    padding: .5rem;
 
     .header {
-      margin: 1em 1em 1em 0;
+      margin: 0 1em 1em 0;
     }
 
     .material-list {

--- a/tests/acceptance/dashboard/materials-test.js
+++ b/tests/acceptance/dashboard/materials-test.js
@@ -92,7 +92,7 @@ module('Acceptance | Dashboard Materials', function (hooks) {
   });
 
   test('it renders with materials in show-current mode', async function (assert) {
-    assert.expect(77);
+    assert.expect(78);
     this.server.get(`/api/usermaterials/:id`, (scheme, { params, queryParams }) => {
       assert.ok('id' in params);
       assert.strictEqual(parseInt(params.id, 10), 100);
@@ -112,6 +112,7 @@ module('Acceptance | Dashboard Materials', function (hooks) {
     assert.notOk(page.materials.dashboardViewPicker.activities.isActive);
     assert.notOk(page.materials.dashboardViewPicker.week.isActive);
     assert.ok(page.materials.dashboardViewPicker.isVisible);
+    assert.strictEqual(page.materials.title, 'My Materials');
     assert.ok(page.materials.header.displayToggle.firstButton.isChecked);
     assert.strictEqual(page.materials.courseFilter.options.length, 5);
     assert.strictEqual(page.materials.courseFilter.options[0].text, 'All Courses');

--- a/tests/integration/components/dashboard/materials-test.js
+++ b/tests/integration/components/dashboard/materials-test.js
@@ -106,7 +106,7 @@ module('Integration | Component | dashboard/materials', function (hooks) {
   });
 
   test('it renders with materials in show-current mode', async function (assert) {
-    assert.expect(72);
+    assert.expect(73);
     this.server.get(`/api/usermaterials/:id`, (scheme, { params, queryParams }) => {
       assert.ok('id' in params);
       assert.strictEqual(parseInt(params.id, 10), 11);
@@ -137,6 +137,7 @@ module('Integration | Component | dashboard/materials', function (hooks) {
     />`);
     assert.ok(component.dashboardViewPicker.isVisible);
     assert.ok(component.header.displayToggle.firstButton.isChecked);
+    assert.strictEqual(component.title, 'My Materials');
     assert.strictEqual(component.courseFilter.options.length, 5);
     assert.strictEqual(component.courseFilter.options[0].text, 'All Courses');
     assert.strictEqual(component.courseFilter.options[1].text, 'course 0');


### PR DESCRIPTION
For a11y we need continuity in our titles from h1,h2,h3 without the h2
in this component we lose that on the dashboard.