### PR TITLE
remove bottom margin override for last item in list.

### DIFF
--- a/app/styles/ilios-common/components/body.scss
+++ b/app/styles/ilios-common/components/body.scss
@@ -57,17 +57,13 @@ select {
 ul {
   li {
     margin-bottom: .5rem;
-
-    &:last-of-type {
-      margin-bottom: 0;
-    }
   }
 }
 
 p {
   margin-bottom: 1rem;
   @include paragraph-line-height;
-  
+
   a {
     text-decoration: underline;
   }


### PR DESCRIPTION
while this may add additional .5rem bottom margin to some lists,
it also fixes all styling issues with any tag-lists that sit on top
of the default list styles.

fixes https://github.com/ilios/common/issues/2934