### PR TITLE
Add a class to create sticky table headers

### DIFF
--- a/addon/components/detail-learning-materials.hbs
+++ b/addon/components/detail-learning-materials.hbs
@@ -70,7 +70,7 @@
           {{t "general.sortMaterials"}}
         </button>
       {{/if}}
-      <table>
+      <table class={{if (gt this.materials.length 10) "sticky-header"}}>
         <thead>
           <tr>
             <th class="text-left" colspan="3">

--- a/app/styles/ilios-common/components/session-details.scss
+++ b/app/styles/ilios-common/components/session-details.scss
@@ -7,7 +7,8 @@
   padding-left: .8rem;
 
   table {
-    thead {
+    thead,
+    th {
       background-color: $tealBlue;
       color: $white;
     }

--- a/app/styles/ilios-common/mixins/collapsed-container.scss
+++ b/app/styles/ilios-common/mixins/collapsed-container.scss
@@ -30,25 +30,19 @@
   @include font-size('small');
 
   table,
-  tr,
-  td,
-  th {
+  tr {
     margin: 0;
     padding: 0;
   }
 
   td,
   th {
-    padding: 0 0 .5rem .5rem;
+    margin: 0;
     vertical-align: top;
   }
 
-  td:first-of-type,
-  th:first-of-type {
-    padding-left: 0;
-  }
-
-  thead {
+  thead,
+  th {
     background-color: $blueMunsell;
     color: $white;
   }

--- a/app/styles/ilios-common/mixins/ilios-table.scss
+++ b/app/styles/ilios-common/mixins/ilios-table.scss
@@ -79,6 +79,15 @@
       display: table-cell;
     }
   }
+
+  &.sticky-header {
+    position: relative;
+
+    th {
+      position: sticky;
+      top: 0;
+    }
+  }
 }
 
 
@@ -89,6 +98,7 @@
 
   th {
     border-bottom: 1px solid color.adjust($culturedGrey, $lightness: -15%);
+    background-color: $slightWhite;
   }
 }
 


### PR DESCRIPTION
For reasons that are very web you can't apply the sticky to a thead
element, you have to apply it to the th. Since our colors were on the
thead and once they rolled down it disappeared I had to add the color to
the th and make some adjustments elsewhere. We don't really need this
anywhere in common, but possibly on a very long list of LMs so I added
the style there.