### PR TITLE
Balance whitespace at the top of the dashboard

### DIFF
--- a/app/styles/ilios-common/components/dashboard/view-picker.scss
+++ b/app/styles/ilios-common/components/dashboard/view-picker.scss
@@ -5,8 +5,12 @@
     display: flex;
     justify-content: space-around;
     list-style-type: none;
-    margin: 0;
+    margin: 0 0 calc($golden-ratio-small * .5rem) 0;
     padding: 0;
+
+    li {
+      margin: 0;
+    }
 
     @include for-tablet-and-up {
       justify-content: flex-start;

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -45,7 +45,7 @@
   & > main {
    background-color: $white;
    grid-area: main;
-   margin: 5px;
+   margin: 0 5px;
   }
  
   & > footer {


### PR DESCRIPTION
Removed the global margin on main so we can move closer to the top or
the page and then set the space under the buttons to be a pleasing ratio
to the space above them.

Fixes ilios/ilios#4150