### PR TITLE
customize validation and error message for LM file upload.

### DIFF
--- a/addon-test-support/ilios-common/page-objects/components/new-learningmaterial.js
+++ b/addon-test-support/ilios-common/page-objects/components/new-learningmaterial.js
@@ -24,6 +24,10 @@ const definition = {
   save: clickable('.done'),
   cancel: clickable('.cancel'),
   hasAgreementValidationError: isVisible('[data-test-agreement-validation-error-message]'),
+  fileUpload: {
+    scope: '[data-test-file]',
+    validationErrors: collection('.validation-error-message'),
+  },
 };
 
 export default definition;

--- a/addon/components/new-learningmaterial.hbs
+++ b/addon/components/new-learningmaterial.hbs
@@ -163,7 +163,7 @@
           </span>
         </div>
       {{/unless}}
-      <div class="item">
+      <div class="item" data-test-file>
         <label>
           {{t "general.file"}}:
         </label>

--- a/addon/components/new-learningmaterial.js
+++ b/addon/components/new-learningmaterial.js
@@ -3,7 +3,14 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { dropTask } from 'ember-concurrency';
-import { validatable, Length, NotBlank, IsTrue, IsURL } from 'ilios-common/decorators/validation';
+import {
+  validatable,
+  Custom,
+  Length,
+  NotBlank,
+  IsTrue,
+  IsURL,
+} from 'ilios-common/decorators/validation';
 import { ValidateIf } from 'class-validator';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from '../classes/resolve-async-value';
@@ -15,7 +22,11 @@ export default class NewLearningmaterialComponent extends Component {
   @service store;
   @service currentUser;
   @service iliosConfig;
-  @ValidateIf((o) => o.isFile) @NotBlank() @tracked filename;
+  @service intl;
+  @ValidateIf((o) => o.isFile)
+  @Custom('validateFilenameCallback', 'validateFilenameMessageCallback')
+  @tracked
+  filename;
   @ValidateIf((o) => o.isFile) @NotBlank() @tracked fileHash;
   @tracked statusId;
   @tracked userRoleId;
@@ -145,5 +156,16 @@ export default class NewLearningmaterialComponent extends Component {
     if (target.value === DEFAULT_URL_VALUE) {
       target.select();
     }
+  }
+
+  validateFilenameCallback() {
+    if (typeof this.filename === 'string') {
+      return this.filename.trim() !== '';
+    }
+    return this.filename !== null && this.filename !== undefined;
+  }
+
+  validateFilenameMessageCallback() {
+    return this.intl.t('errors.missingFile');
   }
 }

--- a/tests/integration/components/new-learningmaterial-test.js
+++ b/tests/integration/components/new-learningmaterial-test.js
@@ -69,4 +69,20 @@ module('Integration | Component | new learningmaterial', function (hooks) {
       'This field is too long (maximum is 256 characters)'
     );
   });
+
+  test('missing file', async function (assert) {
+    this.set('type', 'file');
+    await render(hbs`
+      <NewLearningmaterial
+        @type={{this.type}}
+        @learningMaterialStatuses={{(array)}}
+        @learningMaterialUserRoles={{(array)}}
+        @save={{(noop)}}
+        @cancel={{(noop)}}
+      />
+   `);
+    assert.strictEqual(component.fileUpload.validationErrors.length, 0);
+    await component.save();
+    assert.strictEqual(component.fileUpload.validationErrors[0].text, 'Missing file');
+  });
 });

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -397,6 +397,7 @@ errors:
   invalid: "{description} is invalid"
   lessThan: "{description} must be less than {lt}"
   lessThanOrEqualTo: "{description} must be less than or equal to {lte}"
+  missingFile: "Missing file"
   notANumber: "{description} must be a number"
   notAnInteger: "{description} must be an integer"
   odd: "{description} must be odd"

--- a/translations/es.yaml
+++ b/translations/es.yaml
@@ -397,6 +397,7 @@ errors:
   invalid: "{description} es inválido"
   lessThan: "{description} debe ser menos que {lt}"
   lessThanOrEqualTo: "{description} debe ser menos que o igual a {lte}"
+  missingFile: "Archivo faltante"
   notANumber: "{description} no es un número"
   notAnInteger: "{description} debe ser un numero entero"
   odd: "{description} debe ser número impar"

--- a/translations/fr.yaml
+++ b/translations/fr.yaml
@@ -397,6 +397,7 @@ errors:
   invalid: "{description} est invalide"
   lessThan: "{description} doit être inférieure à {lt}"
   lessThanOrEqualTo: "{description} doit être supérieure ou inférieure à {lte}"
+  missingFile: "Fichier manquant"
   notANumber: "{description} doit contenir une valeur numérique"
   notAnInteger: "{description} doit être un entier"
   odd: "{description} doit étre une chiffre impair"


### PR DESCRIPTION
since the class-validator library still doesn't jive with ember-intl, our options are to either inject a lang-key override into the `NotBlank()` validator, create yet another custom validator class, or use our golden hammer `Custom()` validator class.

I opted for the third option since it seems to be the most reasonable out of the three kludges. :shrug: 

![image](https://user-images.githubusercontent.com/1410427/173942809-907c27ce-e8dd-4dcd-a792-84b69c62f03e.png)


fixes https://github.com/ilios/common/issues/2894