### PR TITLE
chore: remove superfluous complexity in clear()

### DIFF
--- a/addon/services/loading-opacity-tracker.js
+++ b/addon/services/loading-opacity-tracker.js
@@ -12,7 +12,4 @@ export default class LoadingOpacityTrackerService extends Service {
   has(key) {
     return this.#opacities.has(key);
   }
-  clear() {
-    this.#opacities.clear();
-  }
 }

--- a/addon/services/loading-opacity-tracker.js
+++ b/addon/services/loading-opacity-tracker.js
@@ -12,7 +12,7 @@ export default class LoadingOpacityTrackerService extends Service {
   has(key) {
     return this.#opacities.has(key);
   }
-  clear(key) {
-    delete this.#opacities.clear(key);
+  clear() {
+    this.#opacities.clear();
   }
 }


### PR DESCRIPTION
`delete` does not work on return values from functions.
`Map.prototype.clear()` does not take an argument. (Perhaps
`Map.prototype.delete()` was intended instead?)