### PR TITLE
Update test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,9 @@ jobs:
       fail-fast: false
       matrix:
         try-scenario:
-          - ember-lts-3.28
           - ember-release
-          # - ember-beta
-          # - ember-canary
+          - ember-beta
+          - ember-canary
           - embroider-safe
           - embroider-optimized
 


### PR DESCRIPTION
We don't need to test against 3.28 as we're not using that on the
frontend anymore, re-enabled the beta/canary ember tests as well.