### PR TITLE
Restructure prework materials for single events

### DIFF
--- a/addon-test-support/ilios-common/page-objects/components/single-event-learningmaterial-list.js
+++ b/addon-test-support/ilios-common/page-objects/components/single-event-learningmaterial-list.js
@@ -1,4 +1,4 @@
-import { collection, create, property } from 'ember-cli-page-object';
+import { collection, create, property, text } from 'ember-cli-page-object';
 import item from './single-event-learningmaterial-list-item';
 
 const definition = {
@@ -6,6 +6,8 @@ const definition = {
   items: collection('[data-test-single-event-learningmaterial-list-item]', item),
   prework: collection('[data-test-prework-event]', {
     url: property('href', 'a'),
+    name: text('[data-test-name]'),
+    items: collection('[data-test-single-event-learningmaterial-list-item]', item),
   }),
 };
 

--- a/addon/components/single-event-learningmaterial-list.hbs
+++ b/addon/components/single-event-learningmaterial-list.hbs
@@ -1,17 +1,19 @@
 <div class="single-event-learningmaterial-list" data-test-single-event-learningmaterial-list ...attributes>
   {{#if (or @learningMaterials.length @prework.length)}}
-    <ul class="static-list">
+    <ul class="static-list prework">
       {{#each @prework as |event|}}
-        <li class="prework-title" data-test-prework-event>
+        <li data-test-prework-event>
           <FaIcon @icon="person-chalkboard" />
-          <LinkTo @route="events" @model={{event.slug}}>
+          <LinkTo @route="events" @model={{event.slug}} data-test-name>
             {{event.name}}
           </LinkTo>
+          {{#each event.learningMaterials as |lm| }}
+            <SingleEventLearningmaterialListItem @learningMaterial={{lm}} />
+          {{/each}}
         </li>
-        {{#each event.learningMaterials as |lm| }}
-          <SingleEventLearningmaterialListItem @learningMaterial={{lm}} class="sub-item" />
-        {{/each}}
       {{/each}}
+    </ul>
+    <ul class="static-list">
       {{#each @learningMaterials as |lm|}}
         <SingleEventLearningmaterialListItem @learningMaterial={{lm}} @linked={{true}} />
       {{/each}}

--- a/app/styles/ilios-common/components/single-event-learningmaterial-list.scss
+++ b/app/styles/ilios-common/components/single-event-learningmaterial-list.scss
@@ -1,7 +1,33 @@
 .single-event-learningmaterial-list {
   .static-list {
     @include ilios-static-list;
-    padding-left: .25rem;
+    padding: .25rem;
+    margin: 0;
+
+    &:last-of-type {
+      border-top: 0;
+      border-top-left-radius: 0;
+      border-top-right-radius: 0;
+    }
+
+    li:last-of-type {
+      margin-bottom: .25rem;
+    }
+
+    &.prework {
+      border-bottom: 0;
+  
+      li > li {
+        margin-left: 1.5rem;
+      }
+
+      li:last-of-type {
+        li:last-of-type {
+          border-bottom: 1px dashed $davysGrey;
+          padding-bottom: .25rem;
+        }
+      }
+    }
   }
 
   .single-event-learningmaterial-item-timing-info {
@@ -24,11 +50,6 @@
     margin-bottom: 0;
     margin-top: 0;
   }
-
-  .sub-item {
-    margin-left: 1.5rem;
-  }
-
 
   .single-event-learningmaterial-item-title {
     display: flex;

--- a/tests/integration/components/single-event-learningmaterial-list-test.js
+++ b/tests/integration/components/single-event-learningmaterial-list-test.js
@@ -108,14 +108,18 @@ module('Integration | Component | single-event-learningmaterial-list', function 
     );
     assert.strictEqual(component.items.length, 5);
     assert.strictEqual(component.prework.length, 2);
-    assert.strictEqual(component.items[0].title, 'aardvark');
-    assert.strictEqual(component.items[1].title, 'foo bar');
-    assert.strictEqual(component.items[2].title, 'readme');
+    assert.strictEqual(component.prework[0].name, 'prework 1');
+    assert.ok(component.prework[0].url.endsWith('/events/prework1'));
+    assert.strictEqual(component.prework[0].items.length, 2);
+    assert.strictEqual(component.prework[0].items[0].title, 'aardvark');
+    assert.strictEqual(component.prework[0].items[1].title, 'foo bar');
+
+    assert.strictEqual(component.prework[1].name, 'prework 2');
+    assert.strictEqual(component.prework[1].items.length, 1);
+    assert.strictEqual(component.prework[1].items[0].title, 'readme');
+    assert.ok(component.prework[1].url.endsWith('/events/prework2'));
+
     assert.strictEqual(component.items[3].title, 'first one');
     assert.strictEqual(component.items[4].title, 'second one');
-    assert.strictEqual(component.prework[0].text, 'prework 1');
-    assert.ok(component.prework[0].url.endsWith('/events/prework1'));
-    assert.strictEqual(component.prework[1].text, 'prework 2');
-    assert.ok(component.prework[1].url.endsWith('/events/prework2'));
   });
 });

--- a/tests/integration/components/single-event-test.js
+++ b/tests/integration/components/single-event-test.js
@@ -350,20 +350,22 @@ module('Integration | Component | ilios calendar single event', function (hooks)
     await render(hbs`<SingleEvent @event={{this.ev}} />`);
     assert.notOk(component.summary.title.hasLink);
     assert.strictEqual(component.summary.title.text, 'course - Learn to Learn');
-    assert.strictEqual(component.sessionLearningMaterials.materials.items.length, 4);
-    assert.strictEqual(component.sessionLearningMaterials.materials.prework.length, 2);
-    assert.strictEqual(component.sessionLearningMaterials.materials.items[0].title, 'foo bar');
-    assert.strictEqual(component.sessionLearningMaterials.materials.items[1].title, 'aardvark');
-    assert.strictEqual(component.sessionLearningMaterials.materials.items[2].title, 'readme');
-    assert.strictEqual(component.sessionLearningMaterials.materials.items[3].title, 'some file');
-    assert.strictEqual(component.sessionLearningMaterials.materials.prework[0].text, 'prework 1');
-    assert.ok(
-      component.sessionLearningMaterials.materials.prework[0].url.endsWith('/events/prework1')
-    );
-    assert.strictEqual(component.sessionLearningMaterials.materials.prework[1].text, 'prework 2');
-    assert.ok(
-      component.sessionLearningMaterials.materials.prework[1].url.endsWith('/events/prework2')
-    );
+    const { materials } = component.sessionLearningMaterials;
+    assert.strictEqual(materials.items.length, 4);
+    assert.strictEqual(materials.prework.length, 2);
+
+    assert.strictEqual(materials.prework[0].name, 'prework 1');
+    assert.strictEqual(materials.prework[0].items.length, 2);
+    assert.strictEqual(materials.prework[0].items[0].title, 'foo bar');
+    assert.strictEqual(materials.prework[0].items[1].title, 'aardvark');
+    assert.ok(materials.prework[0].url.endsWith('/events/prework1'));
+
+    assert.strictEqual(materials.prework[1].name, 'prework 2');
+    assert.strictEqual(materials.prework[1].items.length, 1);
+    assert.strictEqual(materials.prework[1].items[0].title, 'readme');
+    assert.ok(materials.prework[1].url.endsWith('/events/prework2'));
+
+    assert.strictEqual(materials.items[3].title, 'some file');
   });
 
   test('for non ilms postrequisite date and title are displayed along with offering date', async function (assert) {


### PR DESCRIPTION
Adding some space and a border to the prework events makes it clearer
where one starts and the other ends.

Fixes #2959