### PR TITLE
Fix zebra stripe color

### DIFF
--- a/app/styles/ilios-common/mixins/ilios-table.scss
+++ b/app/styles/ilios-common/mixins/ilios-table.scss
@@ -130,6 +130,6 @@
 
 @mixin ilios-zebra-table () {
   tbody tr:nth-child(even) {
-    background-color: color.adjust($culturedGrey, $lightness: 96%);
+    background-color: color.adjust($culturedGrey, $lightness: 4%);
   }
 }


### PR DESCRIPTION
Bad math here, was lightening all the way to white. This moves it back
to a very light grey.

Fixes ilios/ilios#4185