### PR TITLE
reduce space between course details and session details

### DIFF
--- a/app/styles/ilios-common/components/course-details.scss
+++ b/app/styles/ilios-common/components/course-details.scss
@@ -8,7 +8,6 @@
     @include ilios-button-reset;
     display: flex;
     justify-content: center;
-    margin-bottom: 1rem;
     width: 100%;
 
     span {

--- a/app/styles/ilios-common/components/course-session.scss
+++ b/app/styles/ilios-common/components/course-session.scss
@@ -3,4 +3,8 @@
   border-top: 0;
   border-top-left-radius: 0;
   border-top-right-radius: 0;
+
+  .backtosessionlink {
+    margin-top: 0;
+  }
 }


### PR DESCRIPTION
fixes #2906 

that's as much as i can squeeze here.

![image](https://user-images.githubusercontent.com/1410427/175436752-bc1c90a9-1ae6-4667-9a44-6e30a79dd622.png)
