### PR TITLE
Use resources for course instructors visualizations

### DIFF
--- a/addon-test-support/ilios-common/page-objects/components/course-visualize-instructors.js
+++ b/addon-test-support/ilios-common/page-objects/components/course-visualize-instructors.js
@@ -1,4 +1,5 @@
 import { attribute, collection, create, fillable, text, value } from 'ember-cli-page-object';
+import instructorsChart from './visualizer-course-instructors';
 
 const definition = create({
   scope: '[data-test-course-visualize-instructors]',
@@ -14,11 +15,7 @@ const definition = create({
     value: value('input'),
     set: fillable('input'),
   },
-  chart: {
-    scope: '.simple-chart-horz-bar',
-    bars: collection('.bars rect'),
-    labels: collection('.bars text'),
-  },
+  instructorsChart,
 });
 
 export default definition;

--- a/addon-test-support/ilios-common/page-objects/components/visualizer-course-instructors.js
+++ b/addon-test-support/ilios-common/page-objects/components/visualizer-course-instructors.js
@@ -1,0 +1,15 @@
+import { collection, create, notHasClass } from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-visualizer-course-instructors]',
+  isIcon: notHasClass('no-icon'),
+  chart: {
+    scope: '.simple-chart',
+    bars: collection('.bars rect'),
+    labels: collection('.bars text'),
+    slices: collection('svg .slice'),
+  },
+};
+
+export default definition;
+export const component = create(definition);

--- a/addon-test-support/ilios-common/page-objects/course-visualizations-instructors.js
+++ b/addon-test-support/ilios-common/page-objects/course-visualizations-instructors.js
@@ -1,0 +1,7 @@
+import { create, visitable } from 'ember-cli-page-object';
+import root from './components/course-visualize-instructors';
+
+export default create({
+  visit: visitable('/data/courses/:courseId/instructors'),
+  root,
+});

--- a/addon/components/visualizer-course-instructors.hbs
+++ b/addon/components/visualizer-course-instructors.hbs
@@ -1,5 +1,7 @@
 <div
   class="visualizer-course-instructors {{unless @isIcon "not-icon"}}"
+  data-test-visualizer-course-instructors
+  ...attributes
 >
   {{#if (or @isIcon this.data.length)}}
     <SimpleChart

--- a/addon/components/visualizer-course-instructors.hbs
+++ b/addon/components/visualizer-course-instructors.hbs
@@ -1,22 +1,20 @@
 <div
   class="visualizer-course-instructors {{unless @isIcon "not-icon"}}"
 >
-  {{#if this.isLoaded}}
-    {{#if (or @isIcon this.data.length)}}
-      <SimpleChart
-        @name={{this.chartType}}
-        @isIcon={{@isIcon}}
-        @data={{this.filteredData}}
-        @onClick={{this.barClick}}
-        @hover={{perform this.barHover}}
-        @leave={{perform this.barHover}} as |chart|
-      >
-        {{#if this.tooltipContent}}
-          <chart.tooltip @title={{this.tooltipTitle}}>
-            {{this.tooltipContent}}
-          </chart.tooltip>
-        {{/if}}
-      </SimpleChart>
-    {{/if}}
+  {{#if (or @isIcon this.data.length)}}
+    <SimpleChart
+      @name={{this.chartType}}
+      @isIcon={{@isIcon}}
+      @data={{this.filteredData}}
+      @onClick={{this.barClick}}
+      @hover={{perform this.barHover}}
+      @leave={{perform this.barHover}} as |chart|
+    >
+      {{#if this.tooltipContent}}
+        <chart.tooltip @title={{this.tooltipTitle}}>
+          {{this.tooltipContent}}
+        </chart.tooltip>
+      {{/if}}
+    </SimpleChart>
   {{/if}}
 </div>

--- a/addon/components/visualizer-course-instructors.js
+++ b/addon/components/visualizer-course-instructors.js
@@ -2,13 +2,14 @@ import Component from '@glimmer/component';
 import { isEmpty } from '@ember/utils';
 import { htmlSafe } from '@ember/template';
 import { restartableTask, timeout } from 'ember-concurrency';
+import { map } from 'rsvp';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { cleanQuery } from 'ilios-common/utils/query-utils';
-
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import AsyncProcess from 'ilios-common/classes/async-process';
 
 export default class VisualizerCourseInstructors extends Component {
   @service router;
@@ -16,14 +17,15 @@ export default class VisualizerCourseInstructors extends Component {
   @tracked tooltipContent = null;
   @tracked tooltipTitle = null;
 
-  @use _sessions = new ResolveAsyncValue(() => [this.args.course.sessions]);
+  @use sessions = new ResolveAsyncValue(() => [this.args.course.sessions]);
+  @use loadedData = new AsyncProcess(() => [this.getData.bind(this), this.sessions]);
 
   get chartType() {
     return this.args.chartType || 'horz-bar';
   }
 
   get isLoaded() {
-    return !!this._sessions;
+    return !!this.sessions;
   }
 
   get filteredData() {
@@ -43,30 +45,39 @@ export default class VisualizerCourseInstructors extends Component {
     });
   }
 
-  get sessions() {
-    if (!this._sessions) {
+  get data() {
+    if (!this.loadedData) {
+      return [];
+    }
+    return this.loadedData;
+  }
+
+  async getData() {
+    if (!this.sessions) {
       return [];
     }
 
-    const sessionsWithLoadedInstructors = this._sessions.filter(
-      (session) => session.allInstructors
-    );
-
-    return sessionsWithLoadedInstructors.map((session) => {
-      const minutes = Math.round(session.maxSingleOfferingDuration * 60);
+    const sessionsWithInstructors = await map(this.sessions.toArray(), async (session) => {
+      const instructors = await session.getAllInstructors();
+      const totalInstructionalTime = await session.getTotalSumOfferingsDuration();
+      const instructorsWithInstructionalTime = await map(instructors, async (instructor) => {
+        const minutes = await session.getTotalSumOfferingsDurationByInstructor(instructor);
+        return {
+          instructor,
+          minutes,
+        };
+      });
       return {
         sessionTitle: session.title,
-        instructors: session.allInstructors,
-        minutes,
+        totalInstructionalTime: Math.round(totalInstructionalTime * 60),
+        instructorsWithInstructionalTime,
       };
     });
-  }
 
-  get data() {
-    const instructorData = this.sessions.reduce((set, obj) => {
-      obj.instructors.forEach((instructor) => {
-        const name = instructor.get('fullName');
-        const id = instructor.get('id');
+    const instructorData = sessionsWithInstructors.reduce((set, obj) => {
+      obj.instructorsWithInstructionalTime.forEach((instructorWithInstructionalTime) => {
+        const name = instructorWithInstructionalTime.instructor.get('fullName');
+        const id = instructorWithInstructionalTime.instructor.get('id');
         let existing = set.findBy('label', name);
         if (!existing) {
           existing = {
@@ -79,19 +90,19 @@ export default class VisualizerCourseInstructors extends Component {
           };
           set.pushObject(existing);
         }
-        existing.data += obj.minutes;
+        existing.data += instructorWithInstructionalTime.minutes;
         existing.meta.sessions.pushObject(obj.sessionTitle);
       });
 
       return set;
     }, []);
 
-    const totalMinutes = instructorData
-      .mapBy('data')
+    const totalMinutes = sessionsWithInstructors
+      .mapBy('totalInstructionalTime')
       .reduce((total, minutes) => total + minutes, 0);
     return instructorData.map((obj) => {
       const percent = ((obj.data / totalMinutes) * 100).toFixed(1);
-      obj.label = `${obj.label} ${percent}%`;
+      obj.label = `${obj.label}: ${obj.data} ${this.intl.t('general.minutes')}`;
       obj.meta.totalMinutes = totalMinutes;
       obj.meta.percent = percent;
       return obj;
@@ -106,10 +117,9 @@ export default class VisualizerCourseInstructors extends Component {
       this.tooltipContent = null;
       return;
     }
-    const { label, data, meta } = obj;
+    const { label, meta } = obj;
     const sessions = meta.sessions.uniq().sort().join(', ');
-
-    this.tooltipTitle = htmlSafe(`${label} ${data} ${this.intl.t('general.minutes')}`);
+    this.tooltipTitle = htmlSafe(label);
     this.tooltipContent = htmlSafe(sessions + '<br /><br />' + this.intl.t('general.clickForMore'));
   }
 

--- a/addon/components/visualizer-course-instructors.js
+++ b/addon/components/visualizer-course-instructors.js
@@ -24,10 +24,6 @@ export default class VisualizerCourseInstructors extends Component {
     return this.args.chartType || 'horz-bar';
   }
 
-  get isLoaded() {
-    return !!this.sessions;
-  }
-
   get filteredData() {
     if (!this.data) {
       return [];

--- a/tests/acceptance/dashboard/course-visualizations-instructors-test.js
+++ b/tests/acceptance/dashboard/course-visualizations-instructors-test.js
@@ -1,0 +1,92 @@
+import { module, test } from 'qunit';
+import { currentURL, waitFor } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import page from 'ilios-common/page-objects/course-visualizations-instructors';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setupAuthentication } from 'ilios-common';
+import { DateTime } from 'luxon';
+
+module('Acceptance | course visualizations - instructors', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  hooks.beforeEach(async function () {
+    this.user = await setupAuthentication();
+  });
+
+  test('it renders', async function (assert) {
+    const instructor1 = this.server.create('user');
+    const instructor2 = this.server.create('user');
+    const vocabulary1 = this.server.create('vocabulary');
+    const vocabulary2 = this.server.create('vocabulary');
+    const term1 = this.server.create('term', {
+      vocabulary: vocabulary1,
+    });
+    const term2 = this.server.create('term', {
+      vocabulary: vocabulary1,
+    });
+    const term3 = this.server.create('term', {
+      vocabulary: vocabulary2,
+    });
+    const sessionType1 = this.server.create('sessionType');
+    const sessionType2 = this.server.create('sessionType');
+    const session1 = this.server.create('session', {
+      sessionType: sessionType1,
+      terms: [term1],
+    });
+    const session2 = this.server.create('session', {
+      sessionType: sessionType2,
+      terms: [term2, term3],
+    });
+    const session3 = this.server.create('session');
+    const instructorGroup1 = this.server.create('instructorGroup', {
+      users: [instructor1],
+    });
+    const instructorGroup2 = this.server.create('instructorGroup', {
+      users: [instructor2],
+    });
+    this.server.create('offering', {
+      instructorGroups: [instructorGroup1],
+      startDate: DateTime.fromISO('2022-07-20T09:00:00').toJSDate(),
+      endDate: DateTime.fromISO('2022-07-20T10:00:00').toJSDate(),
+      session: session1,
+    });
+    this.server.create('offering', {
+      instructors: [instructor1],
+      startDate: DateTime.fromISO('2022-07-20T09:00:00').toJSDate(),
+      endDate: DateTime.fromISO('2022-07-20T09:15:00').toJSDate(),
+      session: session2,
+    });
+    this.server.create('offering', {
+      instructorGroups: [instructorGroup2],
+      startDate: DateTime.fromISO('2022-07-20T09:00:00').toJSDate(),
+      endDate: DateTime.fromISO('2022-07-20T10:30:00').toJSDate(),
+      session: session1,
+    });
+    const course = this.server.create('course', {
+      sessions: [session1, session2, session3],
+      year: 2022,
+    });
+    await page.visit({ courseId: course.id });
+    assert.strictEqual(currentURL(), '/data/courses/1/instructors');
+    assert.strictEqual(page.root.title, 'course 0 2022');
+    assert.strictEqual(page.root.breadcrumb.crumbs.length, 3);
+    assert.strictEqual(page.root.breadcrumb.crumbs[0].text, 'course 0');
+    assert.strictEqual(page.root.breadcrumb.crumbs[0].link, '/courses/1');
+    assert.strictEqual(page.root.breadcrumb.crumbs[1].text, 'Visualizations');
+    assert.strictEqual(page.root.breadcrumb.crumbs[1].link, '/data/courses/1');
+    assert.strictEqual(page.root.breadcrumb.crumbs[2].text, 'Instructors');
+    // wait for charts to load
+    await waitFor('.loaded');
+    await waitFor('svg .bars');
+    assert.strictEqual(page.root.instructorsChart.chart.bars.length, 2);
+    assert.strictEqual(page.root.instructorsChart.chart.labels.length, 2);
+    assert.strictEqual(
+      page.root.instructorsChart.chart.labels[0].text,
+      '1 guy M. Mc1son: 75 Minutes'
+    );
+    assert.strictEqual(
+      page.root.instructorsChart.chart.labels[1].text,
+      '2 guy M. Mc2son: 90 Minutes'
+    );
+  });
+});

--- a/tests/integration/components/course-visualize-instructors-test.js
+++ b/tests/integration/components/course-visualize-instructors-test.js
@@ -13,12 +13,53 @@ module('Integration | Component | course-visualize-instructors', function (hooks
 
   test('it renders', async function (assert) {
     const school = this.server.create('school');
+    const instructor1 = this.server.create('user', { displayName: 'Marie' });
+    const instructor2 = this.server.create('user', { displayName: 'Daisy' });
+    const instructor3 = this.server.create('user', { displayName: 'Duke' });
+    const instructor4 = this.server.create('user', {
+      displayName: 'William',
+    });
     const course = this.server.create('course', { year: 2021, school });
+    const session1 = this.server.create('session', {
+      title: 'Berkeley Investigations',
+      course,
+    });
+    const session2 = this.server.create('session', {
+      title: 'The San Leandro Horror',
+      course,
+    });
+    this.server.create('offering', {
+      session: session1,
+      startDate: new Date('2019-12-08T12:00:00'),
+      endDate: new Date('2019-12-08T17:00:00'),
+      instructors: [instructor1],
+    });
+    this.server.create('offering', {
+      session: session1,
+      startDate: new Date('2019-12-21T12:00:00'),
+      endDate: new Date('2019-12-21T17:30:00'),
+      instructors: [instructor1, instructor4],
+    });
+    this.server.create('offering', {
+      session: session2,
+      startDate: new Date('2019-12-05T18:00:00'),
+      endDate: new Date('2019-12-05T21:00:00'),
+      instructors: [instructor1, instructor2, instructor3, instructor4],
+    });
     const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
 
     await render(hbs`<CourseVisualizeInstructors @model={{this.course}} />`);
     assert.strictEqual(component.title, 'course 0 2021');
+    //let the chart animations finish
+    await waitFor('.loaded');
+    await waitFor('svg .bars');
+    assert.strictEqual(component.instructorsChart.chart.bars.length, 4);
+    assert.strictEqual(component.instructorsChart.chart.labels.length, 4);
+    assert.strictEqual(component.instructorsChart.chart.labels[0].text, 'Daisy: 180 Minutes');
+    assert.strictEqual(component.instructorsChart.chart.labels[1].text, 'Duke: 180 Minutes');
+    assert.strictEqual(component.instructorsChart.chart.labels[2].text, 'William: 510 Minutes');
+    assert.strictEqual(component.instructorsChart.chart.labels[3].text, 'Marie: 810 Minutes');
   });
 
   test('filter works', async function (assert) {
@@ -30,7 +71,7 @@ module('Integration | Component | course-visualize-instructors', function (hooks
     this.server.create('offering', {
       session,
       startDate: new Date('2021/03/01'),
-      endDate: new Date('2021/04/01'),
+      endDate: new Date('2021/03/02'),
       instructors: [instructor1, instructor2],
     });
     const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
@@ -42,11 +83,23 @@ module('Integration | Component | course-visualize-instructors', function (hooks
     await waitFor('svg .bars');
 
     assert.strictEqual(component.title, 'course 0 2021');
-    assert.strictEqual(component.chart.bars.length, 2);
-    assert.strictEqual(component.chart.labels.length, 2);
+    assert.strictEqual(component.instructorsChart.chart.bars.length, 2);
+    assert.strictEqual(component.instructorsChart.chart.labels.length, 2);
+    assert.strictEqual(
+      component.instructorsChart.chart.labels[0].text,
+      'foo M. Mc0son: 1440 Minutes'
+    );
+    assert.strictEqual(
+      component.instructorsChart.chart.labels[1].text,
+      'bar M. Mc1son: 1440 Minutes'
+    );
     await component.filter.set('foo');
-    assert.strictEqual(component.chart.bars.length, 1);
-    assert.strictEqual(component.chart.labels.length, 1);
+    assert.strictEqual(component.instructorsChart.chart.bars.length, 1);
+    assert.strictEqual(component.instructorsChart.chart.labels.length, 1);
+    assert.strictEqual(
+      component.instructorsChart.chart.labels[0].text,
+      'foo M. Mc0son: 1440 Minutes'
+    );
   });
 
   test('course year is shown as range if applicable by configuration', async function (assert) {

--- a/tests/integration/components/visualizer-course-instructors-test.js
+++ b/tests/integration/components/visualizer-course-instructors-test.js
@@ -2,9 +2,10 @@ import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
-import { click, render, findAll, waitFor } from '@ember/test-helpers';
+import { render, waitFor } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { component } from 'ilios-common/page-objects/components/visualizer-course-instructors';
 
 module('Integration | Component | visualizer-course-instructors', function (hooks) {
   setupRenderingTest(hooks);
@@ -58,12 +59,12 @@ module('Integration | Component | visualizer-course-instructors', function (hook
     await waitFor('.loaded');
     await waitFor('svg .bars');
 
-    const chartLabels = 'svg .bars text';
-    assert.dom(chartLabels).exists({ count: 4 });
-    assert.dom(findAll(chartLabels)[0]).containsText('Daisy 13.0%');
-    assert.dom(findAll(chartLabels)[1]).containsText('Duke 13.0%');
-    assert.dom(findAll(chartLabels)[2]).containsText('Marie 37.0%');
-    assert.dom(findAll(chartLabels)[3]).containsText('William 37.0%');
+    assert.strictEqual(component.chart.bars.length, 4);
+    assert.strictEqual(component.chart.labels.length, 4);
+    assert.strictEqual(component.chart.labels[0].text, 'Daisy: 180 Minutes');
+    assert.strictEqual(component.chart.labels[1].text, 'Duke: 180 Minutes');
+    assert.strictEqual(component.chart.labels[2].text, 'William: 510 Minutes');
+    assert.strictEqual(component.chart.labels[3].text, 'Marie: 810 Minutes');
   });
 
   test('filter applies', async function (assert) {
@@ -77,9 +78,9 @@ module('Integration | Component | visualizer-course-instructors', function (hook
     await waitFor('.loaded');
     await waitFor('svg .bars');
 
-    const chartLabels = 'svg .bars text';
-    assert.dom(chartLabels).exists({ count: 1 });
-    assert.dom(findAll(chartLabels)[0]).containsText('Marie 37.0%');
+    assert.strictEqual(component.chart.bars.length, 1);
+    assert.strictEqual(component.chart.labels.length, 1);
+    assert.strictEqual(component.chart.labels[0].text, 'Marie: 810 Minutes');
   });
 
   test('it renders as donut chart', async function (assert) {
@@ -92,8 +93,11 @@ module('Integration | Component | visualizer-course-instructors', function (hook
     await waitFor('.loaded');
     await waitFor('svg .slice');
 
-    const chartLabels = 'svg .slice text';
-    assert.dom(chartLabels).exists({ count: 4 });
+    assert.strictEqual(component.chart.slices.length, 4);
+    assert.strictEqual(component.chart.slices[0].text, 'Daisy: 180 Minutes');
+    assert.strictEqual(component.chart.slices[1].text, 'Duke: 180 Minutes');
+    assert.strictEqual(component.chart.slices[2].text, 'William: 510 Minutes');
+    assert.strictEqual(component.chart.slices[3].text, 'Marie: 810 Minutes');
   });
 
   test('on-click transition fires', async function (assert) {
@@ -113,6 +117,6 @@ module('Integration | Component | visualizer-course-instructors', function (hook
     await waitFor('.loaded');
     await waitFor('svg .bars');
 
-    await click('svg .bars rect:nth-of-type(1)');
+    await component.chart.bars[0].click();
   });
 });


### PR DESCRIPTION
this corrects:
- the display number of instructional minutes across the entire course per instructor,
- the calculation of percentage of how much instructional time each instructor, compared against the total sum of instructional time in the given course

it improves:
- the labeling of chart bars: show minutes instead of the less meaningful percentage value