### PR TITLE
Allow users to track material status

### DIFF
--- a/addon-mirage-support/get-name.js
+++ b/addon-mirage-support/get-name.js
@@ -34,6 +34,7 @@ var models = [
   'sessionObjectives',
   'sessionTypes',
   'userRoles',
+  'userSessionMaterialStatuses',
 ];
 export default function getName(string) {
   var camelString = models.find(function (item) {

--- a/addon-mirage-support/routes.js
+++ b/addon-mirage-support/routes.js
@@ -64,6 +64,7 @@ export default function (server) {
     { route: 'pendinguserupdates/', name: 'pendingUserUpdate' },
     { route: 'programyears/', name: 'programYear' },
     { route: 'users/', name: 'user' },
+    { route: 'usersessionmaterialstatuses/', name: 'userSessionMaterialStatus' },
   ];
 
   models.forEach((obj) => {

--- a/addon-test-support/ilios-common/page-objects/components/dashboard/materials.js
+++ b/addon-test-support/ilios-common/page-objects/components/dashboard/materials.js
@@ -14,6 +14,7 @@ import {
 import dashboardViewPicker from './view-picker';
 import controls from '../pagedlist-controls';
 import displayToggle from '../toggle-buttons';
+import status from '../user-material-status';
 
 const definition = {
   scope: '[data-test-dashboard-materials]',
@@ -50,31 +51,31 @@ const definition = {
     headers: {
       scope: 'thead',
       sessionTitle: {
-        scope: 'th:nth-of-type(1)',
-        isSortedAscending: hasClass('fa-arrow-down-a-z', 'svg'),
-        isSortedDescending: hasClass('fa-arrow-down-z-a', 'svg'),
-        isSortedOn: notHasClass('fa-sort', 'svg'),
-        click: clickable('button'),
-      },
-      courseTitle: {
         scope: 'th:nth-of-type(2)',
         isSortedAscending: hasClass('fa-arrow-down-a-z', 'svg'),
         isSortedDescending: hasClass('fa-arrow-down-z-a', 'svg'),
         isSortedOn: notHasClass('fa-sort', 'svg'),
         click: clickable('button'),
       },
-      title: {
+      courseTitle: {
         scope: 'th:nth-of-type(3)',
         isSortedAscending: hasClass('fa-arrow-down-a-z', 'svg'),
         isSortedDescending: hasClass('fa-arrow-down-z-a', 'svg'),
         isSortedOn: notHasClass('fa-sort', 'svg'),
         click: clickable('button'),
       },
-      instructor: {
+      title: {
         scope: 'th:nth-of-type(4)',
+        isSortedAscending: hasClass('fa-arrow-down-a-z', 'svg'),
+        isSortedDescending: hasClass('fa-arrow-down-z-a', 'svg'),
+        isSortedOn: notHasClass('fa-sort', 'svg'),
+        click: clickable('button'),
+      },
+      instructor: {
+        scope: 'th:nth-of-type(5)',
       },
       firstOfferingDate: {
-        scope: 'th:nth-of-type(5)',
+        scope: 'th:nth-of-type(6)',
         isSortedAscending: hasClass('fa-arrow-down-1-9', 'svg'),
         isSortedDescending: hasClass('fa-arrow-down-9-1', 'svg'),
         isSortedOn: notHasClass('fa-sort', 'svg'),
@@ -82,6 +83,7 @@ const definition = {
       },
     },
     rows: collection('[data-test-learning-material]', {
+      status,
       sessionTitle: text('[data-test-session-title]'),
       courseTitle: text('[data-test-course-title]'),
       title: text('[data-test-title]'),

--- a/addon-test-support/ilios-common/page-objects/components/user-material-status.js
+++ b/addon-test-support/ilios-common/page-objects/components/user-material-status.js
@@ -1,0 +1,10 @@
+import { create, property } from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-user-material-status]',
+  isChecked: property('checked', 'input'),
+  isIndeterminate: property('indeterminate', 'input'),
+};
+
+export default definition;
+export const component = create(definition);

--- a/addon-test-support/ilios-common/page-objects/components/user-material-status.js
+++ b/addon-test-support/ilios-common/page-objects/components/user-material-status.js
@@ -5,6 +5,7 @@ const definition = {
   isChecked: property('checked', 'input'),
   isIndeterminate: property('indeterminate', 'input'),
   click: clickable('input'),
+  isDisabled: property('disabled', 'input'),
 };
 
 export default definition;

--- a/addon-test-support/ilios-common/page-objects/components/user-material-status.js
+++ b/addon-test-support/ilios-common/page-objects/components/user-material-status.js
@@ -1,9 +1,10 @@
-import { create, property } from 'ember-cli-page-object';
+import { clickable, create, property } from 'ember-cli-page-object';
 
 const definition = {
   scope: '[data-test-user-material-status]',
   isChecked: property('checked', 'input'),
   isIndeterminate: property('indeterminate', 'input'),
+  click: clickable('input'),
 };
 
 export default definition;

--- a/addon/components/dashboard/materials.hbs
+++ b/addon/components/dashboard/materials.hbs
@@ -67,8 +67,9 @@
       <table>
         <thead>
           <tr>
+            <th></th>
             <SortableTh
-              @colspan={{3}}
+              @colspan={{6}}
               @sortedAscending={{this.sortedAscending}}
               @sortedBy={{or
               (eq @sortBy "sessionTitle")
@@ -79,7 +80,7 @@
               {{t "general.session"}}
             </SortableTh>
             <SortableTh
-              @colspan={{3}}
+              @colspan={{6}}
               @sortedAscending={{this.sortedAscending}}
               @sortedBy={{or
               (eq @sortBy "courseTitle")
@@ -90,18 +91,18 @@
               {{t "general.course"}}
             </SortableTh>
             <SortableTh
-              @colspan={{3}}
+              @colspan={{6}}
               @sortedAscending={{this.sortedAscending}}
               @sortedBy={{or (eq @sortBy "title") (eq @sortBy "title:desc")}}
               @onClick={{fn this.sortBy "title"}}
             >
               {{t "general.title"}}
             </SortableTh>
-            <th class="hide-from-small-screen">
+            <th colspan="4" class="hide-from-small-screen">
               {{t "general.instructor"}}
             </th>
             <SortableTh
-              @colspan={{1}}
+              @colspan={{4}}
               @sortedAscending={{this.sortedAscending}}
               @sortedBy={{or
               (eq @sortBy "firstOfferingDate")
@@ -118,13 +119,16 @@
           {{#if this.materialsLoaded}}
             {{#each this.filteredMaterials as |lmObject|}}
               <tr data-test-learning-material>
-                <td colspan="3" data-test-session-title>
+                <td>
+                  <UserMaterialStatus @learningMaterial={{lmObject}} />
+                </td>
+                <td colspan="6" data-test-session-title>
                   {{lmObject.sessionTitle}}
                 </td>
-                <td colspan="3" data-test-course-title>
+                <td colspan="6" data-test-course-title>
                   {{lmObject.courseTitle}}
                 </td>
-                <td colspan="3" data-test-title>
+                <td colspan="6" data-test-title>
                   {{#if lmObject.isBlanked}}
                     <span class="lm-type-icon">
                       <FaIcon @icon="clock" @title={{t "general.timedRelease"}} data-test-is-blanked />
@@ -188,7 +192,7 @@
                     {{/if}}
                   {{/if}}
                 </td>
-                <td class="hide-from-small-screen" colspan="1" data-test-instructors>
+                <td class="hide-from-small-screen" colspan="4" data-test-instructors>
                   <TruncateText
                     @length={{25}}
                     @text={{join
@@ -197,7 +201,7 @@
                   }}
                   />
                 </td>
-                <td data-test-date>
+                <td colspan="4" data-test-date>
                   {{#if lmObject.firstOfferingDate}}
                     {{format-date lmObject.firstOfferingDate}}
                   {{else}}
@@ -207,14 +211,14 @@
               </tr>
             {{else}}
               <tr>
-                <td colspan="11" class="no-results" data-test-none>
+                <td colspan="27" class="no-results" data-test-none>
                   {{t "general.none"}}
                 </td>
               </tr>
             {{/each}}
           {{else}}
             <tr>
-              <td class="text-center" colspan="11">
+              <td class="text-center" colspan="27">
                 <FaIcon @icon="spinner" class="orange" @size="2x" @spin={{true}} />
               </td>
             </tr>

--- a/addon/components/single-event-learningmaterial-list-item.hbs
+++ b/addon/components/single-event-learningmaterial-list-item.hbs
@@ -23,6 +23,7 @@
       </div>
     {{else}}
       <div class="single-event-learningmaterial-item-title">
+        <UserMaterialStatus @learningMaterial={{@learningMaterial}} />
         <LmIcons @learningMaterial={{@learningMaterial}} />
         <span data-test-title>
           {{#if @linked}}

--- a/addon/components/user-material-status.hbs
+++ b/addon/components/user-material-status.hbs
@@ -1,0 +1,32 @@
+{{#if this.isSessionLearningMaterial}}
+  <span data-test-user-material-status>
+    {{#if this.isStatusLoaded}}
+      {{#if (eq this.status 0)}}
+        <input
+          aria-label={{t "general.notStarted"}}
+          type="checkbox"
+          disabled={{this.setStatus.isRunning}}
+          {{on "click" (perform this.setStatus 1)}}
+        >
+      {{else if (eq this.status 1)}}
+        <input
+          aria-label={{t "general.inProgress"}}
+          indeterminate={{true}}
+          type="checkbox"
+          disabled={{this.setStatus.isRunning}}
+          {{on "click" (perform this.setStatus 2)}}
+        >
+      {{else if (eq this.status 2)}}
+        <input
+          aria-label={{t "general.complete"}}
+          checked={{true}}
+          type="checkbox"
+          disabled={{this.setStatus.isRunning}}
+          {{on "click" (perform this.setStatus 0)}}
+        >
+      {{/if}}
+    {{else}}
+      <LoadingSpinner />
+    {{/if}}
+  </span>
+{{/if}}

--- a/addon/components/user-material-status.hbs
+++ b/addon/components/user-material-status.hbs
@@ -1,5 +1,5 @@
 {{#if (and this.isSessionLearningMaterial this.isStatusLoaded)}}
-  <span data-test-user-material-status>
+  <span class="user-material-status" data-test-user-material-status>
     {{#if (eq this.status 0)}}
       <input
         aria-label={{t "general.notStarted"}}

--- a/addon/components/user-material-status.hbs
+++ b/addon/components/user-material-status.hbs
@@ -4,6 +4,7 @@
       <input
         aria-label={{t "general.notStarted"}}
         type="checkbox"
+        disabled={{@disabled}}
         {{on "click" (perform this.setStatus 1)}}
       >
     {{else if (eq this.status 1)}}
@@ -11,6 +12,7 @@
         aria-label={{t "general.inProgress"}}
         indeterminate={{true}}
         type="checkbox"
+        disabled={{@disabled}}
         {{on "click" (perform this.setStatus 2)}}
       >
     {{else if (eq this.status 2)}}
@@ -18,6 +20,7 @@
         aria-label={{t "general.complete"}}
         checked={{true}}
         type="checkbox"
+        disabled={{@disabled}}
         {{on "click" (perform this.setStatus 0)}}
       >
     {{/if}}

--- a/addon/components/user-material-status.hbs
+++ b/addon/components/user-material-status.hbs
@@ -1,32 +1,25 @@
-{{#if this.isSessionLearningMaterial}}
+{{#if (and this.isSessionLearningMaterial this.isStatusLoaded)}}
   <span data-test-user-material-status>
-    {{#if this.isStatusLoaded}}
-      {{#if (eq this.status 0)}}
-        <input
-          aria-label={{t "general.notStarted"}}
-          type="checkbox"
-          disabled={{this.setStatus.isRunning}}
-          {{on "click" (perform this.setStatus 1)}}
-        >
-      {{else if (eq this.status 1)}}
-        <input
-          aria-label={{t "general.inProgress"}}
-          indeterminate={{true}}
-          type="checkbox"
-          disabled={{this.setStatus.isRunning}}
-          {{on "click" (perform this.setStatus 2)}}
-        >
-      {{else if (eq this.status 2)}}
-        <input
-          aria-label={{t "general.complete"}}
-          checked={{true}}
-          type="checkbox"
-          disabled={{this.setStatus.isRunning}}
-          {{on "click" (perform this.setStatus 0)}}
-        >
-      {{/if}}
-    {{else}}
-      <LoadingSpinner />
+    {{#if (eq this.status 0)}}
+      <input
+        aria-label={{t "general.notStarted"}}
+        type="checkbox"
+        {{on "click" (perform this.setStatus 1)}}
+      >
+    {{else if (eq this.status 1)}}
+      <input
+        aria-label={{t "general.inProgress"}}
+        indeterminate={{true}}
+        type="checkbox"
+        {{on "click" (perform this.setStatus 2)}}
+      >
+    {{else if (eq this.status 2)}}
+      <input
+        aria-label={{t "general.complete"}}
+        checked={{true}}
+        type="checkbox"
+        {{on "click" (perform this.setStatus 0)}}
+      >
     {{/if}}
   </span>
 {{/if}}

--- a/addon/components/user-material-status.hbs
+++ b/addon/components/user-material-status.hbs
@@ -1,4 +1,4 @@
-{{#if (and this.isSessionLearningMaterial this.isStatusLoaded)}}
+{{#if (and this.isEnabled this.isSessionLearningMaterial this.isStatusLoaded)}}
   <span class="user-material-status" data-test-user-material-status>
     {{#if (eq this.status 0)}}
       <input

--- a/addon/components/user-material-status.js
+++ b/addon/components/user-material-status.js
@@ -8,11 +8,15 @@ import { tracked } from '@glimmer/tracking';
 export default class UserMaterialStatusComponent extends Component {
   @service store;
   @service currentUser;
+  @service iliosConfig;
 
   @tracked tmpStatus = null;
 
   @use user = new ResolveAsyncValue(() => [this.currentUser.getModel()]);
   @use sessionMaterialStatuses = new ResolveAsyncValue(() => [this.user?.sessionMaterialStatuses]);
+  @use isEnabled = new ResolveAsyncValue(() => [
+    this.iliosConfig.itemFromConfig('materialStatusEnabled'),
+  ]);
 
   get isStatusLoaded() {
     return Boolean(this.sessionMaterialStatuses);

--- a/addon/components/user-material-status.js
+++ b/addon/components/user-material-status.js
@@ -1,0 +1,62 @@
+import Component from '@glimmer/component';
+import { use } from 'ember-could-get-used-to-this';
+import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { inject as service } from '@ember/service';
+import { restartableTask } from 'ember-concurrency';
+import { tracked } from '@glimmer/tracking';
+
+export default class UserMaterialStatusComponent extends Component {
+  @service store;
+  @service currentUser;
+
+  @tracked tmpStatus = null;
+
+  @use user = new ResolveAsyncValue(() => [this.currentUser.getModel()]);
+  @use sessionMaterialStatuses = new ResolveAsyncValue(() => [this.user?.sessionMaterialStatuses]);
+
+  get isStatusLoaded() {
+    return Boolean(this.sessionMaterialStatuses);
+  }
+
+  get isSessionLearningMaterial() {
+    return Boolean(this.args.learningMaterial.sessionLearningMaterial);
+  }
+
+  get materialStatus() {
+    return this.sessionMaterialStatuses?.find((status) => {
+      const materialId = Number(status.belongsTo('material').id());
+      const targetId = Number(this.args.learningMaterial.sessionLearningMaterial);
+      return materialId === targetId;
+    });
+  }
+
+  get status() {
+    if (this.tmpStatus) {
+      return this.tmpStatus;
+    }
+
+    return this.materialStatus?.status || 0;
+  }
+
+  @restartableTask
+  *setStatus(statusValue) {
+    this.tmpStatus = statusValue;
+    const user = yield this.currentUser.getModel();
+    const sessionLearningMaterial = yield this.store.find(
+      'session-learning-material',
+      this.args.learningMaterial.sessionLearningMaterial
+    );
+    let materialStatus = this.materialStatus;
+    if (!materialStatus) {
+      materialStatus = this.store.createRecord('user-session-material-status', {
+        user,
+        material: sessionLearningMaterial,
+        status: 0,
+      });
+    }
+
+    materialStatus.set('status', statusValue);
+    yield materialStatus.save();
+    this.tmpStatus = null;
+  }
+}

--- a/addon/components/user-material-status.js
+++ b/addon/components/user-material-status.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import { inject as service } from '@ember/service';
-import { restartableTask } from 'ember-concurrency';
+import { restartableTask, timeout } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
 
 export default class UserMaterialStatusComponent extends Component {
@@ -41,13 +41,13 @@ export default class UserMaterialStatusComponent extends Component {
   @restartableTask
   *setStatus(statusValue) {
     this.tmpStatus = statusValue;
-    const user = yield this.currentUser.getModel();
-    const sessionLearningMaterial = yield this.store.find(
-      'session-learning-material',
-      this.args.learningMaterial.sessionLearningMaterial
-    );
     let materialStatus = this.materialStatus;
     if (!materialStatus) {
+      const user = yield this.currentUser.getModel();
+      const sessionLearningMaterial = yield this.store.findRecord(
+        'session-learning-material',
+        this.args.learningMaterial.sessionLearningMaterial
+      );
       materialStatus = this.store.createRecord('user-session-material-status', {
         user,
         material: sessionLearningMaterial,
@@ -56,6 +56,7 @@ export default class UserMaterialStatusComponent extends Component {
     }
 
     materialStatus.set('status', statusValue);
+    yield timeout(500);
     yield materialStatus.save();
     this.tmpStatus = null;
   }

--- a/addon/components/week-glance/learning-material-list-item.hbs
+++ b/addon/components/week-glance/learning-material-list-item.hbs
@@ -7,9 +7,7 @@
       {{@lm.title}}
     </span>
   {{else}}
-    {{#if @showLink}}
-      <UserMaterialStatus @learningMaterial={{@lm}} />
-    {{/if}}
+    <UserMaterialStatus @learningMaterial={{@lm}} @disabled={{not @showLink}} />
     <LmIcons @learningMaterial={{@lm}} />
     {{#if (and @lm.absoluteFileUri @showLink)}}
       {{#if (eq @lm.mimetype "application/pdf")}}

--- a/addon/components/week-glance/learning-material-list-item.hbs
+++ b/addon/components/week-glance/learning-material-list-item.hbs
@@ -7,6 +7,9 @@
       {{@lm.title}}
     </span>
   {{else}}
+    {{#if @showLink}}
+      <UserMaterialStatus @learningMaterial={{@lm}} />
+    {{/if}}
     <LmIcons @learningMaterial={{@lm}} />
     {{#if (and @lm.absoluteFileUri @showLink)}}
       {{#if (eq @lm.mimetype "application/pdf")}}

--- a/addon/models/user-session-material-status.js
+++ b/addon/models/user-session-material-status.js
@@ -4,6 +4,9 @@ export default class UserSessionMaterialStatusModel extends Model {
   @attr('number')
   status;
 
+  @attr('date')
+  updatedAt;
+
   @belongsTo('user', { async: true })
   user;
 

--- a/addon/models/user-session-material-status.js
+++ b/addon/models/user-session-material-status.js
@@ -1,0 +1,12 @@
+import Model, { belongsTo, attr } from '@ember-data/model';
+
+export default class UserSessionMaterialStatusModel extends Model {
+  @attr('number')
+  status;
+
+  @belongsTo('user', { async: true })
+  user;
+
+  @belongsTo('session-learning-material', { async: true })
+  material;
+}

--- a/addon/models/user.js
+++ b/addon/models/user.js
@@ -176,6 +176,9 @@ export default class User extends Model {
   })
   administeredCurriculumInventoryReports;
 
+  @hasMany('user-session-material-status', { async: true })
+  sessionMaterialStatuses;
+
   @use _roles = new ResolveAsyncValue(() => [this.roles, []]);
 
   get _roleTitles() {

--- a/addon/serializers/user-session-material-status.js
+++ b/addon/serializers/user-session-material-status.js
@@ -1,0 +1,10 @@
+import IliosSerializer from './ilios';
+
+export default class UserSessionMaterialStatusSerializer extends IliosSerializer {
+  serialize(snapshot, options) {
+    const json = super.serialize(snapshot, options);
+    //don't persist this, it is handled by the server
+    delete json.data.attributes.updatedAt;
+    return json;
+  }
+}

--- a/addon/services/current-user.js
+++ b/addon/services/current-user.js
@@ -34,7 +34,9 @@ export default class CurrentUserService extends Service {
     }
 
     if (!this._userPromise) {
-      this._userPromise = this.store.findRecord('user', currentUserId);
+      this._userPromise = this.store.findRecord('user', currentUserId, {
+        include: 'sessionMaterialStatuses',
+      });
     }
     return await this._userPromise;
   }

--- a/app/components/user-material-status.js
+++ b/app/components/user-material-status.js
@@ -1,0 +1,1 @@
+export { default } from 'ilios-common/components/user-material-status';

--- a/app/models/user-session-material-status.js
+++ b/app/models/user-session-material-status.js
@@ -1,0 +1,1 @@
+export { default } from 'ilios-common/models/user-session-material-status';

--- a/app/serializers/user-session-material-status.js
+++ b/app/serializers/user-session-material-status.js
@@ -1,0 +1,1 @@
+export { default } from 'ilios-common/serializers/user-session-material-status';

--- a/app/styles/ilios-common/components.scss
+++ b/app/styles/ilios-common/components.scss
@@ -115,6 +115,7 @@
 @import 'components/toggle-yesno';
 @import 'components/truncate-text';
 @import 'components/user-search';
+@import 'components/user-material-status';
 @import 'components/visualizer-course-instructor-session-type';
 @import 'components/visualizer-course-instructors';
 @import 'components/visualizer-course-objectives';

--- a/app/styles/ilios-common/components/lm-icons.scss
+++ b/app/styles/ilios-common/components/lm-icons.scss
@@ -1,5 +1,6 @@
 .lm-icons {
   height: 1rem;
+  margin-left: .1rem;
 
   .required {
     grid-column-start: 1;

--- a/app/styles/ilios-common/components/user-material-status.scss
+++ b/app/styles/ilios-common/components/user-material-status.scss
@@ -1,0 +1,3 @@
+.user-material-status {
+  margin-right: .1rem;
+}

--- a/config/api-version.js
+++ b/config/api-version.js
@@ -1,3 +1,3 @@
 /* eslint-env node */
 
-module.exports = 'v3.6';
+module.exports = 'v3.7';

--- a/tests/acceptance/dashboard/materials-test.js
+++ b/tests/acceptance/dashboard/materials-test.js
@@ -22,6 +22,7 @@ module('Acceptance | Dashboard Materials', function (hooks) {
       title: 'title1',
       absoluteFileUri: 'http://myhost.com/url1',
       sessionTitle: 'session1title',
+      sessionLearningMaterial: 1,
       course: courses[0].id,
       type: 'file',
       mimetype: 'application/pdf',
@@ -33,6 +34,7 @@ module('Acceptance | Dashboard Materials', function (hooks) {
       title: 'title2',
       link: 'http://myhost.com/url2',
       sessionTitle: 'session2title',
+      sessionLearningMaterial: 2,
       course: courses[1].id,
       type: 'link',
       courseTitle: courses[1].title,
@@ -43,6 +45,7 @@ module('Acceptance | Dashboard Materials', function (hooks) {
       title: 'title3',
       citation: 'citationtext',
       sessionTitle: 'session3title',
+      sessionLearningMaterial: 3,
       type: 'citation',
       course: courses[2].id,
       courseTitle: courses[2].title,
@@ -52,6 +55,7 @@ module('Acceptance | Dashboard Materials', function (hooks) {
       title: 'title4',
       absoluteFileUri: 'http://myhost.com/document.txt',
       sessionTitle: 'session4title',
+      sessionLearningMaterial: 4,
       course: courses[0].id,
       type: 'file',
       mimetype: 'text/plain',
@@ -64,24 +68,50 @@ module('Acceptance | Dashboard Materials', function (hooks) {
       isBlanked: true,
       course: courses[4].id,
       sessionTitle: 'session5title',
+      sessionLearningMaterial: 5,
       courseTitle: courses[4].title,
       firstOfferingDate: tomorrow.toDate(),
       endDate: new Date('2013-03-01T01:10:00'),
     };
+    const lm6 = {
+      title: 'title6',
+      absoluteFileUri: 'http://myhost.com/document.txt',
+      course: courses[0].id,
+      type: 'file',
+      mimetype: 'text/plain',
+      courseTitle: courses[0].title,
+      instructors: ['Instructor3name', 'Instructor4name'],
+      firstOfferingDate: today.toDate(),
+    };
 
-    const currentMaterials = [lm1, lm2, lm3, lm4, lm5];
+    const currentMaterials = [lm1, lm2, lm3, lm4, lm5, lm6];
     const notCurrentMaterials = [];
     for (let i = currentMaterials.length + 1, n = i + 200; i < n; i++) {
       notCurrentMaterials.push({
         title: `title ${i}`,
         citation: `citationtext ${i}`,
         sessionTitle: `session title`,
+        sessionLearningMaterial: i,
         type: 'citation',
         course: courses[3].id,
         courseTitle: courses[3].title,
         firstOfferingDate: nextWeek.toDate(),
       });
     }
+
+    this.server.createList('session-learning-material', 6);
+
+    this.server.create('user-session-material-status', {
+      user: this.user,
+      materialId: 3,
+      status: 1,
+    });
+
+    this.server.create('user-session-material-status', {
+      user: this.user,
+      material: this.server.create('session-learning-material', { id: 2 }),
+      status: 2,
+    });
 
     this.today = today;
     this.tomorrow = tomorrow;
@@ -92,7 +122,7 @@ module('Acceptance | Dashboard Materials', function (hooks) {
   });
 
   test('it renders with materials in show-current mode', async function (assert) {
-    assert.expect(78);
+    assert.expect(95);
     this.server.get(`/api/usermaterials/:id`, (scheme, { params, queryParams }) => {
       assert.ok('id' in params);
       assert.strictEqual(parseInt(params.id, 10), 100);
@@ -128,11 +158,11 @@ module('Acceptance | Dashboard Materials', function (hooks) {
     assert.strictEqual(page.materials.textFilter.value, '');
     assert.strictEqual(
       page.materials.topPaginator.controls.pagerDetails.text,
-      'Showing 1 - 5 of 5'
+      'Showing 1 - 6 of 6'
     );
     assert.strictEqual(
       page.materials.bottomPaginator.controls.pagerDetails.text,
-      'Showing 1 - 5 of 5'
+      'Showing 1 - 6 of 6'
     );
     assert.strictEqual(page.materials.table.headers.sessionTitle.text, 'Session');
     assert.notOk(page.materials.table.headers.sessionTitle.isSortedOn);
@@ -145,7 +175,9 @@ module('Acceptance | Dashboard Materials', function (hooks) {
     assert.ok(page.materials.table.headers.firstOfferingDate.isSortedOn);
     assert.ok(page.materials.table.headers.firstOfferingDate.isSortedDescending);
     assert.notOk(page.materials.table.noResults.isVisible);
-    assert.strictEqual(page.materials.table.rows.length, 5);
+    assert.strictEqual(page.materials.table.rows.length, 6);
+    assert.ok(page.materials.table.rows[0].status.isPresent);
+    assert.notOk(page.materials.table.rows[0].status.isChecked);
     assert.strictEqual(page.materials.table.rows[0].sessionTitle, 'session5title');
     assert.strictEqual(page.materials.table.rows[0].courseTitle, 'course 4');
     assert.strictEqual(
@@ -158,6 +190,8 @@ module('Acceptance | Dashboard Materials', function (hooks) {
       page.materials.table.rows[0].firstOfferingDate,
       this.tomorrow.format('M/D/YYYY')
     );
+    assert.ok(page.materials.table.rows[1].status.isPresent);
+    assert.notOk(page.materials.table.rows[1].status.isChecked);
     assert.strictEqual(page.materials.table.rows[1].sessionTitle, 'session4title');
     assert.strictEqual(page.materials.table.rows[1].courseTitle, 'course 0');
     assert.strictEqual(page.materials.table.rows[1].title, 'File title4');
@@ -172,6 +206,8 @@ module('Acceptance | Dashboard Materials', function (hooks) {
       page.materials.table.rows[1].firstOfferingDate,
       this.tomorrow.format('M/D/YYYY')
     );
+    assert.ok(page.materials.table.rows[2].status.isPresent);
+    assert.ok(page.materials.table.rows[2].status.isChecked);
     assert.strictEqual(page.materials.table.rows[2].sessionTitle, 'session2title');
     assert.strictEqual(page.materials.table.rows[2].courseTitle, 'course 1');
     assert.strictEqual(page.materials.table.rows[2].title, 'Web Link title2');
@@ -186,29 +222,48 @@ module('Acceptance | Dashboard Materials', function (hooks) {
       page.materials.table.rows[2].firstOfferingDate,
       this.tomorrow.format('M/D/YYYY')
     );
-    assert.strictEqual(page.materials.table.rows[3].sessionTitle, 'session3title');
-    assert.strictEqual(page.materials.table.rows[3].courseTitle, 'course 2');
-    assert.strictEqual(page.materials.table.rows[3].title, 'Citation title3 citationtext');
-    assert.ok(page.materials.table.rows[3].isCitation);
-    assert.strictEqual(page.materials.table.rows[3].instructors, '');
+
+    assert.notOk(page.materials.table.rows[3].status.isPresent);
+    assert.strictEqual(page.materials.table.rows[3].sessionTitle, '');
+    assert.strictEqual(page.materials.table.rows[3].courseTitle, 'course 0');
+    assert.strictEqual(page.materials.table.rows[3].title, 'File title6');
+    assert.ok(page.materials.table.rows[3].isFile);
+    assert.strictEqual(
+      page.materials.table.rows[3].instructors,
+      'Instructor3name, Instructor4name'
+    );
     assert.strictEqual(
       page.materials.table.rows[3].firstOfferingDate,
       this.today.format('M/D/YYYY')
     );
-    assert.strictEqual(page.materials.table.rows[4].sessionTitle, 'session1title');
-    assert.strictEqual(page.materials.table.rows[4].courseTitle, 'course 0');
-    assert.strictEqual(page.materials.table.rows[4].title, 'File title1 Download');
-    assert.ok(page.materials.table.rows[4].isPdf);
-    assert.ok(page.materials.table.rows[4].pdfDownloadLink.isVisible);
-    assert.strictEqual(page.materials.table.rows[4].pdfDownloadLink.url, 'http://myhost.com/url1');
-    assert.ok(page.materials.table.rows[4].pdfLink.isVisible);
-    assert.strictEqual(page.materials.table.rows[4].pdfLink.url, 'http://myhost.com/url1?inline');
+
+    assert.ok(page.materials.table.rows[4].status.isPresent);
+    assert.ok(page.materials.table.rows[4].status.isIndeterminate);
+    assert.strictEqual(page.materials.table.rows[4].sessionTitle, 'session3title');
+    assert.strictEqual(page.materials.table.rows[4].courseTitle, 'course 2');
+    assert.strictEqual(page.materials.table.rows[4].title, 'Citation title3 citationtext');
+    assert.ok(page.materials.table.rows[4].isCitation);
+    assert.strictEqual(page.materials.table.rows[4].instructors, '');
     assert.strictEqual(
-      page.materials.table.rows[4].instructors,
+      page.materials.table.rows[4].firstOfferingDate,
+      this.today.format('M/D/YYYY')
+    );
+    assert.ok(page.materials.table.rows[5].status.isPresent);
+    assert.notOk(page.materials.table.rows[5].status.isChecked);
+    assert.strictEqual(page.materials.table.rows[5].sessionTitle, 'session1title');
+    assert.strictEqual(page.materials.table.rows[5].courseTitle, 'course 0');
+    assert.strictEqual(page.materials.table.rows[5].title, 'File title1 Download');
+    assert.ok(page.materials.table.rows[5].isPdf);
+    assert.ok(page.materials.table.rows[5].pdfDownloadLink.isVisible);
+    assert.strictEqual(page.materials.table.rows[5].pdfDownloadLink.url, 'http://myhost.com/url1');
+    assert.ok(page.materials.table.rows[5].pdfLink.isVisible);
+    assert.strictEqual(page.materials.table.rows[5].pdfLink.url, 'http://myhost.com/url1?inline');
+    assert.strictEqual(
+      page.materials.table.rows[5].instructors,
       'Instructor1name, Instructor2name'
     );
     assert.strictEqual(
-      page.materials.table.rows[4].firstOfferingDate,
+      page.materials.table.rows[5].firstOfferingDate,
       this.today.format('M/D/YYYY')
     );
     await a11yAudit();
@@ -239,11 +294,11 @@ module('Acceptance | Dashboard Materials', function (hooks) {
     assert.strictEqual(page.materials.courseFilter.options[5].text, 'course 4');
     assert.strictEqual(
       page.materials.topPaginator.controls.pagerDetails.text,
-      'Showing 1 - 25 of 205'
+      'Showing 1 - 25 of 206'
     );
     assert.strictEqual(
       page.materials.bottomPaginator.controls.pagerDetails.text,
-      'Showing 1 - 25 of 205'
+      'Showing 1 - 25 of 206'
     );
     assert.strictEqual(page.materials.table.rows.length, 25);
   });
@@ -258,16 +313,16 @@ module('Acceptance | Dashboard Materials', function (hooks) {
     await page.visit({ showAll: true, offset: 100, limit: 50 });
     assert.strictEqual(
       page.materials.topPaginator.controls.pagerDetails.text,
-      'Showing 101 - 150 of 205'
+      'Showing 101 - 150 of 206'
     );
     assert.strictEqual(page.materials.table.rows.length, 50);
-    assert.strictEqual(page.materials.table.rows[0].title, 'Citation title 105 citationtext 105');
+    assert.strictEqual(page.materials.table.rows[0].title, 'Citation title 106 citationtext 106');
     await page.materials.topPaginator.controls.nextPage.click();
     assert.strictEqual(
       page.materials.topPaginator.controls.pagerDetails.text,
-      'Showing 151 - 200 of 205'
+      'Showing 151 - 200 of 206'
     );
-    assert.strictEqual(page.materials.table.rows[0].title, 'Citation title 55 citationtext 55');
+    assert.strictEqual(page.materials.table.rows[0].title, 'Citation title 56 citationtext 56');
   });
 
   test('sorting works', async function (assert) {
@@ -279,7 +334,7 @@ module('Acceptance | Dashboard Materials', function (hooks) {
     await page.visit({ showAll: true, sortBy: 'title:desc' });
     assert.ok(page.materials.table.headers.title.isSortedDescending);
     assert.strictEqual(
-      page.materials.table.rows[0].title,
+      page.materials.table.rows[1].title,
       'Timed Release title5 (Available until 3/1/2013, 1:10 AM)'
     );
     await page.materials.table.headers.title.click();
@@ -295,7 +350,7 @@ module('Acceptance | Dashboard Materials', function (hooks) {
     assert.notOk(page.materials.table.headers.sessionTitle.isSortedOn);
     await page.materials.table.headers.sessionTitle.click();
     assert.ok(page.materials.table.headers.sessionTitle.isSortedAscending);
-    assert.strictEqual(page.materials.table.rows[0].sessionTitle, 'session title');
+    assert.strictEqual(page.materials.table.rows[0].sessionTitle, '');
     await page.materials.table.headers.sessionTitle.click();
     assert.ok(page.materials.table.headers.sessionTitle.isSortedDescending);
     assert.strictEqual(page.materials.table.rows[0].sessionTitle, 'session5title');
@@ -324,18 +379,18 @@ module('Acceptance | Dashboard Materials', function (hooks) {
     assert.ok(page.materials.header.displayToggle.firstButton.isChecked);
     assert.strictEqual(
       page.materials.topPaginator.controls.pagerDetails.text,
-      'Showing 1 - 25 of 205'
+      'Showing 1 - 25 of 206'
     );
     await page.materials.topPaginator.controls.limit.set(50);
     await page.materials.topPaginator.controls.nextPage.click();
     assert.strictEqual(
       page.materials.topPaginator.controls.pagerDetails.text,
-      'Showing 51 - 100 of 205'
+      'Showing 51 - 100 of 206'
     );
     await page.materials.header.displayToggle.secondButton.click();
     assert.strictEqual(
       page.materials.topPaginator.controls.pagerDetails.text,
-      'Showing 1 - 25 of 205'
+      'Showing 1 - 25 of 206'
     );
     assert.ok(page.materials.header.displayToggle.secondButton.isChecked);
   });
@@ -355,13 +410,13 @@ module('Acceptance | Dashboard Materials', function (hooks) {
     await page.materials.textFilter.set('');
     assert.strictEqual(
       page.materials.topPaginator.controls.pagerDetails.text,
-      'Showing 1 - 25 of 205'
+      'Showing 1 - 25 of 206'
     );
     await page.materials.topPaginator.controls.limit.set(50);
     await page.materials.topPaginator.controls.nextPage.click();
     assert.strictEqual(
       page.materials.topPaginator.controls.pagerDetails.text,
-      'Showing 51 - 100 of 205'
+      'Showing 51 - 100 of 206'
     );
     await page.materials.textFilter.set('session title');
     assert.strictEqual(
@@ -379,20 +434,20 @@ module('Acceptance | Dashboard Materials', function (hooks) {
     await page.visit({ course: 1 });
     assert.strictEqual(
       page.materials.topPaginator.controls.pagerDetails.text,
-      'Showing 1 - 2 of 2'
+      'Showing 1 - 3 of 3'
     );
     assert.ok(page.materials.courseFilter.options[1].isSelected);
     await page.materials.courseFilter.set('');
     assert.ok(page.materials.courseFilter.options[0].isSelected);
     assert.strictEqual(
       page.materials.topPaginator.controls.pagerDetails.text,
-      'Showing 1 - 25 of 205'
+      'Showing 1 - 25 of 206'
     );
     await page.materials.topPaginator.controls.limit.set(50);
     await page.materials.topPaginator.controls.nextPage.click();
     assert.strictEqual(
       page.materials.topPaginator.controls.pagerDetails.text,
-      'Showing 51 - 100 of 205'
+      'Showing 51 - 100 of 206'
     );
     await page.materials.textFilter.set('session title');
     assert.strictEqual(
@@ -443,5 +498,38 @@ module('Acceptance | Dashboard Materials', function (hooks) {
     assert.strictEqual(page.materials.courseFilter.options[5].text, '** course not found **');
     assert.ok(page.materials.courseFilter.options[5].isSelected);
     assert.ok(page.materials.courseFilter.options[5].isDisabled);
+  });
+
+  test('mark material status', async function (assert) {
+    this.server.get(`/api/usermaterials/:id`, () => {
+      return {
+        userMaterials: this.currentMaterials,
+      };
+    });
+    await page.visit();
+
+    const materials = page.materials.table.rows;
+    assert.strictEqual(materials.length, 6);
+
+    assert.notOk(materials[0].status.isChecked);
+    assert.notOk(materials[1].status.isChecked);
+    assert.ok(materials[2].status.isChecked);
+    assert.ok(materials[4].status.isIndeterminate);
+    assert.notOk(materials[5].status.isChecked);
+
+    await materials[0].status.click();
+    await materials[0].status.click();
+    await materials[2].status.click();
+    await materials[4].status.click();
+    await materials[4].status.click();
+    await materials[5].status.click();
+
+    assert.ok(materials[0].status.isChecked);
+    assert.notOk(materials[1].status.isChecked);
+    assert.notOk(materials[2].status.isChecked);
+    assert.notOk(materials[2].status.isIndeterminate);
+    assert.notOk(materials[4].status.isChecked);
+    assert.notOk(materials[4].status.isIndeterminate);
+    assert.ok(materials[5].status.isIndeterminate);
   });
 });

--- a/tests/dummy/mirage/config.js
+++ b/tests/dummy/mirage/config.js
@@ -16,6 +16,7 @@ export default function (config) {
         return {
           config: {
             type: 'form',
+            materialStatusEnabled: true,
             apiVersion,
           },
         };

--- a/tests/integration/components/dashboard/materials-test.js
+++ b/tests/integration/components/dashboard/materials-test.js
@@ -24,6 +24,9 @@ module('Integration | Component | dashboard/materials', function (hooks) {
     }
     class IliosConfigMock extends Service {
       apiNameSpace = '/api';
+      async itemFromConfig(name) {
+        return name === 'materialStatusEnabled';
+      }
     }
     this.owner.register('service:iliosConfig', IliosConfigMock);
     this.owner.register('service:current-user', CurrentUserMock);

--- a/tests/integration/components/single-event-learningmaterial-list-item-test.js
+++ b/tests/integration/components/single-event-learningmaterial-list-item-test.js
@@ -5,10 +5,12 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { DateTime } from 'luxon';
 import { component } from 'ilios-common/page-objects/components/single-event-learningmaterial-list-item';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | single-event-learningmaterial-list-item', function (hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks, 'en-us');
+  setupMirage(hooks);
 
   test('blanked', async function (assert) {
     const lm = { title: 'foo bar', isBlanked: true };

--- a/tests/integration/components/single-event-learningmaterial-list-test.js
+++ b/tests/integration/components/single-event-learningmaterial-list-test.js
@@ -5,10 +5,12 @@ import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { component } from 'ilios-common/page-objects/components/single-event-learningmaterial-list';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | single-event-learningmaterial-list', function (hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks, 'en-us');
+  setupMirage(hooks);
 
   test('it renders', async function (assert) {
     this.set('learningMaterials', [

--- a/tests/integration/components/user-material-status-test.js
+++ b/tests/integration/components/user-material-status-test.js
@@ -1,0 +1,74 @@
+import Service from '@ember/service';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setupIntl } from 'ember-intl/test-support';
+import { component } from 'ilios-common/page-objects/components/user-material-status';
+
+module('Integration | Component | user-material-status', function (hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+  setupIntl(hooks);
+
+  hooks.beforeEach(async function () {
+    const user = this.server.create('user');
+    for (let i = 1; i < 4; i++) {
+      this.server.create('user-session-material-status', {
+        id: i,
+        status: i - 1,
+        material: this.server.create('session-learning-material', { id: i }),
+        user,
+      });
+    }
+    this.server.create('session-learning-material', { id: 4 });
+    const userModel = await this.owner.lookup('service:store').find('user', user.id);
+    class CurrentUserMock extends Service {
+      async getModel() {
+        return userModel;
+      }
+    }
+    this.owner.register('service:current-user', CurrentUserMock);
+  });
+
+  test('it renders with no status', async function (assert) {
+    this.set('learningMaterial', {
+      sessionLearningMaterial: 4,
+    });
+
+    await render(hbs`<UserMaterialStatus @learningMaterial={{this.learningMaterial}} />`);
+    assert.false(component.isChecked);
+    assert.dom(this.element).hasText('');
+  });
+
+  test('it renders status of not started', async function (assert) {
+    this.set('learningMaterial', {
+      sessionLearningMaterial: 1,
+    });
+
+    await render(hbs`<UserMaterialStatus @learningMaterial={{this.learningMaterial}} />`);
+    assert.false(component.isChecked);
+    assert.dom(this.element).hasText('');
+  });
+
+  test('it renders status of in progress', async function (assert) {
+    this.set('learningMaterial', {
+      sessionLearningMaterial: 2,
+    });
+
+    await render(hbs`<UserMaterialStatus @learningMaterial={{this.learningMaterial}} />`);
+    assert.true(component.isIndeterminate);
+    assert.dom(this.element).hasText('');
+  });
+
+  test('it renders status of complete', async function (assert) {
+    this.set('learningMaterial', {
+      sessionLearningMaterial: 3,
+    });
+
+    await render(hbs`<UserMaterialStatus @learningMaterial={{this.learningMaterial}} />`);
+    assert.true(component.isChecked);
+    assert.dom(this.element).hasText('');
+  });
+});

--- a/tests/integration/components/user-material-status-test.js
+++ b/tests/integration/components/user-material-status-test.js
@@ -49,6 +49,7 @@ module('Integration | Component | user-material-status', function (hooks) {
 
     await render(hbs`<UserMaterialStatus @learningMaterial={{this.learningMaterial}} />`);
     assert.false(component.isChecked);
+    assert.false(component.isDisabled);
     assert.dom(this.element).hasText('');
   });
 
@@ -98,5 +99,18 @@ module('Integration | Component | user-material-status', function (hooks) {
 
     await render(hbs`<UserMaterialStatus @learningMaterial={{this.learningMaterial}} />`);
     assert.false(component.isPresent);
+  });
+
+  test('checkbox inactive when disabled', async function (assert) {
+    this.set('learningMaterial', {
+      sessionLearningMaterial: 3,
+    });
+
+    await render(hbs`
+      <UserMaterialStatus @learningMaterial={{this.learningMaterial}} @disabled={{true}} />
+    `);
+    assert.true(component.isChecked);
+    assert.true(component.isDisabled);
+    assert.dom(this.element).hasText('');
   });
 });

--- a/tests/integration/components/user-material-status-test.js
+++ b/tests/integration/components/user-material-status-test.js
@@ -30,6 +30,16 @@ module('Integration | Component | user-material-status', function (hooks) {
       }
     }
     this.owner.register('service:current-user', CurrentUserMock);
+
+    const { apiVersion } = this.owner.resolveRegistration('config:environment');
+    this.server.get('application/config', function () {
+      return {
+        config: {
+          materialStatusEnabled: true,
+          apiVersion,
+        },
+      };
+    });
   });
 
   test('it renders with no status', async function (assert) {
@@ -70,5 +80,23 @@ module('Integration | Component | user-material-status', function (hooks) {
     await render(hbs`<UserMaterialStatus @learningMaterial={{this.learningMaterial}} />`);
     assert.true(component.isChecked);
     assert.dom(this.element).hasText('');
+  });
+
+  test('it does not render when not enabled', async function (assert) {
+    const { apiVersion } = this.owner.resolveRegistration('config:environment');
+    this.server.get('application/config', function () {
+      return {
+        config: {
+          materialStatusEnabled: false,
+          apiVersion,
+        },
+      };
+    });
+    this.set('learningMaterial', {
+      sessionLearningMaterial: 3,
+    });
+
+    await render(hbs`<UserMaterialStatus @learningMaterial={{this.learningMaterial}} />`);
+    assert.false(component.isPresent);
   });
 });

--- a/tests/integration/components/week-glance-event-test.js
+++ b/tests/integration/components/week-glance-event-test.js
@@ -6,12 +6,14 @@ import hbs from 'htmlbars-inline-precompile';
 import moment from 'moment';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { component } from 'ilios-common/page-objects/components/week-glance-event';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 const today = moment();
 
 module('Integration | Component | week-glance-event', function (hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks, 'en-us');
+  setupMirage(hooks);
 
   test('it renders with some stuff', async function (assert) {
     this.set('event', {

--- a/tests/integration/components/week-glance/learning-material-list-item-test.js
+++ b/tests/integration/components/week-glance/learning-material-list-item-test.js
@@ -3,12 +3,13 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupIntl } from 'ember-intl/test-support';
-
 import { component } from 'ilios-common/page-objects/components/week-glance/learning-material';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | week-glance/learning-material-list-item', function (hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks);
+  setupMirage(hooks);
 
   test('it renders', async function (assert) {
     const lm = {

--- a/tests/integration/components/week-glance/learning-material-list-test.js
+++ b/tests/integration/components/week-glance/learning-material-list-test.js
@@ -4,10 +4,12 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupIntl } from 'ember-intl/test-support';
 import { component } from 'ilios-common/page-objects/components/week-glance/learning-material-list';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | week-glance/learning-material-list', function (hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks);
+  setupMirage(hooks);
 
   test('it renders', async function (assert) {
     this.set('event', {});

--- a/tests/unit/models/user-session-material-status-test.js
+++ b/tests/unit/models/user-session-material-status-test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | user session material status', function (hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let store = this.owner.lookup('service:store');
+    let model = store.createRecord('user-session-material-status', {});
+    assert.ok(model);
+  });
+});

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -49,6 +49,7 @@ general:
   collapse: collapse
   collapseDetail: "Hide Details"
   competencies: Competencies
+  complete: "Complete"
   completeSessions: "Sessions Complete: ready to publish"
   confirmObjectiveRemoval: "Are you sure you want to delete this objective?"
   confirmObjectiveRemovalMultipleSessionObjectives: "You are about to delete this course objective, which is linked to {count} session objectives. This will delete those relationships as well. Are you sure you want to continue?"
@@ -142,6 +143,7 @@ general:
   incompleteSessions: "Sessions Incomplete: cannot publish"
   independentLearning: "Independent Learning"
   independentLearningActivities: "Independent Learning Activities"
+  inProgress: "In Progress"
   instructionalNotes: "Instructional Notes"
   instructor: Instructor
   instructorGroupMembers: "Instructor Group Members"
@@ -216,6 +218,7 @@ general:
   notes: Notes
   notFoundMessage: "Rats! I couldn't find that. Please check your page address, and try again."
   notPublished: "Not Published"
+  notStarted: "Not Started"
   objectiveCompetencyManagerTitle: "Select Parent Competency for Objective"
   objectiveCount: "There {count, plural, =1 {is 1 objective} other {are # objectives}}"
   objectiveDescriptorTitle: "Select MeSH Descriptors for Objective"

--- a/translations/es.yaml
+++ b/translations/es.yaml
@@ -49,6 +49,7 @@ general:
   collapse: colapsar
   collapseDetail: "Esconder Detalles"
   competencies: Competencias
+  complete: Completo
   completeSessions: "Sesiónes Completas: Listo a Publicar"
   confirmObjectiveRemoval: "¿Está seguro que desea eliminar este objetivo?"
   confirmObjectiveRemovalMultipleSessionObjectives: "Está a punto de eliminar este objetivo de curso, que está vinculado a {count} objetivos de sesión. Esto eliminará también esas relaciones. ¿Está seguro que desea continuar?"
@@ -142,6 +143,7 @@ general:
   incompleteSessions: "Sesiónes Incompletas: No se pueden publicar"
   independentLearning: "Aprendizaje Independiente"
   independentLearningActivities: "Aprendizaje Independiente Actividades"
+  inProgress: "En Progreso"
   instructionalNotes: "Notes para la Instrucción"
   instructor: Instructor
   instructorGroupMembers: "Miembros del grupo instructor"
@@ -216,6 +218,7 @@ general:
   notes: Notas
   notFoundMessage: "Malditas! Éso no puede encontrar. Favor de verificar la dirección de la página, y trata otra vez."
   notPublished: "No Publicado"
+  notStarted: "No Comenzado"
   objectiveCompetencyManagerTitle: "Seleccione Competencia Principal para Objetivo"
   objectiveCount: "Hay {count, plural, =1 {1 objectivo} other {# objectivos}}"
   objectiveDescriptorTitle: "Seleccione Descriptores de MeSH para Objetivo"

--- a/translations/fr.yaml
+++ b/translations/fr.yaml
@@ -49,6 +49,7 @@ general:
   collapse: réduire
   collapseDetail: "Masquer Détails"
   competencies: "Compétences"
+  complete: "Accompli"
   completeSessions: "Séances complète: prêt à publier"
   confirmObjectiveRemoval: "Êtes vous sûr de vouloir supprimer cet objectif?"
   confirmObjectiveRemovalMultipleSessionObjectives: "Vous êtes sur le point de supprimer cet objectif de cours, qui est lié à {count} objectifs de séance. Cela supprimera également ces liens. Êtes-vous certain de vouloir continuer?"
@@ -142,6 +143,7 @@ general:
   incompleteSessions: "Séances incomplète: ne peut être pas publiée"
   independentLearning: "Apprentissage autonome"
   independentLearningActivities: "Apprentissage autonome Activités"
+  inProgress: "En Cours"
   instructionalNotes: "Notes Didactiques"
   instructor: Instructeur
   instructorGroupMembers: "Membres du groupe d'instructeurs"
@@ -216,6 +218,7 @@ general:
   notes: Notes
   notFoundMessage: "Zut! Je ne pouvais pas trouver cette chôse. S'il vous plaît vérifier votre adresse de la page et essayez à nouveau."
   notPublished: "Non Publier"
+  notStarted: "Non Commencé"
   objectiveCompetencyManagerTitle: "Sélectionner Compétence Mère pour Objectif"
   objectiveCount:  "Il y a {count, plural, =1 {1 objectif} other {# objectifs}}"
   objectiveDescriptorTitle: "Choisi MeSH pour l'objectif"


### PR DESCRIPTION
Using the new API users can now mark the status of their learning
materials on the single event detail page.

WIP: 
- [x] Translations