### PR TITLE
reworks course session-types/session-type visualizations

### DIFF
--- a/addon-test-support/ilios-common/page-objects/components/course-visualize-session-type.js
+++ b/addon-test-support/ilios-common/page-objects/components/course-visualize-session-type.js
@@ -1,4 +1,5 @@
 import { attribute, collection, create, text } from 'ember-cli-page-object';
+import sessionTypeChart from './visualizer-course-session-type';
 
 const definition = create({
   scope: '[data-test-course-visualize-session-type]',
@@ -9,6 +10,7 @@ const definition = create({
       link: attribute('href', 'a'),
     }),
   },
+  sessionTypeChart,
 });
 
 export default definition;

--- a/addon-test-support/ilios-common/page-objects/components/course-visualize-session-types.js
+++ b/addon-test-support/ilios-common/page-objects/components/course-visualize-session-types.js
@@ -1,4 +1,5 @@
 import { attribute, collection, create, fillable, text, value } from 'ember-cli-page-object';
+import sessionTypesChart from './visualizer-course-session-types';
 
 const definition = create({
   scope: '[data-test-course-visualize-session-types]',
@@ -14,11 +15,7 @@ const definition = create({
     value: value('input'),
     set: fillable('input'),
   },
-  chart: {
-    scope: '.simple-chart-horz-bar',
-    bars: collection('.bars rect'),
-    labels: collection('.bars text'),
-  },
+  sessionTypesChart,
 });
 
 export default definition;

--- a/addon-test-support/ilios-common/page-objects/components/visualizer-course-session-type.js
+++ b/addon-test-support/ilios-common/page-objects/components/visualizer-course-session-type.js
@@ -1,0 +1,14 @@
+import { collection, create, notHasClass } from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-visualizer-course-session-type]',
+  isIcon: notHasClass('no-icon'),
+  chart: {
+    scope: '.simple-chart',
+    bars: collection('.bars rect'),
+    labels: collection('.bars text'),
+  },
+};
+
+export default definition;
+export const component = create(definition);

--- a/addon-test-support/ilios-common/page-objects/components/visualizer-course-session-types.js
+++ b/addon-test-support/ilios-common/page-objects/components/visualizer-course-session-types.js
@@ -1,0 +1,15 @@
+import { collection, create, notHasClass } from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-visualizer-course-session-types]',
+  isIcon: notHasClass('no-icon'),
+  chart: {
+    scope: '.simple-chart',
+    bars: collection('.bars rect'),
+    labels: collection('.bars text'),
+    slices: collection('svg .slice'),
+  },
+};
+
+export default definition;
+export const component = create(definition);

--- a/addon-test-support/ilios-common/page-objects/course-visualizations-session-type.js
+++ b/addon-test-support/ilios-common/page-objects/course-visualizations-session-type.js
@@ -1,0 +1,7 @@
+import { create, visitable } from 'ember-cli-page-object';
+import root from './components/course-visualize-session-type';
+
+export default create({
+  visit: visitable('/data/courses/:courseId/session-types/:sessionTypeId'),
+  root,
+});

--- a/addon-test-support/ilios-common/page-objects/course-visualizations-session-types.js
+++ b/addon-test-support/ilios-common/page-objects/course-visualizations-session-types.js
@@ -1,0 +1,7 @@
+import { create, visitable } from 'ember-cli-page-object';
+import root from './components/course-visualize-session-types';
+
+export default create({
+  visit: visitable('/data/courses/:courseId/session-types'),
+  root,
+});

--- a/addon/components/course-visualize-session-types.hbs
+++ b/addon/components/course-visualize-session-types.hbs
@@ -1,47 +1,44 @@
 <section
   class="course-visualize-session-types"
   data-test-course-visualize-session-types
-  {{did-insert (perform this.load)}}
 >
-  {{#unless this.load.isRunning}}
-    <div class="breadcrumbs" data-test-breadcrumb>
-      <span>
-        <LinkTo @route="course" @model={{@model}}>
-          {{@model.title}}
-        </LinkTo>
-      </span>
-      <span>
-        <LinkTo @route="course-visualizations" @model={{@model}}>
-          {{t "general.visualizations"}}
-        </LinkTo>
-      </span>
-      <span>
-        {{t "general.sessionTypes"}}
-      </span>
-    </div>
-    <h2>
-      {{t "general.sessionTypes"}}
-    </h2>
-    <h3 class="clickable" data-test-title>
+  <div class="breadcrumbs" data-test-breadcrumb>
+    <span>
       <LinkTo @route="course" @model={{@model}}>
         {{@model.title}}
-        {{#if this.academicYearCrossesCalendarYearBoundaries}}
-          {{@model.year}} - {{add @model.year 1}}
-        {{else}}
-          {{@model.year}}
-        {{/if}}
       </LinkTo>
-    </h3>
-    <div class="filter" data-test-filter>
-      <input
-        aria-label={{t "general.filterChartPlaceholder"}}
-        autocomplete="off"
-        type="search"
-        value={{this.title}}
-        placeholder={{t "general.filterPlaceholder"}}
-        {{on "input" (pick "target.value" (set this.title))}}
-      >
-    </div>
-    <VisualizerCourseSessionTypes @filter={{this.title}} @course={{@model}} />
-  {{/unless}}
+    </span>
+    <span>
+      <LinkTo @route="course-visualizations" @model={{@model}}>
+        {{t "general.visualizations"}}
+      </LinkTo>
+    </span>
+    <span>
+      {{t "general.sessionTypes"}}
+    </span>
+  </div>
+  <h2>
+    {{t "general.sessionTypes"}}
+  </h2>
+  <h3 class="clickable" data-test-title>
+    <LinkTo @route="course" @model={{@model}}>
+      {{@model.title}}
+      {{#if this.academicYearCrossesCalendarYearBoundaries}}
+        {{@model.year}} - {{add @model.year 1}}
+      {{else}}
+        {{@model.year}}
+      {{/if}}
+    </LinkTo>
+  </h3>
+  <div class="filter" data-test-filter>
+    <input
+      aria-label={{t "general.filterChartPlaceholder"}}
+      autocomplete="off"
+      type="search"
+      value={{this.title}}
+      placeholder={{t "general.filterPlaceholder"}}
+      {{on "input" (pick "target.value" (set this.title))}}
+    >
+  </div>
+  <VisualizerCourseSessionTypes @filter={{this.title}} @course={{@model}} />
 </section>

--- a/addon/components/course-visualize-session-types.js
+++ b/addon/components/course-visualize-session-types.js
@@ -1,16 +1,12 @@
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
-import { restartableTask } from 'ember-concurrency';
+import { use } from 'ember-could-get-used-to-this';
+import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 
 export default class CourseVisualizeSessionTypesComponent extends Component {
   @service iliosConfig;
-  @tracked academicYearCrossesCalendarYearBoundaries = false;
 
-  @restartableTask
-  *load() {
-    this.academicYearCrossesCalendarYearBoundaries = yield this.iliosConfig.itemFromConfig(
-      'academicYearCrossesCalendarYearBoundaries'
-    );
-  }
+  @use academicYearCrossesCalendarYearBoundaries = new ResolveAsyncValue(() => [
+    this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries'),
+  ]);
 }

--- a/addon/components/visualizer-course-session-type.hbs
+++ b/addon/components/visualizer-course-session-type.hbs
@@ -1,5 +1,7 @@
 <div
   class="visualizer-course-session-type {{unless @isIcon "not-icon"}}"
+  data-test-visualizer-course-session-type
+  ...attributes
 >
   {{#if this.isLoaded}}
     {{#if (or @isIcon this.data.length)}}

--- a/addon/components/visualizer-course-session-types.hbs
+++ b/addon/components/visualizer-course-session-types.hbs
@@ -1,22 +1,22 @@
 <div
   class="visualizer-course-session-types {{unless @isIcon "not-icon"}}"
+  data-test-visualizer-course-session-types
+  ...attributes
 >
-  {{#if this.isLoaded}}
-    {{#if (or @isIcon this.data.length)}}
-      <SimpleChart
-        @name={{this.chartType}}
-        @isIcon={{@isIcon}}
-        @data={{this.filteredData}}
-        @onClick={{this.barClick}}
-        @hover={{perform this.barHover}}
-        @leave={{perform this.barHover}} as |chart|
-      >
-        {{#if this.tooltipContent}}
-          <chart.tooltip @title={{this.tooltipTitle}}>
-            {{this.tooltipContent}}
-          </chart.tooltip>
-        {{/if}}
-      </SimpleChart>
-    {{/if}}
+  {{#if (or @isIcon this.data.length)}}
+    <SimpleChart
+      @name={{this.chartType}}
+      @isIcon={{@isIcon}}
+      @data={{this.filteredData}}
+      @onClick={{this.barClick}}
+      @hover={{perform this.barHover}}
+      @leave={{perform this.barHover}} as |chart|
+    >
+      {{#if this.tooltipContent}}
+        <chart.tooltip @title={{this.tooltipTitle}}>
+          {{this.tooltipContent}}
+        </chart.tooltip>
+      {{/if}}
+    </SimpleChart>
   {{/if}}
 </div>

--- a/addon/components/visualizer-course-session-types.js
+++ b/addon/components/visualizer-course-session-types.js
@@ -88,7 +88,7 @@ export default class VisualizerCourseSessionTypes extends Component {
     return mappedSessionTypes
       .map((obj) => {
         const percent = ((obj.data / totalMinutes) * 100).toFixed(1);
-        obj.label = `${obj.meta.sessionType} ${percent}%`;
+        obj.label = `${obj.meta.sessionType}: ${obj.data} ${this.intl.t('general.minutes')}`;
         obj.meta.totalMinutes = totalMinutes;
         obj.meta.percent = percent;
         return obj;
@@ -106,9 +106,9 @@ export default class VisualizerCourseSessionTypes extends Component {
       this.tooltipContent = null;
       return;
     }
-    const { label, data, meta } = obj;
+    const { label, meta } = obj;
 
-    const title = htmlSafe(`${label} ${data} ${this.intl.t('general.minutes')}`);
+    const title = htmlSafe(label);
     const sessions = meta.sessions.uniq().sort().join(', ');
 
     this.tooltipTitle = title;

--- a/addon/components/visualizer-course-session-types.js
+++ b/addon/components/visualizer-course-session-types.js
@@ -5,10 +5,10 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { cleanQuery } from 'ilios-common/utils/query-utils';
-
+import { map } from 'rsvp';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
-import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
+import AsyncProcess from 'ilios-common/classes/async-process';
 
 export default class VisualizerCourseSessionTypes extends Component {
   @service router;
@@ -17,11 +17,7 @@ export default class VisualizerCourseSessionTypes extends Component {
   @tracked tooltipTitle = null;
 
   @use sessions = new ResolveAsyncValue(() => [this.args.course.sessions]);
-  @use sessionTypes = new ResolveFlatMapBy(() => [this.sessions, 'sessionType']);
-
-  get isLoaded() {
-    return !!this.sessionTypes;
-  }
+  @use loadedData = new AsyncProcess(() => [this.getData.bind(this), this.sessions]);
 
   get chartType() {
     return this.args.chartType || 'horz-bar';
@@ -31,7 +27,6 @@ export default class VisualizerCourseSessionTypes extends Component {
     if (!this.data) {
       return [];
     }
-
     let data = this.data;
     const q = cleanQuery(this.args.filter);
     if (q) {
@@ -44,9 +39,21 @@ export default class VisualizerCourseSessionTypes extends Component {
   }
 
   get data() {
-    const dataMap = this.sessions.map((session) => {
-      const minutes = Math.round(session.totalSumDuration * 60);
-      const sessionType = this.sessionTypes.findBy('id', session.belongsTo('sessionType').id());
+    if (!this.loadedData) {
+      return [];
+    }
+    return this.loadedData;
+  }
+
+  async getData(sessions) {
+    if (!sessions) {
+      return [];
+    }
+
+    const dataMap = await map(sessions.toArray(), async (session) => {
+      const hours = await session.getTotalSumDuration();
+      const minutes = Math.round(hours * 60);
+      const sessionType = await session.sessionType;
       return {
         sessionTitle: session.title,
         sessionTypeTitle: sessionType.title,

--- a/addon/routes/course-visualize-session-types.js
+++ b/addon/routes/course-visualize-session-types.js
@@ -1,6 +1,6 @@
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
-import { all, map } from 'rsvp';
+import { map } from 'rsvp';
 
 export default class CourseVisualizeSessionTypesRoute extends Route {
   @service session;
@@ -15,10 +15,7 @@ export default class CourseVisualizeSessionTypesRoute extends Route {
 
   async afterModel(course) {
     const sessions = (await course.sessions).toArray();
-    return await all([
-      map(sessions.toArray(), (s) => s.sessionType),
-      map(sessions.toArray(), (s) => s.totalSumDuration),
-    ]);
+    return await map(sessions.toArray(), (s) => s.sessionType);
   }
 
   beforeModel(transition) {

--- a/tests/acceptance/course-visualizations-session-type-test.js
+++ b/tests/acceptance/course-visualizations-session-type-test.js
@@ -1,0 +1,86 @@
+import { module, test } from 'qunit';
+import { currentURL, waitFor } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import page from 'ilios-common/page-objects/course-visualizations-session-type';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setupAuthentication } from 'ilios-common';
+import { DateTime } from 'luxon';
+
+module('Acceptance | course visualizations - session-type', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  hooks.beforeEach(async function () {
+    this.user = await setupAuthentication();
+  });
+
+  test('it renders', async function (assert) {
+    const sessionType = this.server.create('sessionType');
+    const vocabulary1 = this.server.create('vocabulary');
+    const vocabulary2 = this.server.create('vocabulary');
+    const term1 = this.server.create('term', {
+      vocabulary: vocabulary1,
+    });
+    const term2 = this.server.create('term', {
+      vocabulary: vocabulary1,
+    });
+    const term3 = this.server.create('term', {
+      vocabulary: vocabulary2,
+    });
+    const session1 = this.server.create('session', {
+      sessionType,
+      terms: [term1],
+    });
+    const session2 = this.server.create('session', {
+      sessionType,
+      terms: [term2, term3],
+    });
+    const session3 = this.server.create('session', sessionType);
+    this.server.create('ilmSession', {
+      session: session3,
+      hours: 2,
+    });
+    this.server.create('offering', {
+      startDate: DateTime.fromISO('2022-07-20T09:00:00').toJSDate(),
+      endDate: DateTime.fromISO('2022-07-20T10:00:00').toJSDate(),
+      session: session1,
+    });
+    this.server.create('offering', {
+      startDate: DateTime.fromISO('2022-07-20T09:00:00').toJSDate(),
+      endDate: DateTime.fromISO('2022-07-20T09:30:00').toJSDate(),
+      session: session2,
+    });
+    const course = this.server.create('course', {
+      sessions: [session1, session2, session3],
+      year: 2022,
+    });
+    await page.visit({ courseId: course.id, sessionTypeId: sessionType.id });
+    assert.strictEqual(currentURL(), '/data/courses/1/session-types/1');
+    assert.strictEqual(page.root.title, 'course 0 2022');
+    assert.strictEqual(page.root.breadcrumb.crumbs.length, 4);
+    assert.strictEqual(page.root.breadcrumb.crumbs[0].text, 'course 0');
+    assert.strictEqual(page.root.breadcrumb.crumbs[0].link, '/courses/1');
+    assert.strictEqual(page.root.breadcrumb.crumbs[1].text, 'Visualizations');
+    assert.strictEqual(page.root.breadcrumb.crumbs[1].link, '/data/courses/1');
+    assert.strictEqual(page.root.breadcrumb.crumbs[2].text, 'Session Types');
+    assert.strictEqual(page.root.breadcrumb.crumbs[2].link, '/data/courses/1/session-types');
+    assert.strictEqual(page.root.breadcrumb.crumbs[3].text, 'session type 0');
+    // wait for charts to load
+    await waitFor('.loaded');
+    await waitFor('svg .bars');
+    assert.strictEqual(page.root.title, 'course 0 2022');
+    assert.strictEqual(page.root.sessionTypeChart.chart.bars.length, 3);
+    assert.strictEqual(page.root.sessionTypeChart.chart.labels.length, 3);
+    assert.strictEqual(
+      page.root.sessionTypeChart.chart.labels[0].text,
+      'Vocabulary 1 - term 1: 30 Minutes'
+    );
+    assert.strictEqual(
+      page.root.sessionTypeChart.chart.labels[1].text,
+      'Vocabulary 1 - term 0: 60 Minutes'
+    );
+    assert.strictEqual(
+      page.root.sessionTypeChart.chart.labels[2].text,
+      'Vocabulary 2 - term 2: 30 Minutes'
+    );
+  });
+});

--- a/tests/acceptance/course-visualizations-session-types-test.js
+++ b/tests/acceptance/course-visualizations-session-types-test.js
@@ -1,0 +1,88 @@
+import { module, test } from 'qunit';
+import { currentURL, waitFor } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import page from 'ilios-common/page-objects/course-visualizations-session-types';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setupAuthentication } from 'ilios-common';
+import { DateTime } from 'luxon';
+
+module('Acceptance | course visualizations - session-types', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  hooks.beforeEach(async function () {
+    this.user = await setupAuthentication();
+  });
+
+  test('it renders', async function (assert) {
+    const sessionType1 = this.server.create('sessionType');
+    const sessionType2 = this.server.create('sessionType');
+    const sessionType3 = this.server.create('sessionType');
+    const vocabulary1 = this.server.create('vocabulary');
+    const vocabulary2 = this.server.create('vocabulary');
+    const term1 = this.server.create('term', {
+      vocabulary: vocabulary1,
+    });
+    const term2 = this.server.create('term', {
+      vocabulary: vocabulary1,
+    });
+    const term3 = this.server.create('term', {
+      vocabulary: vocabulary2,
+    });
+    const session1 = this.server.create('session', {
+      sessionType: sessionType1,
+      terms: [term1],
+    });
+    const session2 = this.server.create('session', {
+      sessionType: sessionType2,
+      terms: [term2, term3],
+    });
+    const session3 = this.server.create('session', {
+      sessionType: sessionType3,
+    });
+    this.server.create('ilmSession', {
+      session: session3,
+      hours: 2,
+    });
+    this.server.create('offering', {
+      startDate: DateTime.fromISO('2022-07-20T09:00:00').toJSDate(),
+      endDate: DateTime.fromISO('2022-07-20T10:00:00').toJSDate(),
+      session: session1,
+    });
+    this.server.create('offering', {
+      startDate: DateTime.fromISO('2022-07-20T09:00:00').toJSDate(),
+      endDate: DateTime.fromISO('2022-07-20T09:30:00').toJSDate(),
+      session: session2,
+    });
+    const course = this.server.create('course', {
+      sessions: [session1, session2, session3],
+      year: 2022,
+    });
+    await page.visit({ courseId: course.id });
+    assert.strictEqual(currentURL(), '/data/courses/1/session-types');
+    assert.strictEqual(page.root.title, 'course 0 2022');
+    assert.strictEqual(page.root.breadcrumb.crumbs.length, 3);
+    assert.strictEqual(page.root.breadcrumb.crumbs[0].text, 'course 0');
+    assert.strictEqual(page.root.breadcrumb.crumbs[0].link, '/courses/1');
+    assert.strictEqual(page.root.breadcrumb.crumbs[1].text, 'Visualizations');
+    assert.strictEqual(page.root.breadcrumb.crumbs[1].link, '/data/courses/1');
+    assert.strictEqual(page.root.breadcrumb.crumbs[2].text, 'Session Types');
+    // wait for charts to load
+    await waitFor('.loaded');
+    await waitFor('svg .bars');
+    assert.strictEqual(page.root.title, 'course 0 2022');
+    assert.strictEqual(page.root.sessionTypesChart.chart.bars.length, 3);
+    assert.strictEqual(page.root.sessionTypesChart.chart.labels.length, 3);
+    assert.strictEqual(
+      page.root.sessionTypesChart.chart.labels[0].text,
+      'session type 1: 30 Minutes'
+    );
+    assert.strictEqual(
+      page.root.sessionTypesChart.chart.labels[1].text,
+      'session type 0: 60 Minutes'
+    );
+    assert.strictEqual(
+      page.root.sessionTypesChart.chart.labels[2].text,
+      'session type 2: 120 Minutes'
+    );
+  });
+});

--- a/tests/integration/components/course-visualize-session-types-test.js
+++ b/tests/integration/components/course-visualize-session-types-test.js
@@ -54,6 +54,13 @@ module('Integration | Component | course-visualize-session-types', function (hoo
     this.set('course', this.courseModel);
     await render(hbs`<CourseVisualizeSessionTypes @model={{this.course}} />`);
     assert.strictEqual(component.title, 'course 0 2021');
+    assert.strictEqual(component.title, 'course 0 2021');
+    await waitFor('.loaded');
+    await waitFor('svg .bars');
+    assert.strictEqual(component.sessionTypesChart.chart.bars.length, 2);
+    assert.strictEqual(component.sessionTypesChart.chart.labels.length, 2);
+    assert.strictEqual(component.sessionTypesChart.chart.labels[0].text, 'Campaign: 180 Minutes');
+    assert.strictEqual(component.sessionTypesChart.chart.labels[1].text, 'Standalone: 630 Minutes');
   });
 
   test('course year is shown as range if applicable by configuration', async function (assert) {
@@ -74,12 +81,16 @@ module('Integration | Component | course-visualize-session-types', function (hoo
     await render(hbs`<CourseVisualizeSessionTypes @model={{this.course}} />`);
     //let the chart animations finish
     await waitFor('.loaded');
+    await waitFor('svg .bars');
     assert.strictEqual(component.title, 'course 0 2021');
-    assert.strictEqual(component.chart.bars.length, 2);
-    assert.strictEqual(component.chart.labels.length, 2);
+    assert.strictEqual(component.sessionTypesChart.chart.bars.length, 2);
+    assert.strictEqual(component.sessionTypesChart.chart.labels.length, 2);
+    assert.strictEqual(component.sessionTypesChart.chart.labels[0].text, 'Campaign: 180 Minutes');
+    assert.strictEqual(component.sessionTypesChart.chart.labels[1].text, 'Standalone: 630 Minutes');
     await component.filter.set('Campaign');
-    assert.strictEqual(component.chart.bars.length, 1);
-    assert.strictEqual(component.chart.labels.length, 1);
+    assert.strictEqual(component.sessionTypesChart.chart.bars.length, 1);
+    assert.strictEqual(component.sessionTypesChart.chart.labels.length, 1);
+    assert.strictEqual(component.sessionTypesChart.chart.labels[0].text, 'Campaign: 180 Minutes');
   });
 
   test('breadcrumb', async function (assert) {

--- a/tests/integration/components/visualizer-course-session-type-test.js
+++ b/tests/integration/components/visualizer-course-session-type-test.js
@@ -1,9 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
-import { render, findAll, waitFor } from '@ember/test-helpers';
+import { render, waitFor } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { component } from 'ilios-common/page-objects/components/visualizer-course-session-type';
 
 module('Integration | Component | visualizer-course-session-type', function (hooks) {
   setupRenderingTest(hooks);
@@ -11,7 +12,6 @@ module('Integration | Component | visualizer-course-session-type', function (hoo
   setupMirage(hooks);
 
   test('it renders', async function (assert) {
-    assert.expect(3);
     const vocabulary1 = this.server.create('vocabulary');
     const vocabulary2 = this.server.create('vocabulary');
     const term1 = this.server.create('term', {
@@ -67,9 +67,9 @@ module('Integration | Component | visualizer-course-session-type', function (hoo
     await waitFor('.loaded');
     await waitFor('svg .bars');
 
-    const chartLabels = 'svg .bars text';
-    assert.dom(chartLabels).exists({ count: 2 });
-    assert.dom(findAll(chartLabels)[0]).hasText('Vocabulary 1 - Standalone 77.8%');
-    assert.dom(findAll(chartLabels)[1]).hasText('Vocabulary 2 - Campaign 22.2%');
+    assert.strictEqual(component.chart.bars.length, 2);
+    assert.strictEqual(component.chart.labels.length, 2);
+    assert.strictEqual(component.chart.labels[0].text, 'Vocabulary 1 - Standalone: 630 Minutes');
+    assert.strictEqual(component.chart.labels[1].text, 'Vocabulary 2 - Campaign: 180 Minutes');
   });
 });

--- a/tests/integration/components/visualizer-course-session-types-test.js
+++ b/tests/integration/components/visualizer-course-session-types-test.js
@@ -58,8 +58,8 @@ module('Integration | Component | visualizer-course-session-types', function (ho
 
     assert.strictEqual(component.chart.bars.length, 2);
     assert.strictEqual(component.chart.labels.length, 2);
-    assert.strictEqual(component.chart.labels[0].text, 'Campaign 22.2%');
-    assert.strictEqual(component.chart.labels[1].text, 'Standalone 77.8%');
+    assert.strictEqual(component.chart.labels[0].text, 'Campaign: 180 Minutes');
+    assert.strictEqual(component.chart.labels[1].text, 'Standalone: 630 Minutes');
   });
 
   test('it renders as donut chart', async function (assert) {
@@ -73,8 +73,8 @@ module('Integration | Component | visualizer-course-session-types', function (ho
     await waitFor('svg .slice');
 
     assert.strictEqual(component.chart.slices.length, 2);
-    assert.strictEqual(component.chart.slices[0].text, 'Campaign 22.2%');
-    assert.strictEqual(component.chart.slices[1].text, 'Standalone 77.8%');
+    assert.strictEqual(component.chart.slices[0].text, 'Campaign: 180 Minutes');
+    assert.strictEqual(component.chart.slices[1].text, 'Standalone: 630 Minutes');
   });
 
   test('filter applies', async function (assert) {
@@ -90,6 +90,6 @@ module('Integration | Component | visualizer-course-session-types', function (ho
 
     assert.strictEqual(component.chart.bars.length, 1);
     assert.strictEqual(component.chart.labels.length, 1);
-    assert.strictEqual(component.chart.labels[0].text, 'Campaign 22.2%');
+    assert.strictEqual(component.chart.labels[0].text, 'Campaign: 180 Minutes');
   });
 });

--- a/tests/integration/components/visualizer-course-session-types-test.js
+++ b/tests/integration/components/visualizer-course-session-types-test.js
@@ -1,9 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
-import { findAll, render, waitFor } from '@ember/test-helpers';
+import { render, waitFor } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { component } from 'ilios-common/page-objects/components/visualizer-course-session-types';
 
 module('Integration | Component | visualizer-course-session-types', function (hooks) {
   setupRenderingTest(hooks);
@@ -48,8 +49,6 @@ module('Integration | Component | visualizer-course-session-types', function (ho
   });
 
   test('it renders as bar chart by default', async function (assert) {
-    assert.expect(3);
-
     this.set('course', this.courseModel);
 
     await render(hbs`<VisualizerCourseSessionTypes @course={{this.course}} @isIcon={{false}} />`);
@@ -57,15 +56,13 @@ module('Integration | Component | visualizer-course-session-types', function (ho
     await waitFor('.loaded');
     await waitFor('svg .bars');
 
-    const chartLabels = 'svg .bars text';
-    assert.dom(chartLabels).exists({ count: 2 });
-    assert.dom(findAll(chartLabels)[0]).hasText('Campaign 22.2%');
-    assert.dom(findAll(chartLabels)[1]).hasText('Standalone 77.8%');
+    assert.strictEqual(component.chart.bars.length, 2);
+    assert.strictEqual(component.chart.labels.length, 2);
+    assert.strictEqual(component.chart.labels[0].text, 'Campaign 22.2%');
+    assert.strictEqual(component.chart.labels[1].text, 'Standalone 77.8%');
   });
 
   test('it renders as donut chart', async function (assert) {
-    assert.expect(3);
-
     this.set('course', this.courseModel);
 
     await render(
@@ -75,10 +72,9 @@ module('Integration | Component | visualizer-course-session-types', function (ho
     await waitFor('.loaded');
     await waitFor('svg .slice');
 
-    const chartLabels = 'svg .slice text';
-    assert.dom(chartLabels).exists({ count: 2 });
-    assert.dom(findAll(chartLabels)[0]).hasText('Campaign 22.2%');
-    assert.dom(findAll(chartLabels)[1]).hasText('Standalone 77.8%');
+    assert.strictEqual(component.chart.slices.length, 2);
+    assert.strictEqual(component.chart.slices[0].text, 'Campaign 22.2%');
+    assert.strictEqual(component.chart.slices[1].text, 'Standalone 77.8%');
   });
 
   test('filter applies', async function (assert) {
@@ -91,8 +87,9 @@ module('Integration | Component | visualizer-course-session-types', function (ho
     //let the chart animations finish
     await waitFor('.loaded');
     await waitFor('svg .bars');
-    const chartLabels = 'svg .bars text';
-    assert.dom(chartLabels).exists({ count: 1 });
-    assert.dom(findAll(chartLabels)[0]).hasText('Campaign 22.2%');
+
+    assert.strictEqual(component.chart.bars.length, 1);
+    assert.strictEqual(component.chart.labels.length, 1);
+    assert.strictEqual(component.chart.labels[0].text, 'Campaign 22.2%');
   });
 });


### PR DESCRIPTION
- replace any invocations of Resources outside of `@use` with async methods
- improves chart labeling by dropping meaningless percentage from the bars
- fleshes out test coverage