### PR TITLE
Replace deprecated store.find with store.findRecord

### DIFF
--- a/addon/routes/course-visualize-instructor.js
+++ b/addon/routes/course-visualize-instructor.js
@@ -9,8 +9,8 @@ export default class CourseVisualizeInstructorRoute extends Route {
   titleToken = 'general.coursesAndSessions';
 
   async model(params) {
-    const course = await this.store.find('course', params.course_id);
-    const user = await this.store.find('user', params.user_id);
+    const course = await this.store.findRecord('course', params.course_id);
+    const user = await this.store.findRecord('user', params.user_id);
     return { course, user };
   }
 

--- a/addon/routes/course-visualize-session-type.js
+++ b/addon/routes/course-visualize-session-type.js
@@ -9,8 +9,8 @@ export default class CourseVisualizeSessionTypeRoute extends Route {
   titleToken = 'general.coursesAndSessions';
 
   async model(params) {
-    const course = await this.store.find('course', params.course_id);
-    const sessionType = await this.store.find('session-type', params['session-type_id']);
+    const course = await this.store.findRecord('course', params.course_id);
+    const sessionType = await this.store.findRecord('session-type', params['session-type_id']);
 
     return { course, sessionType };
   }

--- a/addon/routes/course-visualize-term.js
+++ b/addon/routes/course-visualize-term.js
@@ -9,8 +9,8 @@ export default class CourseVisualizeTermRoute extends Route {
   titleToken = 'general.coursesAndSessions';
 
   async model(params) {
-    const course = await this.store.find('course', params.course_id);
-    const term = await this.store.find('term', params.term_id);
+    const course = await this.store.findRecord('course', params.course_id);
+    const term = await this.store.findRecord('term', params.term_id);
 
     return { course, term };
   }

--- a/addon/routes/course-visualize-vocabulary.js
+++ b/addon/routes/course-visualize-vocabulary.js
@@ -9,8 +9,8 @@ export default class CourseVisualizeVocabularyRoute extends Route {
   titleToken = 'general.coursesAndSessions';
 
   async model(params) {
-    const course = await this.store.find('course', params.course_id);
-    const vocabulary = await this.store.find('vocabulary', params.vocabulary_id);
+    const course = await this.store.findRecord('course', params.course_id);
+    const vocabulary = await this.store.findRecord('vocabulary', params.vocabulary_id);
 
     return { course, vocabulary };
   }

--- a/addon/services/current-user.js
+++ b/addon/services/current-user.js
@@ -34,7 +34,7 @@ export default class CurrentUserService extends Service {
     }
 
     if (!this._userPromise) {
-      this._userPromise = this.store.find('user', currentUserId);
+      this._userPromise = this.store.findRecord('user', currentUserId);
     }
     return await this._userPromise;
   }

--- a/tests/acceptance/course/overview-test.js
+++ b/tests/acceptance/course/overview-test.js
@@ -36,10 +36,12 @@ module('Acceptance | Course - Overview', function (hooks) {
     });
 
     test('collapsed', async function (assert) {
-      const courseModel = await this.owner.lookup('service:store').find('course', this.course.id);
+      const courseModel = await this.owner
+        .lookup('service:store')
+        .findRecord('course', this.course.id);
       const clerkshipTypeModel = await this.owner
         .lookup('service:store')
-        .find('courseClerkshipType', this.clerkshipType.id);
+        .findRecord('courseClerkshipType', this.clerkshipType.id);
       await page.visit({ courseId: courseModel.id });
       assert.strictEqual(
         page.details.overview.startDate.text,
@@ -59,10 +61,12 @@ module('Acceptance | Course - Overview', function (hooks) {
     });
 
     test('expanded', async function (assert) {
-      const courseModel = await this.owner.lookup('service:store').find('course', this.course.id);
+      const courseModel = await this.owner
+        .lookup('service:store')
+        .findRecord('course', this.course.id);
       const clerkshipTypeModel = await this.owner
         .lookup('service:store')
-        .find('courseClerkshipType', this.clerkshipType.id);
+        .findRecord('courseClerkshipType', this.clerkshipType.id);
       await page.visit({ courseId: courseModel.id, details: true });
       assert.strictEqual(
         page.details.overview.startDate.text,
@@ -82,7 +86,9 @@ module('Acceptance | Course - Overview', function (hooks) {
     });
 
     test('open and close details', async function (assert) {
-      const courseModel = await this.owner.lookup('service:store').find('course', this.course.id);
+      const courseModel = await this.owner
+        .lookup('service:store')
+        .findRecord('course', this.course.id);
       await page.visit({ courseId: courseModel.id });
       assert.strictEqual(page.details.titles, 2);
       assert.strictEqual(currentURL(), '/courses/1');
@@ -101,7 +107,7 @@ module('Acceptance | Course - Overview', function (hooks) {
       year: 2013,
       school: this.school,
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     await page.visit({ courseId: courseModel.id, details: true });
     assert.strictEqual(
       page.details.overview.clerkshipType.text,
@@ -125,7 +131,7 @@ module('Acceptance | Course - Overview', function (hooks) {
       school: this.school,
       clerkshipType,
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     await page.visit({ courseId: courseModel.id, details: true });
     assert.strictEqual(
       page.details.overview.clerkshipType.text,
@@ -147,7 +153,7 @@ module('Acceptance | Course - Overview', function (hooks) {
       year: 2013,
       school: this.school,
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     await page.visit({ courseId: courseModel.id, details: true });
     assert.strictEqual(page.details.header.title.value, 'course 0');
     await page.details.header.title.edit();
@@ -164,7 +170,7 @@ module('Acceptance | Course - Overview', function (hooks) {
       endDate: moment('2015-05-22').toDate(),
       school: this.school,
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     await page.visit({ courseId: courseModel.id, details: true });
     const newDate = moment(course.startDate).add(1, 'year').add(1, 'month');
     assert.strictEqual(
@@ -192,7 +198,7 @@ module('Acceptance | Course - Overview', function (hooks) {
       endDate: moment('2013-05-22').toDate(),
       school: this.school,
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     await page.visit({ courseId: courseModel.id, details: true });
     const startDate = this.intl.formatDate(courseModel.startDate);
     const newDate = moment(courseModel.startDate).add(1, 'year');
@@ -213,7 +219,7 @@ module('Acceptance | Course - Overview', function (hooks) {
       endDate: moment('2015-05-22').toDate(),
       school: this.school,
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     await page.visit({ courseId: courseModel.id, details: true });
     const endDate = this.intl.formatDate(courseModel.endDate);
     const newDate = moment(course.endDate).add(1, 'year').add(1, 'month');
@@ -233,7 +239,7 @@ module('Acceptance | Course - Overview', function (hooks) {
       endDate: moment('2013-05-22').toDate(),
       school: this.school,
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     await page.visit({ courseId: courseModel.id, details: true });
     const endDate = this.intl.formatDate(courseModel.endDate);
     const newDate = moment(course.endDate).subtract(1, 'year');
@@ -254,7 +260,7 @@ module('Acceptance | Course - Overview', function (hooks) {
       school: this.school,
       externalId,
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     await page.visit({ courseId: courseModel.id, details: true });
     const newValue = 'new id';
     assert.strictEqual(page.details.overview.externalId.text, `Course ID: ${externalId}`);
@@ -272,7 +278,7 @@ module('Acceptance | Course - Overview', function (hooks) {
       school: this.school,
       externalId: 'abc123',
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     await page.visit({ courseId: courseModel.id, details: true });
     assert.strictEqual(
       page.details.overview.externalId.text,
@@ -293,7 +299,7 @@ module('Acceptance | Course - Overview', function (hooks) {
       year: 2013,
       school: this.school,
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     await page.visit({ courseId: courseModel.id, details: true });
     assert.strictEqual(
       page.details.overview.externalId.text,
@@ -308,7 +314,7 @@ module('Acceptance | Course - Overview', function (hooks) {
       school: this.school,
       level: 3,
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     await page.visit({ courseId: courseModel.id, details: true });
     const newValue = 1;
     assert.strictEqual(page.details.overview.level.text, `Level: ${courseModel.level}`);
@@ -325,7 +331,7 @@ module('Acceptance | Course - Overview', function (hooks) {
       year: 2013,
       school: this.school,
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     await page.visit({ courseId: courseModel.id, details: true });
     assert.ok(page.details.overview.rollover.isVisible);
     await page.details.overview.rollover.visit();
@@ -338,7 +344,7 @@ module('Acceptance | Course - Overview', function (hooks) {
       year: 2013,
       school: this.school,
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     await page.visit({ courseId: courseModel.id, details: true });
     assert.notOk(page.details.overview.rollover.isVisible);
   });
@@ -349,7 +355,7 @@ module('Acceptance | Course - Overview', function (hooks) {
       year: 2013,
       school: this.school,
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     await page.visit({ courseId: courseModel.id, details: true });
     assert.ok(page.details.overview.rollover.isVisible);
   });
@@ -360,7 +366,7 @@ module('Acceptance | Course - Overview', function (hooks) {
       year: 2013,
       school: this.school,
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     await page.visit({ courseId: courseModel.id, details: true });
     assert.ok(page.details.overview.rollover.isVisible);
     await page.details.overview.rollover.visit();

--- a/tests/integration/components/collapsed-competencies-test.js
+++ b/tests/integration/components/collapsed-competencies-test.js
@@ -43,7 +43,7 @@ module('Integration | Component | collapsed competencies', function (hooks) {
       course,
       programYearObjectives: [pyObjectiveC],
     });
-    this.course = await this.owner.lookup('service:store').find('course', course.id);
+    this.course = await this.owner.lookup('service:store').findRecord('course', course.id);
   });
 
   test('it renders', async function (assert) {

--- a/tests/integration/components/collapsed-taxonomies-test.js
+++ b/tests/integration/components/collapsed-taxonomies-test.js
@@ -37,7 +37,9 @@ module('Integration | Component | collapsed taxonomies', function (hooks) {
   });
 
   test('it renders', async function (assert) {
-    const sessionModel = await this.owner.lookup('service:store').find('session', this.session.id);
+    const sessionModel = await this.owner
+      .lookup('service:store')
+      .findRecord('session', this.session.id);
 
     this.set('subject', sessionModel);
     this.set('click', () => {});
@@ -56,7 +58,9 @@ module('Integration | Component | collapsed taxonomies', function (hooks) {
 
   test('click expands', async function (assert) {
     assert.expect(2);
-    const sessionModel = await this.owner.lookup('service:store').find('session', this.session.id);
+    const sessionModel = await this.owner
+      .lookup('service:store')
+      .findRecord('session', this.session.id);
 
     this.set('subject', sessionModel);
     this.set('click', () => {

--- a/tests/integration/components/course-header-test.js
+++ b/tests/integration/components/course-header-test.js
@@ -20,7 +20,7 @@ module('Integration | Component | course-header', function (hooks) {
     const course = this.server.create('course', {
       published: true,
     });
-    const courseModel = await this.store.find('course', course.id);
+    const courseModel = await this.store.findRecord('course', course.id);
     this.set('course', courseModel);
     await render(hbs`<CourseHeader @course={{this.course}} @editable={{true}} />`);
     await a11yAudit(this.element);
@@ -31,7 +31,7 @@ module('Integration | Component | course-header', function (hooks) {
     const course = this.server.create('course', {
       published: true,
     });
-    const courseModel = await this.store.find('course', course.id);
+    const courseModel = await this.store.findRecord('course', course.id);
     this.set('course', courseModel);
     await render(hbs`<CourseHeader @course={{this.course}} @editable={{false}} />`);
     await a11yAudit(this.element);
@@ -40,7 +40,7 @@ module('Integration | Component | course-header', function (hooks) {
 
   test('course title validation fails if value is empty', async function (assert) {
     const course = this.server.create('course');
-    const courseModel = await this.store.find('course', course.id);
+    const courseModel = await this.store.findRecord('course', course.id);
     this.set('course', courseModel);
     await render(hbs`<CourseHeader @course={{this.course}} @editable={{true}} />`);
 
@@ -55,7 +55,7 @@ module('Integration | Component | course-header', function (hooks) {
 
   test('course title validation fails if value is too short', async function (assert) {
     const course = this.server.create('course');
-    const courseModel = await this.store.find('course', course.id);
+    const courseModel = await this.store.findRecord('course', course.id);
     this.set('course', courseModel);
     await render(hbs`<CourseHeader @course={{this.course}} @editable={{true}} />`);
 
@@ -70,7 +70,7 @@ module('Integration | Component | course-header', function (hooks) {
 
   test('course title validation fails if value is too long', async function (assert) {
     const course = this.server.create('course');
-    const courseModel = await this.store.find('course', course.id);
+    const courseModel = await this.store.findRecord('course', course.id);
     this.set('course', courseModel);
     await render(hbs`<CourseHeader @course={{this.course}} @editable={{true}} />`);
 
@@ -85,7 +85,7 @@ module('Integration | Component | course-header', function (hooks) {
 
   test('course title validation fails if value is too short, ignoring whitespace', async function (assert) {
     const course = this.server.create('course');
-    const courseModel = await this.store.find('course', course.id);
+    const courseModel = await this.store.findRecord('course', course.id);
     this.set('course', courseModel);
     await render(hbs`<CourseHeader @course={{this.course}} @editable={{true}} />`);
 
@@ -100,7 +100,7 @@ module('Integration | Component | course-header', function (hooks) {
 
   test('course title validation fails if value is blank string of any length', async function (assert) {
     const course = this.server.create('course');
-    const courseModel = await this.store.find('course', course.id);
+    const courseModel = await this.store.findRecord('course', course.id);
     this.set('course', courseModel);
     await render(hbs`<CourseHeader @course={{this.course}} @editable={{true}} />`);
 
@@ -115,7 +115,7 @@ module('Integration | Component | course-header', function (hooks) {
 
   test('cancel course title changes', async function (assert) {
     const course = this.server.create('course');
-    const courseModel = await this.store.find('course', course.id);
+    const courseModel = await this.store.findRecord('course', course.id);
     this.set('course', courseModel);
     await render(hbs`<CourseHeader @course={{this.course}} @editable={{true}} />`);
 
@@ -129,7 +129,7 @@ module('Integration | Component | course-header', function (hooks) {
 
   test('course academic year', async function (assert) {
     const course = this.server.create('course', { year: 2021 });
-    const courseModel = await this.store.find('course', course.id);
+    const courseModel = await this.store.findRecord('course', course.id);
     this.set('course', courseModel);
     await render(hbs`<CourseHeader @course={{this.course}} @editable={{true}} />`);
     assert.strictEqual(component.academicYear, '2021');
@@ -144,7 +144,7 @@ module('Integration | Component | course-header', function (hooks) {
       };
     });
     const course = this.server.create('course', { year: 2021 });
-    const courseModel = await this.store.find('course', course.id);
+    const courseModel = await this.store.findRecord('course', course.id);
     this.set('course', courseModel);
     await render(hbs`<CourseHeader @course={{this.course}} @editable={{true}} />`);
     assert.strictEqual(component.academicYear, '2021 - 2022');

--- a/tests/integration/components/course-leadership-expanded-test.js
+++ b/tests/integration/components/course-leadership-expanded-test.js
@@ -19,7 +19,7 @@ module('Integration | Component | course leadership expanded', function (hooks) 
       administrators: users,
       studentAdvisors: [users[0]],
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
     await render(hbs`<CourseLeadershipExpanded
       @course={{this.course}}
@@ -46,7 +46,7 @@ module('Integration | Component | course leadership expanded', function (hooks) 
     const course = this.server.create('course', {
       administrators,
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
     this.set('click', () => {
       assert.ok(true, 'Action was fired');
@@ -68,7 +68,7 @@ module('Integration | Component | course leadership expanded', function (hooks) 
     const course = this.server.create('course', {
       directors,
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
     this.set('click', () => {
       assert.ok(true, 'Action was fired');
@@ -90,7 +90,7 @@ module('Integration | Component | course leadership expanded', function (hooks) 
     const course = this.server.create('course', {
       studentAdvisors,
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
     this.set('click', () => {
       assert.ok(true, 'Action was fired');
@@ -109,7 +109,7 @@ module('Integration | Component | course leadership expanded', function (hooks) 
   test('clicking manage fires action', async function (assert) {
     assert.expect(1);
     const course = this.server.create('course');
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
     this.set('click', () => {
       assert.ok(true, 'Action was fired');

--- a/tests/integration/components/course-materials-test.js
+++ b/tests/integration/components/course-materials-test.js
@@ -28,7 +28,7 @@ module('Integration | Component | course materials', function (hooks) {
     const course = this.server.create('course', {
       learningMaterials: [courseLm1],
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
 
     this.setProperties({
       course: courseModel,
@@ -103,7 +103,7 @@ module('Integration | Component | course materials', function (hooks) {
       learningMaterials: [courseLm1, courseLm2, courseLm3],
     });
 
-    return context.owner.lookup('service:store').find('course', course.id);
+    return context.owner.lookup('service:store').findRecord('course', course.id);
   };
 
   test('course & session lms render', async function (assert) {
@@ -395,7 +395,7 @@ module('Integration | Component | course materials', function (hooks) {
 
   test('no materials', async function (assert) {
     const course = this.server.create('course');
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
 
     await render(hbs`<CourseMaterials

--- a/tests/integration/components/course-overview-test.js
+++ b/tests/integration/components/course-overview-test.js
@@ -28,7 +28,7 @@ module('Integration | Component | course overview', function (hooks) {
     this.server.create('course-clerkship-type', {
       courses: [course],
     });
-    const courseModel = await this.store.find('course', course.id);
+    const courseModel = await this.store.findRecord('course', course.id);
     this.set('course', courseModel);
     await render(hbs`<CourseOverview @course={{this.course}} @editable={{true}} />`);
 
@@ -46,7 +46,7 @@ module('Integration | Component | course overview', function (hooks) {
     this.server.create('course-clerkship-type', {
       courses: [course],
     });
-    const courseModel = await this.store.find('course', course.id);
+    const courseModel = await this.store.findRecord('course', course.id);
     this.set('course', courseModel);
     await render(hbs`<CourseOverview @course={{this.course}} @editable={{true}} />`);
 
@@ -64,7 +64,7 @@ module('Integration | Component | course overview', function (hooks) {
       startDate: moment().hour(8).format(),
       endDate: moment().hour(9).format(),
     });
-    const courseModel = await this.store.find('course', course.id);
+    const courseModel = await this.store.findRecord('course', course.id);
     this.set('course', courseModel);
     await render(hbs`<CourseOverview @course={{this.course}} @editable={{true}} />`);
 
@@ -81,7 +81,7 @@ module('Integration | Component | course overview', function (hooks) {
       startDate: moment().hour(8).format(),
       endDate: moment().hour(9).format(),
     });
-    const courseModel = await this.store.find('course', course.id);
+    const courseModel = await this.store.findRecord('course', course.id);
     this.set('course', courseModel);
     await render(hbs`<CourseOverview @course={{this.course}} @editable={{true}} />`);
 

--- a/tests/integration/components/course-publicationcheck-test.js
+++ b/tests/integration/components/course-publicationcheck-test.js
@@ -19,7 +19,7 @@ module('Integration | Component | course-publicationcheck', function (hooks) {
       programYearObjectives: [programYearObjective],
     });
     this.server.create('courseObjective', { course });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('model', courseModel);
     await render(hbs`<CoursePublicationcheck @course={{this.model}} />`);
     assert.ok(component.unlink.isPresent);
@@ -36,7 +36,7 @@ module('Integration | Component | course-publicationcheck', function (hooks) {
       course,
       programYearObjectives: [programYearObjective],
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('model', courseModel);
     await render(hbs`<CoursePublicationcheck @course={{this.model}} />`);
     assert.notOk(component.unlink.isPresent);

--- a/tests/integration/components/course-rollover-test.js
+++ b/tests/integration/components/course-rollover-test.js
@@ -21,7 +21,7 @@ module('Integration | Component | course rollover', function (hooks) {
       title: 'old course',
       school,
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
 
     await render(hbs`<CourseRollover @course={{this.course}} />`);
@@ -50,7 +50,7 @@ module('Integration | Component | course rollover', function (hooks) {
       title: 'old course',
       school,
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
 
     await render(hbs`<CourseRollover @course={{this.course}} />`);
@@ -72,7 +72,7 @@ module('Integration | Component | course rollover', function (hooks) {
       school,
       startDate: moment().hour(0).minute(0).second(0).toDate(),
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
 
     this.server.post(`/api/courses/${course.id}/rollover`, function (schema, request) {
@@ -109,7 +109,7 @@ module('Integration | Component | course rollover', function (hooks) {
       school,
       startDate: moment().hour(0).minute(0).second(0).toDate(),
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
 
     const newTitle = course.title + '2';
@@ -142,7 +142,7 @@ module('Integration | Component | course rollover', function (hooks) {
       school,
       startDate: moment().hour(0).minute(0).second(0).toDate(),
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
     const selectedYear = parseInt(moment().add(2, 'years').format('YYYY'), 10);
     this.server.post(`/api/courses/${course.id}/rollover`, function (schema, request) {
@@ -194,7 +194,7 @@ module('Integration | Component | course rollover', function (hooks) {
       year: lastYear + 2,
     });
 
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
     await render(hbs`<CourseRollover
       @course={{this.course}}
@@ -234,7 +234,7 @@ module('Integration | Component | course rollover', function (hooks) {
       school,
       year: thisYear,
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', 2);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', 2);
     this.set('course', courseModel);
     await render(hbs`<CourseRollover
       @course={{this.course}}
@@ -263,7 +263,7 @@ module('Integration | Component | course rollover', function (hooks) {
       school,
       startDate: courseStartDate.toDate(),
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
 
     this.server.post(`/api/courses/${course.id}/rollover`, function (schema, request) {
@@ -337,7 +337,7 @@ module('Integration | Component | course rollover', function (hooks) {
       school,
       startDate: courseStartDate.toDate(),
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
 
     this.server.post(`/api/courses/${course.id}/rollover`, function (schema, request) {
@@ -403,7 +403,7 @@ module('Integration | Component | course rollover', function (hooks) {
       school,
       startDate: courseStartDate.toDate(),
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
     await render(hbs`<CourseRollover
       @course={{this.course}}
@@ -439,7 +439,7 @@ module('Integration | Component | course rollover', function (hooks) {
       title: 'old course',
       school,
     });
-    const course = await this.owner.lookup('service:store').find('course', 1);
+    const course = await this.owner.lookup('service:store').findRecord('course', 1);
     this.server.post(`/api/courses/${course.id}/rollover`, function (schema, request) {
       const data = queryString.parse(request.requestBody, {
         parseBooleans: true,
@@ -472,7 +472,7 @@ module('Integration | Component | course rollover', function (hooks) {
     const course = this.server.create('course', {
       school,
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
 
     await render(hbs`<CourseRollover @course={{this.course}} />`);
@@ -484,7 +484,7 @@ module('Integration | Component | course rollover', function (hooks) {
     const course = this.server.create('course', {
       school,
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
 
     await render(hbs`<CourseRollover @course={{this.course}} />`);
@@ -518,7 +518,7 @@ module('Integration | Component | course rollover', function (hooks) {
       title: 'old course',
       school,
     });
-    const course = await this.owner.lookup('service:store').find('course', 1);
+    const course = await this.owner.lookup('service:store').findRecord('course', 1);
     this.server.post(`/api/courses/${course.id}/rollover`, function (schema, request) {
       const data = queryString.parse(request.requestBody, {
         arrayFormat: 'bracket',

--- a/tests/integration/components/course-sessions-test.js
+++ b/tests/integration/components/course-sessions-test.js
@@ -28,7 +28,7 @@ module('Integration | Component | course sessions', function (hooks) {
   test('it renders', async function (assert) {
     const school = this.server.create('school');
     const course = this.server.create('course', { school });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
     await render(hbs`<CourseSessions
       @course={{this.course}}
@@ -47,7 +47,7 @@ module('Integration | Component | course sessions', function (hooks) {
     const course = this.server.create('course', { school });
     const sessionType = this.server.create('sessionType', { school });
     this.server.createList('session', 2, { course, sessionType });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
     await render(hbs`<CourseSessions
       @course={{this.course}}
@@ -69,7 +69,7 @@ module('Integration | Component | course sessions', function (hooks) {
     this.server.create('offering', {
       session: sessions[0],
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
     await render(hbs`<CourseSessions
       @course={{this.course}}

--- a/tests/integration/components/course-summary-header-test.js
+++ b/tests/integration/components/course-summary-header-test.js
@@ -44,7 +44,7 @@ module('Integration | Component | course summary header', function (hooks) {
       level: 3,
       published: true,
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
     await render(hbs`<CourseSummaryHeader @course={{this.course}} />`);
     const title = 'h2';
@@ -81,7 +81,7 @@ module('Integration | Component | course summary header', function (hooks) {
     const course = this.server.create('course', {
       school,
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
     await render(hbs`<CourseSummaryHeader @course={{this.course}} />`);
     const actions = '.course-summary-actions a';
@@ -101,7 +101,7 @@ module('Integration | Component | course summary header', function (hooks) {
     this.owner.register('service:router', routerMock);
 
     const course = this.server.create('course');
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
     await render(hbs`<CourseSummaryHeader @course={{this.course}} />`);
     const actions = '.course-summary-actions a';
@@ -124,7 +124,7 @@ module('Integration | Component | course summary header', function (hooks) {
     const course = this.server.create('course', {
       school,
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
     await render(hbs`<CourseSummaryHeader @course={{this.course}} />`);
     const actions = '.course-summary-actions a';

--- a/tests/integration/components/course-visualizations-test.js
+++ b/tests/integration/components/course-visualizations-test.js
@@ -14,7 +14,7 @@ module('Integration | Component | course-visualizations', function (hooks) {
   test('it renders', async function (assert) {
     const school = this.server.create('school');
     const course = this.server.create('course', { year: 2021, school });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
 
     await render(hbs`<CourseVisualizations @model={{this.course}} />`);
@@ -36,7 +36,7 @@ module('Integration | Component | course-visualizations', function (hooks) {
     });
     const school = this.server.create('school');
     const course = this.server.create('course', { year: 2021, school });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
 
     await render(hbs`<CourseVisualizations @model={{this.course}} />`);

--- a/tests/integration/components/course-visualize-instructor-test.js
+++ b/tests/integration/components/course-visualize-instructor-test.js
@@ -16,8 +16,8 @@ module('Integration | Component | course-visualize-instructor', function (hooks)
     const school = this.server.create('school');
     const course = this.server.create('course', { year: 2021, school });
     const user = this.server.create('user');
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
-    const userModel = await this.owner.lookup('service:store').find('user', user.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
+    const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
     this.set('course', courseModel);
     this.set('user', userModel);
 
@@ -40,8 +40,8 @@ module('Integration | Component | course-visualize-instructor', function (hooks)
     const school = this.server.create('school');
     const course = this.server.create('course', { year: 2021, school });
     const user = this.server.create('user');
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
-    const userModel = await this.owner.lookup('service:store').find('user', user.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
+    const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
     this.set('course', courseModel);
     this.set('user', userModel);
 
@@ -61,8 +61,8 @@ module('Integration | Component | course-visualize-instructor', function (hooks)
     const school = this.server.create('school');
     const course = this.server.create('course', { year: 2021, school });
     const user = this.server.create('user');
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
-    const userModel = await this.owner.lookup('service:store').find('user', user.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
+    const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
     this.set('course', courseModel);
     this.set('user', userModel);
 
@@ -127,8 +127,8 @@ module('Integration | Component | course-visualize-instructor', function (hooks)
       year: 2022,
     });
 
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
-    const userModel = await this.owner.lookup('service:store').find('user', instructor.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
+    const userModel = await this.owner.lookup('service:store').findRecord('user', instructor.id);
     this.set('course', courseModel);
     this.set('user', userModel);
 

--- a/tests/integration/components/course-visualize-instructors-test.js
+++ b/tests/integration/components/course-visualize-instructors-test.js
@@ -14,7 +14,7 @@ module('Integration | Component | course-visualize-instructors', function (hooks
   test('it renders', async function (assert) {
     const school = this.server.create('school');
     const course = this.server.create('course', { year: 2021, school });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
 
     await render(hbs`<CourseVisualizeInstructors @model={{this.course}} />`);
@@ -33,7 +33,7 @@ module('Integration | Component | course-visualize-instructors', function (hooks
       endDate: new Date('2021/04/01'),
       instructors: [instructor1, instructor2],
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
 
     await render(hbs`<CourseVisualizeInstructors @model={{this.course}} />`);
@@ -59,7 +59,7 @@ module('Integration | Component | course-visualize-instructors', function (hooks
     });
     const school = this.server.create('school');
     const course = this.server.create('course', { year: 2021, school });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
 
     await render(hbs`<CourseVisualizeInstructors @model={{this.course}} />`);
@@ -70,7 +70,7 @@ module('Integration | Component | course-visualize-instructors', function (hooks
   test('breadcrumb', async function (assert) {
     const school = this.server.create('school');
     const course = this.server.create('course', { year: 2021, school });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
 
     await render(hbs`<CourseVisualizeInstructors @model={{this.course}} />`);

--- a/tests/integration/components/course-visualize-objectives-test.js
+++ b/tests/integration/components/course-visualize-objectives-test.js
@@ -14,7 +14,7 @@ module('Integration | Component | course-visualize-objectives', function (hooks)
   test('it renders', async function (assert) {
     const school = this.server.create('school');
     const course = this.server.create('course', { year: 2021, school });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
 
     await render(hbs`<CourseVisualizeObjectives @model={{this.course}} />`);
@@ -31,7 +31,7 @@ module('Integration | Component | course-visualize-objectives', function (hooks)
     });
     const school = this.server.create('school');
     const course = this.server.create('course', { year: 2021, school });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
 
     await render(hbs`<CourseVisualizeObjectives @model={{this.course}} />`);
@@ -42,7 +42,7 @@ module('Integration | Component | course-visualize-objectives', function (hooks)
   test('breadcrumb', async function (assert) {
     const school = this.server.create('school');
     const course = this.server.create('course', { year: 2021, school });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
 
     await render(hbs`<CourseVisualizeObjectives @model={{this.course}} />`);

--- a/tests/integration/components/course-visualize-session-type-test.js
+++ b/tests/integration/components/course-visualize-session-type-test.js
@@ -18,8 +18,8 @@ module('Integration | Component | course-visualize-session-type', function (hook
     const sessionType = this.server.create('sessionType', { school, sessions: [session] });
     this.sessionTypeModel = await this.owner
       .lookup('service:store')
-      .find('session-type', sessionType.id);
-    this.courseModel = await this.owner.lookup('service:store').find('course', course.id);
+      .findRecord('session-type', sessionType.id);
+    this.courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
   });
 
   test('it renders', async function (assert) {

--- a/tests/integration/components/course-visualize-session-types-test.js
+++ b/tests/integration/components/course-visualize-session-types-test.js
@@ -47,7 +47,7 @@ module('Integration | Component | course-visualize-session-types', function (hoo
       startDate: new Date('2019-12-05T18:00:00'),
       endDate: new Date('2019-12-05T21:00:00'),
     });
-    this.courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    this.courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
   });
 
   test('it renders', async function (assert) {

--- a/tests/integration/components/course-visualize-term-test.js
+++ b/tests/integration/components/course-visualize-term-test.js
@@ -16,8 +16,8 @@ module('Integration | Component | course-visualize-term', function (hooks) {
     const vocabulary = this.server.create('vocabulary', { school });
     const term = this.server.create('term', { vocabulary });
     const course = this.server.create('course', { year: 2021, school, terms: [term] });
-    this.courseModel = await this.owner.lookup('service:store').find('course', course.id);
-    this.termModel = await this.owner.lookup('service:store').find('term', term.id);
+    this.courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
+    this.termModel = await this.owner.lookup('service:store').findRecord('term', term.id);
   });
 
   test('it renders', async function (assert) {

--- a/tests/integration/components/course-visualize-vocabularies-test.js
+++ b/tests/integration/components/course-visualize-vocabularies-test.js
@@ -14,7 +14,7 @@ module('Integration | Component | course-visualize-vocabularies', function (hook
   hooks.beforeEach(async function () {
     const school = this.server.create('school');
     const course = this.server.create('course', { year: 2021, school });
-    this.courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    this.courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
   });
 
   test('it renders', async function (assert) {

--- a/tests/integration/components/course-visualize-vocabulary-test.js
+++ b/tests/integration/components/course-visualize-vocabulary-test.js
@@ -16,10 +16,10 @@ module('Integration | Component | course-visualize-vocabulary', function (hooks)
     const vocabulary = this.server.create('vocabulary', { school });
     const term = this.server.create('term', { vocabulary });
     const course = this.server.create('course', { year: 2021, school, terms: [term] });
-    this.courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    this.courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.vocabularyModel = await this.owner
       .lookup('service:store')
-      .find('vocabulary', vocabulary.id);
+      .findRecord('vocabulary', vocabulary.id);
   });
 
   test('it renders', async function (assert) {

--- a/tests/integration/components/course/collapsed-objectives-test.js
+++ b/tests/integration/components/course/collapsed-objectives-test.js
@@ -36,7 +36,7 @@ module('Integration | Component | course/collapsed-objectives', function (hooks)
         this.objectiveWithTerms,
       ],
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
 
     this.set('course', courseModel);
     await render(hbs`<Course::CollapsedObjectives @course={{this.course}} @expand={{(noop)}} />`);
@@ -56,7 +56,7 @@ module('Integration | Component | course/collapsed-objectives', function (hooks)
     assert.expect(2);
 
     const course = this.server.create('course');
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
 
     this.set('course', courseModel);
     this.set('click', () => {
@@ -74,7 +74,7 @@ module('Integration | Component | course/collapsed-objectives', function (hooks)
     const course = this.server.create('course', {
       courseObjectives: [this.objectiveWithProgramYearObjectives],
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
 
     this.set('course', courseModel);
     await render(hbs`<Course::CollapsedObjectives @course={{this.course}} @expand={{(noop)}} />`);
@@ -86,7 +86,7 @@ module('Integration | Component | course/collapsed-objectives', function (hooks)
     const course = this.server.create('course', {
       courseObjectives: [this.objective],
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
 
     this.set('course', courseModel);
     await render(hbs`<Course::CollapsedObjectives @course={{this.course}} @expand={{(noop)}} />`);
@@ -98,7 +98,7 @@ module('Integration | Component | course/collapsed-objectives', function (hooks)
     const course = this.server.create('course', {
       courseObjectives: [this.objectiveWithMesh],
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
 
     this.set('course', courseModel);
     await render(hbs`<Course::CollapsedObjectives @course={{this.course}} @expand={{(noop)}} />`);
@@ -110,7 +110,7 @@ module('Integration | Component | course/collapsed-objectives', function (hooks)
     const course = this.server.create('course', {
       courseObjectives: [this.objective],
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
 
     this.set('course', courseModel);
     await render(hbs`<Course::CollapsedObjectives @course={{this.course}} @expand={{(noop)}} />`);
@@ -122,7 +122,7 @@ module('Integration | Component | course/collapsed-objectives', function (hooks)
     const course = this.server.create('course', {
       courseObjectives: [this.objectiveWithTerms],
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
 
     this.set('course', courseModel);
     await render(hbs`<Course::CollapsedObjectives @course={{this.course}} @expand={{(noop)}} />`);
@@ -134,7 +134,7 @@ module('Integration | Component | course/collapsed-objectives', function (hooks)
     const course = this.server.create('course', {
       courseObjectives: [this.objective],
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
 
     this.set('course', courseModel);
     await render(hbs`<Course::CollapsedObjectives @course={{this.course}} @expand={{(noop)}} />`);

--- a/tests/integration/components/course/loader-test.js
+++ b/tests/integration/components/course/loader-test.js
@@ -32,7 +32,7 @@ module('Integration | Component | course/loader', function (hooks) {
 
     this.owner.register('service:permissionChecker', PermissionCheckerStub);
 
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
 
     await render(hbs`<Course::Loader @course={{this.course}} />`);

--- a/tests/integration/components/course/loading-test.js
+++ b/tests/integration/components/course/loading-test.js
@@ -15,7 +15,7 @@ module('Integration | Component | course/loading', function (hooks) {
     const course = this.server.create('course', {
       school,
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
 
     await render(hbs`<Course::Loading @course={{this.course}} />`);

--- a/tests/integration/components/course/manage-objective-descriptors-test.js
+++ b/tests/integration/components/course/manage-objective-descriptors-test.js
@@ -15,7 +15,7 @@ module('Integration | Component | course/manage-objective-descriptors', function
     const descriptors = this.server.createList('meshDescriptor', 4);
     const descriptorModel = await this.owner
       .lookup('service:store')
-      .find('meshDescriptor', descriptors[0].id);
+      .findRecord('meshDescriptor', descriptors[0].id);
     this.set('selected', [descriptorModel]);
     await render(hbs`<Course::ManageObjectiveDescriptors
       @selected={{this.selected}}
@@ -44,7 +44,7 @@ module('Integration | Component | course/manage-objective-descriptors', function
     const descriptors = this.server.createList('meshDescriptor', 2);
     const descriptorModel = await this.owner
       .lookup('service:store')
-      .find('meshDescriptor', descriptors[0].id);
+      .findRecord('meshDescriptor', descriptors[0].id);
     this.set('selected', [descriptorModel]);
     this.set('add', (descriptor) => {
       this.set('selected', [descriptorModel, descriptor]);
@@ -83,7 +83,7 @@ module('Integration | Component | course/manage-objective-descriptors', function
     const descriptors = this.server.createList('meshDescriptor', 2);
     const descriptorModel = await this.owner
       .lookup('service:store')
-      .find('meshDescriptor', descriptors[0].id);
+      .findRecord('meshDescriptor', descriptors[0].id);
     this.set('selected', [descriptorModel]);
     this.set('remove', (descriptor) => {
       assert.strictEqual(descriptor.id, descriptorModel.id);

--- a/tests/integration/components/course/objective-list-item-descriptors-test.js
+++ b/tests/integration/components/course/objective-list-item-descriptors-test.js
@@ -33,7 +33,7 @@ module('Integration | Component | course/objective-list-item-descriptors', funct
     const courseObjective = this.server.create('courseObjective', { course });
     const courseObjectiveModel = await this.owner
       .lookup('service:store')
-      .find('courseObjective', courseObjective.id);
+      .findRecord('courseObjective', courseObjective.id);
     this.set('courseObjective', courseObjectiveModel);
     await render(hbs`<Course::ObjectiveListItemDescriptors
       @courseObjective={{this.courseObjective}}
@@ -58,7 +58,7 @@ module('Integration | Component | course/objective-list-item-descriptors', funct
     });
     const courseObjectiveModel = await this.owner
       .lookup('service:store')
-      .find('courseObjective', courseObjective.id);
+      .findRecord('courseObjective', courseObjective.id);
     this.set('courseObjective', courseObjectiveModel);
     await render(hbs`<Course::ObjectiveListItemDescriptors
       @courseObjective={{this.courseObjective}}
@@ -85,7 +85,7 @@ module('Integration | Component | course/objective-list-item-descriptors', funct
     });
     const courseObjectiveModel = await this.owner
       .lookup('service:store')
-      .find('courseObjective', courseObjective.id);
+      .findRecord('courseObjective', courseObjective.id);
     this.set('courseObjective', courseObjectiveModel);
     await render(hbs`<Course::ObjectiveListItemDescriptors
       @courseObjective={{this.courseObjective}}
@@ -113,7 +113,7 @@ module('Integration | Component | course/objective-list-item-descriptors', funct
     });
     const courseObjectiveModel = await this.owner
       .lookup('service:store')
-      .find('courseObjective', courseObjective.id);
+      .findRecord('courseObjective', courseObjective.id);
     this.set('courseObjective', courseObjectiveModel);
     this.set('save', () => {
       assert.ok(true);
@@ -140,7 +140,7 @@ module('Integration | Component | course/objective-list-item-descriptors', funct
     });
     const courseObjectiveModel = await this.owner
       .lookup('service:store')
-      .find('courseObjective', courseObjective.id);
+      .findRecord('courseObjective', courseObjective.id);
     this.set('courseObjective', courseObjectiveModel);
     this.set('cancel', () => {
       assert.ok(true);
@@ -167,7 +167,7 @@ module('Integration | Component | course/objective-list-item-descriptors', funct
     });
     const courseObjectiveModel = await this.owner
       .lookup('service:store')
-      .find('courseObjective', courseObjective.id);
+      .findRecord('courseObjective', courseObjective.id);
     this.set('courseObjective', courseObjectiveModel);
     this.set('manage', () => {
       assert.ok(true);

--- a/tests/integration/components/course/objective-list-item-parents-test.js
+++ b/tests/integration/components/course/objective-list-item-parents-test.js
@@ -33,7 +33,7 @@ module('Integration | Component | course/objective-list-item-parents', function 
     const courseObjective = this.server.create('courseObjective', { course });
     const courseObjectiveModel = await this.owner
       .lookup('service:store')
-      .find('courseObjective', courseObjective.id);
+      .findRecord('courseObjective', courseObjective.id);
     this.set('courseObjective', courseObjectiveModel);
     await render(hbs`<Course::ObjectiveListItemParents
       @courseObjective={{this.courseObjective}}
@@ -61,7 +61,7 @@ module('Integration | Component | course/objective-list-item-parents', function 
     });
     const courseObjectiveModel = await this.owner
       .lookup('service:store')
-      .find('courseObjective', courseObjective.id);
+      .findRecord('courseObjective', courseObjective.id);
     this.set('courseObjective', courseObjectiveModel);
     await render(hbs`<Course::ObjectiveListItemParents
       @courseObjective={{this.courseObjective}}
@@ -91,7 +91,7 @@ module('Integration | Component | course/objective-list-item-parents', function 
     });
     const courseObjectiveModel = await this.owner
       .lookup('service:store')
-      .find('courseObjective', courseObjective.id);
+      .findRecord('courseObjective', courseObjective.id);
     this.set('courseObjective', courseObjectiveModel);
     await render(hbs`<Course::ObjectiveListItemParents
       @courseObjective={{this.courseObjective}}
@@ -119,7 +119,7 @@ module('Integration | Component | course/objective-list-item-parents', function 
     });
     const courseObjectiveModel = await this.owner
       .lookup('service:store')
-      .find('courseObjective', courseObjective.id);
+      .findRecord('courseObjective', courseObjective.id);
     this.set('courseObjective', courseObjectiveModel);
     this.set('save', () => {
       assert.ok(true);
@@ -146,7 +146,7 @@ module('Integration | Component | course/objective-list-item-parents', function 
     });
     const courseObjectiveModel = await this.owner
       .lookup('service:store')
-      .find('courseObjective', courseObjective.id);
+      .findRecord('courseObjective', courseObjective.id);
     this.set('courseObjective', courseObjectiveModel);
     this.set('cancel', () => {
       assert.ok(true);
@@ -173,7 +173,7 @@ module('Integration | Component | course/objective-list-item-parents', function 
     });
     const courseObjectiveModel = await this.owner
       .lookup('service:store')
-      .find('courseObjective', courseObjective.id);
+      .findRecord('courseObjective', courseObjective.id);
     this.set('courseObjective', courseObjectiveModel);
     this.set('manage', () => {
       assert.ok(true);

--- a/tests/integration/components/course/objective-list-item-test.js
+++ b/tests/integration/components/course/objective-list-item-test.js
@@ -18,7 +18,7 @@ module('Integration | Component | course/objective-list-item', function (hooks) 
     const courseObjective = this.server.create('courseObjective', { course });
     const courseObjectiveModel = await this.owner
       .lookup('service:store')
-      .find('courseObjective', courseObjective.id);
+      .findRecord('courseObjective', courseObjective.id);
     this.set('courseObjective', courseObjectiveModel);
     await render(
       hbs`<Course::ObjectiveListItem
@@ -41,7 +41,7 @@ module('Integration | Component | course/objective-list-item', function (hooks) 
     const courseObjective = this.server.create('courseObjective', { course });
     const courseObjectiveModel = await this.owner
       .lookup('service:store')
-      .find('courseObjective', courseObjective.id);
+      .findRecord('courseObjective', courseObjective.id);
     this.set('courseObjective', courseObjectiveModel);
     await render(
       hbs`<Course::ObjectiveListItem
@@ -64,7 +64,7 @@ module('Integration | Component | course/objective-list-item', function (hooks) 
     const courseObjective = this.server.create('courseObjective', { course });
     const courseObjectiveModel = await this.owner
       .lookup('service:store')
-      .find('courseObjective', courseObjective.id);
+      .findRecord('courseObjective', courseObjective.id);
     this.set('courseObjective', courseObjectiveModel);
     await render(
       hbs`<Course::ObjectiveListItem
@@ -83,7 +83,7 @@ module('Integration | Component | course/objective-list-item', function (hooks) 
     const courseObjective = this.server.create('courseObjective', { course });
     const courseObjectiveModel = await this.owner
       .lookup('service:store')
-      .find('courseObjective', courseObjective.id);
+      .findRecord('courseObjective', courseObjective.id);
     this.set('courseObjective', courseObjectiveModel);
     await render(
       hbs`<Course::ObjectiveListItem
@@ -102,7 +102,7 @@ module('Integration | Component | course/objective-list-item', function (hooks) 
     const courseObjective = this.server.create('courseObjective', { course });
     const courseObjectiveModel = await this.owner
       .lookup('service:store')
-      .find('courseObjective', courseObjective.id);
+      .findRecord('courseObjective', courseObjective.id);
     this.set('courseObjective', courseObjectiveModel);
     await render(
       hbs`<Course::ObjectiveListItem
@@ -121,7 +121,7 @@ module('Integration | Component | course/objective-list-item', function (hooks) 
     const courseObjective = this.server.create('courseObjective', { course });
     const courseObjectiveModel = await this.owner
       .lookup('service:store')
-      .find('courseObjective', courseObjective.id);
+      .findRecord('courseObjective', courseObjective.id);
     this.set('courseObjective', courseObjectiveModel);
     await render(
       hbs`<Course::ObjectiveListItem

--- a/tests/integration/components/course/objective-list-test.js
+++ b/tests/integration/components/course/objective-list-test.js
@@ -32,7 +32,7 @@ module('Integration | Component | course/objective-list', function (hooks) {
       terms: [term2],
     });
 
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
 
     await render(
@@ -69,7 +69,7 @@ module('Integration | Component | course/objective-list', function (hooks) {
   test('empty list', async function (assert) {
     assert.expect(2);
     const course = this.server.create('course');
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
 
     await render(
@@ -86,7 +86,7 @@ module('Integration | Component | course/objective-list', function (hooks) {
     assert.expect(3);
     const course = this.server.create('course');
     this.server.create('course-objective', { course, position: 0 });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
 
     await render(

--- a/tests/integration/components/course/objectives-test.js
+++ b/tests/integration/components/course/objectives-test.js
@@ -32,7 +32,7 @@ module('Integration | Component | course/objectives', function (hooks) {
       programYearObjectives: [pyObjectives[0]],
     });
     this.server.create('courseObjective', { course });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
 
     this.set('course', courseModel);
     await render(hbs`<Course::Objectives
@@ -84,7 +84,7 @@ module('Integration | Component | course/objectives', function (hooks) {
       course,
       programYearObjectives: [pyObjectives[0]],
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
 
     this.set('course', courseModel);
     await render(hbs`<Course::Objectives
@@ -159,7 +159,7 @@ module('Integration | Component | course/objectives', function (hooks) {
     this.server.createList('programYearObjective', 4, {
       competency: competencies[1],
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
 
     this.set('course', courseModel);
     await render(hbs`<Course::Objectives
@@ -210,7 +210,7 @@ module('Integration | Component | course/objectives', function (hooks) {
   test('deleting objective', async function (assert) {
     const course = this.server.create('course');
     this.server.create('courseObjective', { course });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
 
     this.set('course', courseModel);
     await render(hbs`<Course::Objectives

--- a/tests/integration/components/course/publication-menu-test.js
+++ b/tests/integration/components/course/publication-menu-test.js
@@ -14,7 +14,7 @@ module('Integration | Component | course/publication-menu', function (hooks) {
 
   test('it renders and is accessible for draft course', async function (assert) {
     this.server.create('course');
-    const courseModel = await this.owner.lookup('service:store').find('course', 1);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', 1);
     this.set('course', courseModel);
     await render(hbs`<Course::PublicationMenu @course={{this.course}} />`);
 
@@ -42,7 +42,7 @@ module('Integration | Component | course/publication-menu', function (hooks) {
       published: true,
       publishedAsTbd: true,
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', 1);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', 1);
     this.set('course', courseModel);
     await render(hbs`<Course::PublicationMenu @course={{this.course}} />`);
 
@@ -58,7 +58,7 @@ module('Integration | Component | course/publication-menu', function (hooks) {
       published: true,
       publishedAsTbd: false,
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', 1);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', 1);
     this.set('course', courseModel);
     await render(hbs`<Course::PublicationMenu @course={{this.course}} />`);
 
@@ -71,7 +71,7 @@ module('Integration | Component | course/publication-menu', function (hooks) {
 
   test('click opens menu', async function (assert) {
     this.server.create('course');
-    const courseModel = await this.owner.lookup('service:store').find('course', 1);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', 1);
     this.set('course', courseModel);
     await render(hbs`<Course::PublicationMenu @course={{this.course}} />`);
     assert.ok(component.menuClosed);
@@ -81,7 +81,7 @@ module('Integration | Component | course/publication-menu', function (hooks) {
 
   test('correct actions for unpublished course', async function (assert) {
     this.server.create('course');
-    const courseModel = await this.owner.lookup('service:store').find('course', 1);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', 1);
     this.set('course', courseModel);
     await render(hbs`<Course::PublicationMenu @course={{this.course}} />`);
     await component.toggle.click();
@@ -98,7 +98,7 @@ module('Integration | Component | course/publication-menu', function (hooks) {
     this.server.create('course', {
       cohorts: [cohort],
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', 1);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', 1);
     this.set('course', courseModel);
     await render(hbs`<Course::PublicationMenu @course={{this.course}} />`);
     await component.toggle.click();
@@ -115,7 +115,7 @@ module('Integration | Component | course/publication-menu', function (hooks) {
       published: true,
       publishedAsTbd: true,
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', 1);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', 1);
     this.set('course', courseModel);
     await render(hbs`<Course::PublicationMenu @course={{this.course}} />`);
     await component.toggle.click();
@@ -134,7 +134,7 @@ module('Integration | Component | course/publication-menu', function (hooks) {
       published: true,
       publishedAsTbd: true,
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', 1);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', 1);
     this.set('course', courseModel);
     await render(hbs`<Course::PublicationMenu @course={{this.course}} />`);
     await component.toggle.click();
@@ -151,7 +151,7 @@ module('Integration | Component | course/publication-menu', function (hooks) {
       published: true,
       publishedAsTbd: false,
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', 1);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', 1);
     this.set('course', courseModel);
     await render(hbs`<Course::PublicationMenu @course={{this.course}} />`);
     await component.toggle.click();
@@ -165,7 +165,7 @@ module('Integration | Component | course/publication-menu', function (hooks) {
 
   test('down opens menu', async function (assert) {
     this.server.create('course');
-    const courseModel = await this.owner.lookup('service:store').find('course', 1);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', 1);
     this.set('course', courseModel);
     await render(hbs`<Course::PublicationMenu @course={{this.course}} />`);
 
@@ -176,7 +176,7 @@ module('Integration | Component | course/publication-menu', function (hooks) {
 
   test('escape closes menu', async function (assert) {
     this.server.create('course');
-    const courseModel = await this.owner.lookup('service:store').find('course', 1);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', 1);
     this.set('course', courseModel);
     await render(hbs`<Course::PublicationMenu @course={{this.course}} />`);
 

--- a/tests/integration/components/course/rollover-date-picker-test.js
+++ b/tests/integration/components/course/rollover-date-picker-test.js
@@ -13,7 +13,7 @@ module('Integration | Component | course/rollover-date-picker', function (hooks)
 
   test('it renders', async function (assert) {
     const course = this.server.create('course');
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
     await render(hbs`<Course::RolloverDatePicker @course={{this.course}} @onChange={{(noop)}} />`);
     assert.dom('input').hasValue(new Date(course.startDate).toLocaleDateString());
@@ -28,7 +28,7 @@ module('Integration | Component | course/rollover-date-picker', function (hooks)
     const course = this.server.create('course', {
       startDate: date,
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
     this.set('change', (changedDate) => {
       assert.strictEqual(newDate.getTime(), changedDate.getTime());

--- a/tests/integration/components/dashboard/courses-calendar-filter-test.js
+++ b/tests/integration/components/dashboard/courses-calendar-filter-test.js
@@ -28,7 +28,7 @@ module('Integration | Component | dashboard/courses-calendar-filter', function (
       school,
       year: thisYear - 1,
     });
-    const schoolModel = await this.owner.lookup('service:store').find('school', school.id);
+    const schoolModel = await this.owner.lookup('service:store').findRecord('school', school.id);
     this.set('school', schoolModel);
     await render(hbs`<Dashboard::CoursesCalendarFilter
       @school={{this.school}}
@@ -74,7 +74,7 @@ module('Integration | Component | dashboard/courses-calendar-filter', function (
       school,
       year: thisYear - 1,
     });
-    const schoolModel = await this.owner.lookup('service:store').find('school', school.id);
+    const schoolModel = await this.owner.lookup('service:store').findRecord('school', school.id);
     this.set('school', schoolModel);
     await render(hbs`<Dashboard::CoursesCalendarFilter
       @school={{this.school}}
@@ -101,7 +101,7 @@ module('Integration | Component | dashboard/courses-calendar-filter', function (
       school,
       year: 2016,
     });
-    const schoolModel = await this.owner.lookup('service:store').find('school', school.id);
+    const schoolModel = await this.owner.lookup('service:store').findRecord('school', school.id);
     this.set('school', schoolModel);
     await render(hbs`<Dashboard::CoursesCalendarFilter
       @school={{this.school}}
@@ -144,7 +144,7 @@ module('Integration | Component | dashboard/courses-calendar-filter', function (
       school,
       year: 2014,
     });
-    const schoolModel = await this.owner.lookup('service:store').find('school', school.id);
+    const schoolModel = await this.owner.lookup('service:store').findRecord('school', school.id);
     this.set('school', schoolModel);
     await render(hbs`<Dashboard::CoursesCalendarFilter
       @school={{this.school}}
@@ -167,7 +167,7 @@ module('Integration | Component | dashboard/courses-calendar-filter', function (
     this.server.createList('course', 4, {
       school,
     });
-    const schoolModel = await this.owner.lookup('service:store').find('school', school.id);
+    const schoolModel = await this.owner.lookup('service:store').findRecord('school', school.id);
     this.set('school', schoolModel);
     await render(hbs`<Dashboard::CoursesCalendarFilter
       @school={{this.school}}
@@ -195,7 +195,7 @@ module('Integration | Component | dashboard/courses-calendar-filter', function (
     this.server.create('course', {
       school,
     });
-    const schoolModel = await this.owner.lookup('service:store').find('school', school.id);
+    const schoolModel = await this.owner.lookup('service:store').findRecord('school', school.id);
     this.set('school', schoolModel);
     this.set('remove', (id) => {
       assert.strictEqual(id, '1');
@@ -216,7 +216,7 @@ module('Integration | Component | dashboard/courses-calendar-filter', function (
     this.server.create('course', {
       school,
     });
-    const schoolModel = await this.owner.lookup('service:store').find('school', school.id);
+    const schoolModel = await this.owner.lookup('service:store').findRecord('school', school.id);
     this.set('school', schoolModel);
     this.set('add', (id) => {
       assert.strictEqual(id, '1');

--- a/tests/integration/components/dashboard/selected-term-tree-test.js
+++ b/tests/integration/components/dashboard/selected-term-tree-test.js
@@ -26,8 +26,8 @@ module('Integration | Component | dashboard/SelectedTermTree', function (hooks) 
       parent: term2,
       vocabulary,
     });
-    const termModel1 = await this.owner.lookup('service:store').find('term', term1.id);
-    const termModel2 = await this.owner.lookup('service:store').find('term', term2.id);
+    const termModel1 = await this.owner.lookup('service:store').findRecord('term', term1.id);
+    const termModel2 = await this.owner.lookup('service:store').findRecord('term', term2.id);
     this.topLevelTerms = [termModel1, termModel2];
   });
 

--- a/tests/integration/components/dashboard/selected-vocabulary-test.js
+++ b/tests/integration/components/dashboard/selected-vocabulary-test.js
@@ -28,7 +28,7 @@ module('Integration | Component | dashboard/selected-vocabulary', function (hook
     });
     this.vocabularyModel = await this.owner
       .lookup('service:store')
-      .find('vocabulary', vocabulary.id);
+      .findRecord('vocabulary', vocabulary.id);
   });
 
   test('it renders', async function (assert) {

--- a/tests/integration/components/detail-learnergroups-list-test.js
+++ b/tests/integration/components/detail-learnergroups-list-test.js
@@ -39,10 +39,10 @@ module('Integration | Component | detail learnergroups list', function (hooks) {
     });
 
     const store = this.owner.lookup('service:store');
-    this.tlg1 = await store.find('learner-group', tlg1.id);
-    this.subGroup1 = await store.find('learner-group', subGroup1.id);
-    this.subSubGroup = await store.find('learner-group', subSubGroup1.id);
-    this.subGroup2 = await store.find('learner-group', subGroup2.id);
+    this.tlg1 = await store.findRecord('learner-group', tlg1.id);
+    this.subGroup1 = await store.findRecord('learner-group', subGroup1.id);
+    this.subSubGroup = await store.findRecord('learner-group', subSubGroup1.id);
+    this.subGroup2 = await store.findRecord('learner-group', subGroup2.id);
   });
 
   test('it renders', async function (assert) {

--- a/tests/integration/components/detail-learners-and-learnergroups-test.js
+++ b/tests/integration/components/detail-learners-and-learnergroups-test.js
@@ -54,19 +54,28 @@ module('Integration | Component | detail-learners-and-learner-groups', function 
     });
 
     const store = this.owner.lookup('service:store');
-    this.cohort1 = await store.find('cohort', cohort1.id);
-    this.cohort2 = await store.find('cohort', cohort2.id);
-    this.topLevelLearnerGroup1 = await store.find('learner-group', topLevelLearnerGroup1.id);
-    this.topLevelLearnerGroup2 = await store.find('learner-group', topLevelLearnerGroup2.id);
-    this.topLevelLearnerGroup3 = await store.find('learner-group', topLevelLearnerGroup3.id);
-    this.secondLevelLearnerGroup1 = await store.find('learner-group', secondLevelLearnerGroup1.id);
-    this.secondLevelLearnerGroup2 = await store.find('learner-group', secondLevelLearnerGroup2.id);
-    this.secondLevelLearnerGroup3 = await store.find('learner-group', secondLevelLearnerGroup3.id);
-    this.learner1 = await store.find('user', learners[0].id);
-    this.learner2 = await store.find('user', learners[1].id);
-    this.learner3 = await store.find('user', learners[2].id);
-    this.learner4 = await store.find('user', learners[3].id);
-    this.ilmSession = await store.find('ilmSession', ilmSession.id);
+    this.cohort1 = await store.findRecord('cohort', cohort1.id);
+    this.cohort2 = await store.findRecord('cohort', cohort2.id);
+    this.topLevelLearnerGroup1 = await store.findRecord('learner-group', topLevelLearnerGroup1.id);
+    this.topLevelLearnerGroup2 = await store.findRecord('learner-group', topLevelLearnerGroup2.id);
+    this.topLevelLearnerGroup3 = await store.findRecord('learner-group', topLevelLearnerGroup3.id);
+    this.secondLevelLearnerGroup1 = await store.findRecord(
+      'learner-group',
+      secondLevelLearnerGroup1.id
+    );
+    this.secondLevelLearnerGroup2 = await store.findRecord(
+      'learner-group',
+      secondLevelLearnerGroup2.id
+    );
+    this.secondLevelLearnerGroup3 = await store.findRecord(
+      'learner-group',
+      secondLevelLearnerGroup3.id
+    );
+    this.learner1 = await store.findRecord('user', learners[0].id);
+    this.learner2 = await store.findRecord('user', learners[1].id);
+    this.learner3 = await store.findRecord('user', learners[2].id);
+    this.learner4 = await store.findRecord('user', learners[3].id);
+    this.ilmSession = await store.findRecord('ilmSession', ilmSession.id);
   });
 
   test('it renders', async function (assert) {

--- a/tests/integration/components/detail-learning-materials-test.js
+++ b/tests/integration/components/detail-learning-materials-test.js
@@ -37,7 +37,7 @@ module('Integration | Component | detail learning materials', function (hooks) {
     const course = this.server.create('course', {
       learningMaterials: [clm],
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
 
     this.set('subject', courseModel);
 
@@ -78,7 +78,7 @@ module('Integration | Component | detail learning materials', function (hooks) {
     const course = this.server.create('course', {
       learningMaterials: [clm],
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
 
     this.set('subject', courseModel);
 
@@ -115,7 +115,7 @@ module('Integration | Component | detail learning materials', function (hooks) {
     const course = this.server.create('course', {
       learningMaterials,
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('subject', courseModel);
 
     await render(hbs`<DetailLearningMaterials
@@ -143,7 +143,7 @@ module('Integration | Component | detail learning materials', function (hooks) {
     const course = this.server.create('course', {
       learningMaterials,
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('subject', courseModel);
 
     await render(hbs`<DetailLearningMaterials
@@ -159,7 +159,7 @@ module('Integration | Component | detail learning materials', function (hooks) {
     assert.expect(1);
 
     const course = this.server.create('course');
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('subject', courseModel);
 
     await render(hbs`<DetailLearningMaterials
@@ -187,7 +187,7 @@ module('Integration | Component | detail learning materials', function (hooks) {
     const course = this.server.create('course', {
       learningMaterials: [clm],
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
 
     this.set('subject', courseModel);
 
@@ -216,7 +216,7 @@ module('Integration | Component | detail learning materials', function (hooks) {
     const course = this.server.create('course', {
       learningMaterials,
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('subject', courseModel);
     await render(hbs`<DetailLearningMaterials
       @subject={{this.subject}}
@@ -248,7 +248,7 @@ module('Integration | Component | detail learning materials', function (hooks) {
     const course = this.server.create('course', {
       learningMaterials,
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('subject', courseModel);
     this.server.patch('/api/courselearningmaterials/1', (schema) => {
       assert.ok(true);

--- a/tests/integration/components/detail-terms-list-item-test.js
+++ b/tests/integration/components/detail-terms-list-item-test.js
@@ -19,7 +19,7 @@ module('Integration | Component | detail terms list item', function (hooks) {
       vocabulary: this.vocabulary,
       title: 'Foo',
     });
-    const termModel = await this.owner.lookup('service:store').find('term', term.id);
+    const termModel = await this.owner.lookup('service:store').findRecord('term', term.id);
     this.set('term', termModel);
     await render(hbs`<DetailTermsListItem @term={{this.term}} @canEdit={{false}} />`);
     assert.notStrictEqual(this.element.textContent.trim().indexOf('Foo'), -1);
@@ -40,7 +40,7 @@ module('Integration | Component | detail terms list item', function (hooks) {
       title: 'Foo',
       parent: term2,
     });
-    const termModel = await this.owner.lookup('service:store').find('term', term3.id);
+    const termModel = await this.owner.lookup('service:store').findRecord('term', term3.id);
     this.set('term', termModel);
     await render(hbs`<DetailTermsListItem @term={{this.term}} @canEdit={{false}} />`);
     assert.dom('.muted').includesText('Lorem »');
@@ -54,7 +54,7 @@ module('Integration | Component | detail terms list item', function (hooks) {
       vocabulary: this.vocabulary,
       title: 'Foo',
     });
-    const termModel = await this.owner.lookup('service:store').find('term', term.id);
+    const termModel = await this.owner.lookup('service:store').findRecord('term', term.id);
     this.set('term', termModel);
     this.set('remove', (val) => {
       assert.strictEqual(termModel, val);
@@ -73,7 +73,7 @@ module('Integration | Component | detail terms list item', function (hooks) {
       vocabulary: this.vocabulary,
       title: 'Foo',
     });
-    const termModel = await this.owner.lookup('service:store').find('term', term.id);
+    const termModel = await this.owner.lookup('service:store').findRecord('term', term.id);
     this.set('term', termModel);
     await render(
       hbs`<DetailTermsListItem @term={{this.term}} @canEdit={{true}} @remove={{(noop)}} />`
@@ -87,7 +87,7 @@ module('Integration | Component | detail terms list item', function (hooks) {
       vocabulary: this.vocabulary,
       title: 'Foo',
     });
-    const termModel = await this.owner.lookup('service:store').find('term', term.id);
+    const termModel = await this.owner.lookup('service:store').findRecord('term', term.id);
     this.set('term', termModel);
     await render(hbs`<DetailTermsListItem @term={{this.term}} @canEdit={{false}} />`);
     assert.dom('.inactive').doesNotExist();

--- a/tests/integration/components/detail-terms-list-test.js
+++ b/tests/integration/components/detail-terms-list-test.js
@@ -45,7 +45,7 @@ module('Integration | Component | detail terms list', function (hooks) {
     });
     const vocabularyModel = await this.owner
       .lookup('service:store')
-      .find('vocabulary', vocabulary.id);
+      .findRecord('vocabulary', vocabulary.id);
     const terms = await this.owner.lookup('service:store').findAll('term');
 
     this.set('vocabulary', vocabularyModel);
@@ -97,7 +97,7 @@ module('Integration | Component | detail terms list', function (hooks) {
 
     const vocabularyModel = await this.owner
       .lookup('service:store')
-      .find('vocabulary', vocabulary.id);
+      .findRecord('vocabulary', vocabulary.id);
     const terms = await this.owner.lookup('service:store').findAll('term');
 
     this.set('vocabulary', vocabularyModel);
@@ -129,7 +129,7 @@ module('Integration | Component | detail terms list', function (hooks) {
 
     const vocabularyModel = await this.owner
       .lookup('service:store')
-      .find('vocabulary', vocabulary.id);
+      .findRecord('vocabulary', vocabulary.id);
     const terms = await this.owner.lookup('service:store').findAll('term');
     this.set('vocabulary', vocabularyModel);
     this.set('terms', terms);
@@ -161,7 +161,7 @@ module('Integration | Component | detail terms list', function (hooks) {
 
     const vocabularyModel = await this.owner
       .lookup('service:store')
-      .find('vocabulary', vocabulary.id);
+      .findRecord('vocabulary', vocabulary.id);
     this.set('vocabulary', vocabularyModel);
     this.set('terms', []);
     await render(hbs`<DetailTermsList
@@ -179,7 +179,7 @@ module('Integration | Component | detail terms list', function (hooks) {
     this.server.create('term', { vocabulary });
     const vocabularyModel = await this.owner
       .lookup('service:store')
-      .find('vocabulary', vocabulary.id);
+      .findRecord('vocabulary', vocabulary.id);
     this.set('vocabulary', vocabularyModel);
     this.set('terms', []);
     this.set('manage', (vocabulary) => {

--- a/tests/integration/components/instructor-selection-manager-test.js
+++ b/tests/integration/components/instructor-selection-manager-test.js
@@ -34,12 +34,18 @@ module('Integration | Component | instructor selection manager', function (hooks
       title: 'Alpha',
     });
     const group3 = this.server.create('instructorGroup', { title: 'Gamma' });
-    this.instructor1 = await this.owner.lookup('service:store').find('user', instructor1.id);
-    this.instructor2 = await this.owner.lookup('service:store').find('user', instructor2.id);
-    this.instructor3 = await this.owner.lookup('service:store').find('user', instructor3.id);
-    this.group1 = await this.owner.lookup('service:store').find('instructor-group', group1.id);
-    this.group2 = await this.owner.lookup('service:store').find('instructor-group', group2.id);
-    this.group3 = await this.owner.lookup('service:store').find('instructor-group', group3.id);
+    this.instructor1 = await this.owner.lookup('service:store').findRecord('user', instructor1.id);
+    this.instructor2 = await this.owner.lookup('service:store').findRecord('user', instructor2.id);
+    this.instructor3 = await this.owner.lookup('service:store').findRecord('user', instructor3.id);
+    this.group1 = await this.owner
+      .lookup('service:store')
+      .findRecord('instructor-group', group1.id);
+    this.group2 = await this.owner
+      .lookup('service:store')
+      .findRecord('instructor-group', group2.id);
+    this.group3 = await this.owner
+      .lookup('service:store')
+      .findRecord('instructor-group', group3.id);
   });
 
   test('it renders', async function (assert) {

--- a/tests/integration/components/leadership-list-test.js
+++ b/tests/integration/components/leadership-list-test.js
@@ -29,9 +29,9 @@ module('Integration | Component | leadership list', function (hooks) {
       displayName: 'adam ant',
     });
 
-    this.user1 = await this.owner.lookup('service:store').find('user', user1.id);
-    this.user2 = await this.owner.lookup('service:store').find('user', user2.id);
-    this.user3 = await this.owner.lookup('service:store').find('user', user3.id);
+    this.user1 = await this.owner.lookup('service:store').findRecord('user', user1.id);
+    this.user2 = await this.owner.lookup('service:store').findRecord('user', user2.id);
+    this.user3 = await this.owner.lookup('service:store').findRecord('user', user3.id);
   });
 
   test('it renders with data', async function (assert) {

--- a/tests/integration/components/leadership-manager-test.js
+++ b/tests/integration/components/leadership-manager-test.js
@@ -78,7 +78,7 @@ module('Integration | Component | leadership manager', function (hooks) {
   test('remove director', async function (assert) {
     assert.expect(3);
     this.server.createList('user', 1);
-    const user = await this.owner.lookup('service:store').find('user', 1);
+    const user = await this.owner.lookup('service:store').findRecord('user', 1);
     this.set('directors', [user]);
     this.set('administrators', []);
     this.set('studentAdvisors', []);
@@ -111,7 +111,7 @@ module('Integration | Component | leadership manager', function (hooks) {
   test('remove administrator', async function (assert) {
     assert.expect(3);
     this.server.createList('user', 1);
-    const user = await this.owner.lookup('service:store').find('user', 1);
+    const user = await this.owner.lookup('service:store').findRecord('user', 1);
     this.set('directors', []);
     this.set('administrators', [user]);
     this.set('studentAdvisors', []);
@@ -144,7 +144,7 @@ module('Integration | Component | leadership manager', function (hooks) {
   test('remove student advisor', async function (assert) {
     assert.expect(3);
     this.server.createList('user', 1);
-    const user = await this.owner.lookup('service:store').find('user', 1);
+    const user = await this.owner.lookup('service:store').findRecord('user', 1);
     this.set('directors', []);
     this.set('administrators', []);
     this.set('studentAdvisors', [user]);
@@ -177,7 +177,7 @@ module('Integration | Component | leadership manager', function (hooks) {
   test('add director', async function (assert) {
     assert.expect(8);
     this.server.createList('user', 1);
-    const user = await this.owner.lookup('service:store').find('user', 1);
+    const user = await this.owner.lookup('service:store').findRecord('user', 1);
     this.set('directors', []);
     this.set('administrators', [user]);
     this.set('studentAdvisors', [user]);
@@ -221,7 +221,7 @@ module('Integration | Component | leadership manager', function (hooks) {
   test('add administrator', async function (assert) {
     assert.expect(8);
     this.server.createList('user', 1);
-    const user = await this.owner.lookup('service:store').find('user', 1);
+    const user = await this.owner.lookup('service:store').findRecord('user', 1);
     this.set('directors', [user]);
     this.set('administrators', []);
     this.set('studentAdvisors', [user]);
@@ -266,7 +266,7 @@ module('Integration | Component | leadership manager', function (hooks) {
   test('add student advisor', async function (assert) {
     assert.expect(8);
     this.server.createList('user', 1);
-    const user = await this.owner.lookup('service:store').find('user', 1);
+    const user = await this.owner.lookup('service:store').findRecord('user', 1);
     this.set('directors', [user]);
     this.set('administrators', [user]);
     this.set('studentAdvisors', []);

--- a/tests/integration/components/leadership-search-test.js
+++ b/tests/integration/components/leadership-search-test.js
@@ -126,7 +126,7 @@ module('Integration | Component | leadership search', function (hooks) {
     this.set('select', (user) => {
       assert.strictEqual(parseInt(user.id, 10), 2, 'only user2 should be sent here');
     });
-    const user1 = this.owner.lookup('service:store').find('user', 1);
+    const user1 = this.owner.lookup('service:store').findRecord('user', 1);
 
     this.set('existingUsers', [user1]);
     await render(hbs`<LeadershipSearch

--- a/tests/integration/components/learner-selection-manager-test.js
+++ b/tests/integration/components/learner-selection-manager-test.js
@@ -26,9 +26,9 @@ module('Integration | Component | learner selection manager', function (hooks) {
       displayName: 'Clem Chowder',
     });
 
-    this.learnerModel1 = await this.owner.lookup('service:store').find('user', learner1.id);
-    this.learnerModel2 = await this.owner.lookup('service:store').find('user', learner2.id);
-    this.learnerModel3 = await this.owner.lookup('service:store').find('user', learner3.id);
+    this.learnerModel1 = await this.owner.lookup('service:store').findRecord('user', learner1.id);
+    this.learnerModel2 = await this.owner.lookup('service:store').findRecord('user', learner2.id);
+    this.learnerModel3 = await this.owner.lookup('service:store').findRecord('user', learner3.id);
   });
 
   test('selected learners', async function (assert) {
@@ -89,7 +89,7 @@ module('Integration | Component | learner selection manager', function (hooks) {
       middleName: 'Roy',
       lastName: 'Schmitt',
     });
-    const learnerModel3 = await this.owner.lookup('service:store').find('user', learner3.id);
+    const learnerModel3 = await this.owner.lookup('service:store').findRecord('user', learner3.id);
 
     this.set('learners', []);
     this.set('add', (user) => {

--- a/tests/integration/components/learnergroup-selection-manager-test.js
+++ b/tests/integration/components/learnergroup-selection-manager-test.js
@@ -52,14 +52,23 @@ module('Integration | Component | learnergroup-selection-manager', function (hoo
     });
 
     const store = this.owner.lookup('service:store');
-    this.cohort1 = await store.find('cohort', cohort1.id);
-    this.cohort2 = await store.find('cohort', cohort2.id);
-    this.topLevelLearnerGroup1 = await store.find('learner-group', topLevelLearnerGroup1.id);
-    this.topLevelLearnerGroup2 = await store.find('learner-group', topLevelLearnerGroup2.id);
-    this.topLevelLearnerGroup3 = await store.find('learner-group', topLevelLearnerGroup3.id);
-    this.secondLevelLearnerGroup1 = await store.find('learner-group', secondLevelLearnerGroup1.id);
-    this.secondLevelLearnerGroup2 = await store.find('learner-group', secondLevelLearnerGroup2.id);
-    this.secondLevelLearnerGroup3 = await store.find('learner-group', secondLevelLearnerGroup3.id);
+    this.cohort1 = await store.findRecord('cohort', cohort1.id);
+    this.cohort2 = await store.findRecord('cohort', cohort2.id);
+    this.topLevelLearnerGroup1 = await store.findRecord('learner-group', topLevelLearnerGroup1.id);
+    this.topLevelLearnerGroup2 = await store.findRecord('learner-group', topLevelLearnerGroup2.id);
+    this.topLevelLearnerGroup3 = await store.findRecord('learner-group', topLevelLearnerGroup3.id);
+    this.secondLevelLearnerGroup1 = await store.findRecord(
+      'learner-group',
+      secondLevelLearnerGroup1.id
+    );
+    this.secondLevelLearnerGroup2 = await store.findRecord(
+      'learner-group',
+      secondLevelLearnerGroup2.id
+    );
+    this.secondLevelLearnerGroup3 = await store.findRecord(
+      'learner-group',
+      secondLevelLearnerGroup3.id
+    );
   });
 
   test('it renders', async function (assert) {

--- a/tests/integration/components/learnergroup-tree-test.js
+++ b/tests/integration/components/learnergroup-tree-test.js
@@ -42,25 +42,25 @@ module('Integration | Component | learnergroup-tree', function (hooks) {
 
     this.topLevelLearnerGroup = await this.owner
       .lookup('service:store')
-      .find('learner-group', topLevelLearnerGroup.id);
+      .findRecord('learner-group', topLevelLearnerGroup.id);
     this.secondLevelLearnerGroup1 = await this.owner
       .lookup('service:store')
-      .find('learner-group', secondLevelLearnerGroup1.id);
+      .findRecord('learner-group', secondLevelLearnerGroup1.id);
     this.secondLevelLearnerGroup2 = await this.owner
       .lookup('service:store')
-      .find('learner-group', secondLevelLearnerGroup2.id);
+      .findRecord('learner-group', secondLevelLearnerGroup2.id);
     this.secondLevelLearnerGroup3 = await this.owner
       .lookup('service:store')
-      .find('learner-group', secondLevelLearnerGroup3.id);
+      .findRecord('learner-group', secondLevelLearnerGroup3.id);
     this.thirdLevelLearnerGroup1 = await this.owner
       .lookup('service:store')
-      .find('learner-group', thirdLevelLearnerGroup1.id);
+      .findRecord('learner-group', thirdLevelLearnerGroup1.id);
     this.thirdLevelLearnerGroup2 = await this.owner
       .lookup('service:store')
-      .find('learner-group', thirdLevelLearnerGroup2.id);
+      .findRecord('learner-group', thirdLevelLearnerGroup2.id);
     this.thirdLevelLearnerGroup3 = await this.owner
       .lookup('service:store')
-      .find('learner-group', thirdLevelLearnerGroup3.id);
+      .findRecord('learner-group', thirdLevelLearnerGroup3.id);
   });
 
   test('the group tree renders', async function (assert) {

--- a/tests/integration/components/learning-materials-sort-manager-test.js
+++ b/tests/integration/components/learning-materials-sort-manager-test.js
@@ -51,17 +51,21 @@ module('Integration | Component | learning materials sort manager', function (ho
     const course = this.server.create('course', {
       learningMaterials: [clm1, clm2],
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     const statusModel1 = await this.owner
       .lookup('service:store')
-      .find('learning-material-status', status1.id);
+      .findRecord('learning-material-status', status1.id);
     const statusModel2 = await this.owner
       .lookup('service:store')
-      .find('learning-material-status', status2.id);
-    const userModel1 = await this.owner.lookup('service:store').find('user', user1.id);
-    const userModel2 = await this.owner.lookup('service:store').find('user', user2.id);
-    const lmModel1 = await this.owner.lookup('service:store').find('learning-material', lm1.id);
-    const lmModel2 = await this.owner.lookup('service:store').find('learning-material', lm2.id);
+      .findRecord('learning-material-status', status2.id);
+    const userModel1 = await this.owner.lookup('service:store').findRecord('user', user1.id);
+    const userModel2 = await this.owner.lookup('service:store').findRecord('user', user2.id);
+    const lmModel1 = await this.owner
+      .lookup('service:store')
+      .findRecord('learning-material', lm1.id);
+    const lmModel2 = await this.owner
+      .lookup('service:store')
+      .findRecord('learning-material', lm2.id);
     this.set('subject', courseModel);
     await render(
       hbs`<LearningMaterialsSortManager @subject={{this.subject}} @cancel={{(noop)}} />`
@@ -119,7 +123,7 @@ module('Integration | Component | learning materials sort manager', function (ho
     const course = this.server.create('course', {
       learningMaterials: [clm1, clm2],
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('subject', courseModel);
     this.set('cancel', () => {
       assert.ok(true, 'Cancel action was invoked correctly.');
@@ -160,13 +164,13 @@ module('Integration | Component | learning materials sort manager', function (ho
     const course = this.server.create('course', {
       learningMaterials: [clm1, clm2],
     });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     const clmModel1 = await this.owner
       .lookup('service:store')
-      .find('course-learning-material', clm1.id);
+      .findRecord('course-learning-material', clm1.id);
     const clmModel2 = await this.owner
       .lookup('service:store')
-      .find('course-learning-material', clm2.id);
+      .findRecord('course-learning-material', clm2.id);
     this.set('subject', courseModel);
     this.set('save', (data) => {
       assert.strictEqual(data.length, 2);

--- a/tests/integration/components/new-session-test.js
+++ b/tests/integration/components/new-session-test.js
@@ -16,10 +16,10 @@ module('Integration | Component | new session', function (hooks) {
     const sessionType2 = this.server.create('sessionType');
     this.sessionType = await this.owner
       .lookup('service:store')
-      .find('session-type', sessionType.id);
+      .findRecord('session-type', sessionType.id);
     this.sessionType2 = await this.owner
       .lookup('service:store')
-      .find('session-type', sessionType2.id);
+      .findRecord('session-type', sessionType2.id);
   });
 
   test('it renders', async function (assert) {

--- a/tests/integration/components/objective-list-item-terms-test.js
+++ b/tests/integration/components/objective-list-item-terms-test.js
@@ -27,10 +27,10 @@ module('Integration | Component | objective-list-item-terms', function (hooks) {
     });
     this.subject = await this.owner
       .lookup('service:store')
-      .find('course-objective', courseObjective.id);
+      .findRecord('course-objective', courseObjective.id);
     this.vocabularyModel1 = await this.owner
       .lookup('service:store')
-      .find('vocabulary', vocabulary1.id);
+      .findRecord('vocabulary', vocabulary1.id);
   });
 
   test('it renders and is accessible when managing', async function (assert) {

--- a/tests/integration/components/objective-sort-manager-test.js
+++ b/tests/integration/components/objective-sort-manager-test.js
@@ -16,7 +16,7 @@ module('Integration | Component | objective sort manager', function (hooks) {
     const session = this.server.create('session');
     this.server.create('sessionObjective', { session, position: 1 });
     this.server.create('sessionObjective', { session, position: 0 });
-    const subject = await this.owner.lookup('service:store').find('session', session.id);
+    const subject = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('subject', subject);
     await render(hbs`<ObjectiveSortManager @subject={{this.subject}} @close={{(noop)}} />`);
     assert.dom('.item').exists({ count: 2 });
@@ -31,7 +31,7 @@ module('Integration | Component | objective sort manager', function (hooks) {
     const course = this.server.create('course');
     this.server.create('courseObjective', { course, position: 1 });
     this.server.create('courseObjective', { course, position: 0 });
-    const subject = await this.owner.lookup('service:store').find('course', course.id);
+    const subject = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('subject', subject);
     await render(hbs`<ObjectiveSortManager @subject={{this.subject}} @close={{(noop)}} />`);
     assert.dom('.item').exists({ count: 2 });
@@ -47,7 +47,9 @@ module('Integration | Component | objective sort manager', function (hooks) {
     const programYear = this.server.create('programYear');
     this.server.create('programYearObjective', { programYear, position: 1 });
     this.server.create('programYearObjective', { programYear, position: 0 });
-    const subject = await this.owner.lookup('service:store').find('programYear', programYear.id);
+    const subject = await this.owner
+      .lookup('service:store')
+      .findRecord('programYear', programYear.id);
     this.set('subject', subject);
     await render(hbs`<ObjectiveSortManager @subject={{this.subject}} @close={{(noop)}} />`);
     assert.dom('.item').exists({ count: 2 });
@@ -60,7 +62,7 @@ module('Integration | Component | objective sort manager', function (hooks) {
   test('cancel', async function (assert) {
     assert.expect(1);
     const course = this.server.create('course');
-    const subject = await this.owner.lookup('service:store').find('course', course.id);
+    const subject = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('subject', subject);
     this.set('cancel', () => {
       assert.ok(true, 'Cancel action was invoked correctly.');

--- a/tests/integration/components/offering-calendar-test.js
+++ b/tests/integration/components/offering-calendar-test.js
@@ -37,10 +37,10 @@ module('Integration | Component | offering-calendar', function (hooks) {
     const learnerGroup = this.server.create('learner-group', {
       offerings: [offering1, offering2],
     });
-    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
     const learnerGroupModel = await this.owner
       .lookup('service:store')
-      .find('learner-group', learnerGroup.id);
+      .findRecord('learner-group', learnerGroup.id);
     this.set('startDate', today.toDate());
     this.set('endDate', tomorrow.toDate());
     this.set('session', sessionModel);

--- a/tests/integration/components/offering-form-test.js
+++ b/tests/integration/components/offering-form-test.js
@@ -419,7 +419,9 @@ module('Integration | Component | offering form', function (hooks) {
       startDate: moment('2005-06-24').hour(18).minute(24).toDate(),
       endDate: moment('2005-06-24').hour(19).minute(24).toDate(),
     });
-    const offeringModel = await this.owner.lookup('service:store').find('offering', offering.id);
+    const offeringModel = await this.owner
+      .lookup('service:store')
+      .findRecord('offering', offering.id);
     this.set('offering', offeringModel);
     await render(hbs`<OfferingForm
       @offering={{this.offering}}
@@ -469,7 +471,9 @@ module('Integration | Component | offering form', function (hooks) {
       startDate: moment('2005-06-24').hour(18).minute(24).toDate(),
       endDate: moment('2005-06-24').hour(19).minute(24).toDate(),
     });
-    const offeringModel = await this.owner.lookup('service:store').find('offering', offering.id);
+    const offeringModel = await this.owner
+      .lookup('service:store')
+      .findRecord('offering', offering.id);
     this.set('offering', offeringModel);
     this.set('save', async (startDate, endDate) => {
       assert.strictEqual(moment(startDate).tz(utc).format('Y-MM-DD HH:mm'), '2005-06-25 05:24');
@@ -523,7 +527,7 @@ module('Integration | Component | offering form', function (hooks) {
     this.server.create('learnerGroup', { cohort, title: 'Learner Group 10' });
     this.server.create('learnerGroup', { cohort, title: 'Learner Group 2' });
 
-    const cohortModel = await this.owner.lookup('service:store').find('cohort', cohort.id);
+    const cohortModel = await this.owner.lookup('service:store').findRecord('cohort', cohort.id);
     this.set('cohorts', [cohortModel]);
     await render(hbs`<OfferingForm @cohorts={{this.cohorts}} @close={{(noop)}} />`);
 
@@ -547,7 +551,9 @@ module('Integration | Component | offering form', function (hooks) {
   test('save by pressing enter in duration hours field', async function (assert) {
     assert.expect(1);
     const offering = this.server.create('offering');
-    const offeringModel = await this.owner.lookup('service:store').find('offering', offering.id);
+    const offeringModel = await this.owner
+      .lookup('service:store')
+      .findRecord('offering', offering.id);
     this.set('offering', offeringModel);
     this.set('save', () => {
       assert.ok(true);
@@ -561,7 +567,9 @@ module('Integration | Component | offering form', function (hooks) {
   test('save by pressing enter in duration minutes field', async function (assert) {
     assert.expect(1);
     const offering = this.server.create('offering');
-    const offeringModel = await this.owner.lookup('service:store').find('offering', offering.id);
+    const offeringModel = await this.owner
+      .lookup('service:store')
+      .findRecord('offering', offering.id);
     this.set('offering', offeringModel);
     this.set('save', () => {
       assert.ok(true);
@@ -575,7 +583,9 @@ module('Integration | Component | offering form', function (hooks) {
   test('save by pressing enter in location field', async function (assert) {
     assert.expect(1);
     const offering = this.server.create('offering');
-    const offeringModel = await this.owner.lookup('service:store').find('offering', offering.id);
+    const offeringModel = await this.owner
+      .lookup('service:store')
+      .findRecord('offering', offering.id);
     this.set('offering', offeringModel);
     this.set('save', () => {
       assert.ok(true);
@@ -592,7 +602,9 @@ module('Integration | Component | offering form', function (hooks) {
   test('save by pressing enter in url field', async function (assert) {
     assert.expect(1);
     const offering = this.server.create('offering');
-    const offeringModel = await this.owner.lookup('service:store').find('offering', offering.id);
+    const offeringModel = await this.owner
+      .lookup('service:store')
+      .findRecord('offering', offering.id);
     this.set('offering', offeringModel);
     this.set('save', () => {
       assert.ok(true);

--- a/tests/integration/components/publish-all-sessions-test.js
+++ b/tests/integration/components/publish-all-sessions-test.js
@@ -57,14 +57,14 @@ module('Integration | Component | publish all sessions', function (hooks) {
     });
     this.server.create('sessionObjective', { session: completeSession });
     const store = this.owner.lookup('service:store');
-    this.publishableSession = await store.find('session', publishableSession.id);
-    this.unpublishableSession = await store.find('session', unpublishableSession.id);
-    this.completeSession = await store.find('session', completeSession.id);
-    this.fullyPublishedByIncompleteSession = await store.find(
+    this.publishableSession = await store.findRecord('session', publishableSession.id);
+    this.unpublishableSession = await store.findRecord('session', unpublishableSession.id);
+    this.completeSession = await store.findRecord('session', completeSession.id);
+    this.fullyPublishedByIncompleteSession = await store.findRecord(
       'session',
       fullyPublishedByIncompleteSession.id
     );
-    this.course = await store.find('course', course.id);
+    this.course = await store.findRecord('course', course.id);
   });
 
   test('it renders', async function (assert) {

--- a/tests/integration/components/selectable-terms-list-item-test.js
+++ b/tests/integration/components/selectable-terms-list-item-test.js
@@ -12,7 +12,7 @@ module('Integration | Component | selectable terms list item', function (hooks) 
 
   hooks.beforeEach(async function () {
     const term = this.server.create('term', { title: 'Term1' });
-    this.termModel = await this.owner.lookup('service:store').find('term', term.id);
+    this.termModel = await this.owner.lookup('service:store').findRecord('term', term.id);
   });
 
   test('it renders', async function (assert) {

--- a/tests/integration/components/selectable-terms-list-test.js
+++ b/tests/integration/components/selectable-terms-list-test.js
@@ -43,12 +43,12 @@ module('Integration | Component | selectable terms list', function (hooks) {
 
     this.vocabularyModel = await this.owner
       .lookup('service:store')
-      .find('vocabulary', vocabulary.id);
-    this.termModel1 = await this.owner.lookup('service:store').find('term', term1.id);
-    this.termModel2 = await this.owner.lookup('service:store').find('term', term2.id);
-    this.termModel3 = await this.owner.lookup('service:store').find('term', term3.id);
-    this.termModel4 = await this.owner.lookup('service:store').find('term', term4.id);
-    this.termModel5 = await this.owner.lookup('service:store').find('term', term5.id);
+      .findRecord('vocabulary', vocabulary.id);
+    this.termModel1 = await this.owner.lookup('service:store').findRecord('term', term1.id);
+    this.termModel2 = await this.owner.lookup('service:store').findRecord('term', term2.id);
+    this.termModel3 = await this.owner.lookup('service:store').findRecord('term', term3.id);
+    this.termModel4 = await this.owner.lookup('service:store').findRecord('term', term4.id);
+    this.termModel5 = await this.owner.lookup('service:store').findRecord('term', term5.id);
   });
 
   test('it renders when given a vocabulary as input ', async function (assert) {

--- a/tests/integration/components/selected-instructor-groups-test.js
+++ b/tests/integration/components/selected-instructor-groups-test.js
@@ -36,13 +36,13 @@ module('Integration | Component | selected-instructor-groups', function (hooks) 
 
     this.instructorGroup1 = await this.owner
       .lookup('service:store')
-      .find('instructor-group', instructorGroup1.id);
+      .findRecord('instructor-group', instructorGroup1.id);
     this.instructorGroup2 = await this.owner
       .lookup('service:store')
-      .find('instructor-group', instructorGroup2.id);
+      .findRecord('instructor-group', instructorGroup2.id);
     this.instructorGroup3 = await this.owner
       .lookup('service:store')
-      .find('instructor-group', instructorGroup3.id);
+      .findRecord('instructor-group', instructorGroup3.id);
   });
 
   test('it renders', async function (assert) {

--- a/tests/integration/components/selected-instructors-test.js
+++ b/tests/integration/components/selected-instructors-test.js
@@ -27,9 +27,15 @@ module('Integration | Component | selected-instructors', function (hooks) {
       displayName: 'Clem Chowder',
     });
 
-    this.instructorModel1 = await this.owner.lookup('service:store').find('user', instructor1.id);
-    this.instructorModel2 = await this.owner.lookup('service:store').find('user', instructor2.id);
-    this.instructorModel3 = await this.owner.lookup('service:store').find('user', instructor3.id);
+    this.instructorModel1 = await this.owner
+      .lookup('service:store')
+      .findRecord('user', instructor1.id);
+    this.instructorModel2 = await this.owner
+      .lookup('service:store')
+      .findRecord('user', instructor2.id);
+    this.instructorModel3 = await this.owner
+      .lookup('service:store')
+      .findRecord('user', instructor3.id);
   });
 
   test('it renders', async function (assert) {

--- a/tests/integration/components/selected-learner-groups-test.js
+++ b/tests/integration/components/selected-learner-groups-test.js
@@ -40,10 +40,10 @@ module('Integration | Component | selected-learner-groups', function (hooks) {
     });
 
     const store = this.owner.lookup('service:store');
-    this.tlg1 = await store.find('learner-group', tlg1.id);
-    this.subGroup1 = await store.find('learner-group', subGroup1.id);
-    this.subSubGroup = await store.find('learner-group', subSubGroup1.id);
-    this.subGroup2 = await store.find('learner-group', subGroup2.id);
+    this.tlg1 = await store.findRecord('learner-group', tlg1.id);
+    this.subGroup1 = await store.findRecord('learner-group', subGroup1.id);
+    this.subSubGroup = await store.findRecord('learner-group', subSubGroup1.id);
+    this.subGroup2 = await store.findRecord('learner-group', subGroup2.id);
   });
 
   test('it renders', async function (assert) {

--- a/tests/integration/components/selected-learners-test.js
+++ b/tests/integration/components/selected-learners-test.js
@@ -27,9 +27,9 @@ module('Integration | Component | selected-learners', function (hooks) {
       displayName: 'Clem Chowder',
     });
 
-    this.learnerModel1 = await this.owner.lookup('service:store').find('user', learner1.id);
-    this.learnerModel2 = await this.owner.lookup('service:store').find('user', learner2.id);
-    this.learnerModel3 = await this.owner.lookup('service:store').find('user', learner3.id);
+    this.learnerModel1 = await this.owner.lookup('service:store').findRecord('user', learner1.id);
+    this.learnerModel2 = await this.owner.lookup('service:store').findRecord('user', learner2.id);
+    this.learnerModel3 = await this.owner.lookup('service:store').findRecord('user', learner3.id);
   });
 
   test('it renders', async function (assert) {

--- a/tests/integration/components/session-copy-test.js
+++ b/tests/integration/components/session-copy-test.js
@@ -48,7 +48,7 @@ module('Integration | Component | session copy', function (hooks) {
     });
     this.owner.register('service:permissionChecker', permissionCheckerMock);
 
-    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('session', sessionModel);
 
     await render(hbs`<SessionCopy @session={{this.session}} />`);
@@ -126,7 +126,7 @@ module('Integration | Component | session copy', function (hooks) {
       },
     });
     this.owner.register('service:permissionChecker', permissionCheckerMock);
-    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('session', sessionModel);
     this.set('visit', (newSession) => {
       assert.strictEqual(parseInt(newSession.id, 10), 2);
@@ -166,7 +166,7 @@ module('Integration | Component | session copy', function (hooks) {
     assert.strictEqual(newSessionObjective.belongsTo('session').id(), newSession.id);
     const objectiveTermModel = await this.owner
       .lookup('service:store')
-      .find('term', objectiveTerm.id);
+      .findRecord('term', objectiveTerm.id);
     const copiedSessionObjectiveTerms = await newSessionObjective.terms;
     assert.strictEqual(copiedSessionObjectiveTerms.length, 1);
     assert.ok(copiedSessionObjectiveTerms.includes(objectiveTermModel));
@@ -194,7 +194,7 @@ module('Integration | Component | session copy', function (hooks) {
       },
     });
     this.owner.register('service:permissionChecker', permissionCheckerMock);
-    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('session', sessionModel);
 
     await render(hbs`<SessionCopy @session={{this.session}} />`);
@@ -239,7 +239,7 @@ module('Integration | Component | session copy', function (hooks) {
       },
     });
     this.owner.register('service:permissionChecker', permissionCheckerMock);
-    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('session', sessionModel);
     await render(hbs`<SessionCopy @session={{this.session}} />`);
     const yearSelect = '.year-select select';
@@ -297,7 +297,7 @@ module('Integration | Component | session copy', function (hooks) {
       },
     });
     this.owner.register('service:permissionChecker', permissionCheckerMock);
-    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('session', sessionModel);
     this.set('visit', (newSession) => {
       assert.strictEqual(parseInt(newSession.id, 10), 2);
@@ -350,7 +350,7 @@ module('Integration | Component | session copy', function (hooks) {
       },
     });
     this.owner.register('service:permissionChecker', permissionCheckerMock);
-    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('session', sessionModel);
     this.set('visit', (newSession) => {
       assert.strictEqual(parseInt(newSession.id, 10), 3);
@@ -406,7 +406,7 @@ module('Integration | Component | session copy', function (hooks) {
       },
     });
     this.owner.register('service:permissionChecker', permissionCheckerMock);
-    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('session', sessionModel);
     this.set('visit', (newSession) => {
       assert.strictEqual(parseInt(newSession.id, 10), 3);
@@ -463,7 +463,7 @@ module('Integration | Component | session copy', function (hooks) {
       },
     });
     this.owner.register('service:permissionChecker', permissionCheckerMock);
-    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('session', sessionModel);
     this.set('visit', (newSession) => {
       assert.strictEqual(parseInt(newSession.id, 10), 4);
@@ -523,7 +523,7 @@ module('Integration | Component | session copy', function (hooks) {
       },
     });
     this.owner.register('service:permissionChecker', permissionCheckerMock);
-    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('session', sessionModel);
     this.set('visit', (newSession) => {
       assert.strictEqual(parseInt(newSession.id, 10), 4);

--- a/tests/integration/components/session-leadership-expanded-test.js
+++ b/tests/integration/components/session-leadership-expanded-test.js
@@ -20,7 +20,7 @@ module('Integration | Component | session leadership expanded', function (hooks)
       administrators: users,
       studentAdvisors: [users[0]],
     });
-    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('session', sessionModel);
     await render(hbs`<SessionLeadershipExpanded
       @session={{this.session}}
@@ -47,7 +47,7 @@ module('Integration | Component | session leadership expanded', function (hooks)
       course,
       administrators,
     });
-    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('session', sessionModel);
     this.set('click', () => {
       assert.ok(true, 'Action was fired');
@@ -71,7 +71,7 @@ module('Integration | Component | session leadership expanded', function (hooks)
       course,
       studentAdvisors,
     });
-    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('session', sessionModel);
     this.set('click', () => {
       assert.ok(true, 'Action was fired');
@@ -90,7 +90,7 @@ module('Integration | Component | session leadership expanded', function (hooks)
   test('clicking manage fires action', async function (assert) {
     assert.expect(1);
     const session = this.server.create('session');
-    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('session', sessionModel);
     this.set('click', () => {
       assert.ok(true, 'Action was fired');

--- a/tests/integration/components/session-overview-ilm-duedate-test.js
+++ b/tests/integration/components/session-overview-ilm-duedate-test.js
@@ -16,7 +16,9 @@ module('Integration | Component | session-overview-ilm-duedate', function (hooks
     const ilmSession = this.server.create('ilm-session', {
       dueDate: new Date(2021, 4, 19, 23, 55, 0),
     });
-    this.ilmSession = await this.owner.lookup('service:store').find('ilmSession', ilmSession.id);
+    this.ilmSession = await this.owner
+      .lookup('service:store')
+      .findRecord('ilmSession', ilmSession.id);
   });
 
   test('it renders and is accessible', async function (assert) {

--- a/tests/integration/components/session-publicationcheck-test.js
+++ b/tests/integration/components/session-publicationcheck-test.js
@@ -24,7 +24,7 @@ module('Integration | Component | session-publicationcheck', function (hooks) {
     this.server.create('session-objective', { session });
 
     await setupAuthentication({ school, administeredSchools: [school] });
-    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('model', sessionModel);
     await render(hbs`<SessionPublicationcheck @session={{this.model}} />`);
     assert.ok(component.unlink.isPresent);
@@ -44,7 +44,7 @@ module('Integration | Component | session-publicationcheck', function (hooks) {
       courseObjectives: [courseObjective],
     });
     await setupAuthentication({ school, administeredSchools: [school] });
-    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('model', sessionModel);
     await render(hbs`<SessionPublicationcheck @session={{this.model}} />`);
     assert.notOk(component.unlink.isPresent);

--- a/tests/integration/components/session/collapsed-objectives-test.js
+++ b/tests/integration/components/session/collapsed-objectives-test.js
@@ -36,7 +36,7 @@ module('Integration | Component | session/collapsed-objectives', function (hooks
         this.objectiveWithTerms,
       ],
     });
-    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
 
     this.set('session', sessionModel);
     await render(hbs`
@@ -61,7 +61,7 @@ module('Integration | Component | session/collapsed-objectives', function (hooks
     assert.expect(2);
 
     const session = this.server.create('session');
-    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
 
     this.set('session', sessionModel);
     this.set('click', () => {
@@ -79,7 +79,7 @@ module('Integration | Component | session/collapsed-objectives', function (hooks
     const session = this.server.create('session', {
       sessionObjectives: [this.objectiveWithCourseObjectives],
     });
-    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
 
     this.set('session', sessionModel);
     await render(hbs`
@@ -96,7 +96,7 @@ module('Integration | Component | session/collapsed-objectives', function (hooks
     const session = this.server.create('session', {
       sessionObjectives: [this.objective],
     });
-    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
 
     this.set('session', sessionModel);
     await render(hbs`
@@ -113,7 +113,7 @@ module('Integration | Component | session/collapsed-objectives', function (hooks
     const session = this.server.create('session', {
       sessionObjectives: [this.objectiveWithMesh],
     });
-    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
 
     this.set('session', sessionModel);
     await render(hbs`
@@ -130,7 +130,7 @@ module('Integration | Component | session/collapsed-objectives', function (hooks
     const session = this.server.create('session', {
       sessionObjectives: [this.objective],
     });
-    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
 
     this.set('session', sessionModel);
     await render(hbs`
@@ -147,7 +147,7 @@ module('Integration | Component | session/collapsed-objectives', function (hooks
     const session = this.server.create('session', {
       sessionObjectives: [this.objectiveWithTerms],
     });
-    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
 
     this.set('session', sessionModel);
     await render(hbs`
@@ -164,7 +164,7 @@ module('Integration | Component | session/collapsed-objectives', function (hooks
     const session = this.server.create('session', {
       sessionObjectives: [this.objective],
     });
-    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
 
     this.set('session', sessionModel);
     await render(hbs`

--- a/tests/integration/components/session/manage-objective-descriptors-test.js
+++ b/tests/integration/components/session/manage-objective-descriptors-test.js
@@ -15,7 +15,7 @@ module('Integration | Component | session/manage-objective-descriptors', functio
     const descriptors = this.server.createList('meshDescriptor', 4);
     const descriptorModel = await this.owner
       .lookup('service:store')
-      .find('meshDescriptor', descriptors[0].id);
+      .findRecord('meshDescriptor', descriptors[0].id);
     this.set('selected', [descriptorModel]);
     await render(hbs`<Session::ManageObjectiveDescriptors
       @selected={{this.selected}}
@@ -44,7 +44,7 @@ module('Integration | Component | session/manage-objective-descriptors', functio
     const descriptors = this.server.createList('meshDescriptor', 2);
     const descriptorModel = await this.owner
       .lookup('service:store')
-      .find('meshDescriptor', descriptors[0].id);
+      .findRecord('meshDescriptor', descriptors[0].id);
     this.set('selected', [descriptorModel]);
     this.set('add', (descriptor) => {
       this.set('selected', [descriptorModel, descriptor]);
@@ -83,7 +83,7 @@ module('Integration | Component | session/manage-objective-descriptors', functio
     const descriptors = this.server.createList('meshDescriptor', 2);
     const descriptorModel = await this.owner
       .lookup('service:store')
-      .find('meshDescriptor', descriptors[0].id);
+      .findRecord('meshDescriptor', descriptors[0].id);
     this.set('selected', [descriptorModel]);
     this.set('remove', (descriptor) => {
       assert.strictEqual(descriptor.id, descriptorModel.id);

--- a/tests/integration/components/session/manage-objective-parents-test.js
+++ b/tests/integration/components/session/manage-objective-parents-test.js
@@ -15,7 +15,7 @@ module('Integration | Component | session/manage-objective-parents', function (h
   test('it renders and is accessible', async function (assert) {
     const course = this.server.create('course');
     this.server.create('courseObjective', { course });
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('courseObjectives', await courseModel.courseObjectives);
     this.set('courseTitle', course.title);
     await render(hbs`<Session::ManageObjectiveParents

--- a/tests/integration/components/session/objective-list-item-descriptors-test.js
+++ b/tests/integration/components/session/objective-list-item-descriptors-test.js
@@ -35,7 +35,7 @@ module('Integration | Component | session/objective-list-item-descriptors', func
     });
     const sessionObjectiveModel = await this.owner
       .lookup('service:store')
-      .find('session-objective', sessionObjective.id);
+      .findRecord('session-objective', sessionObjective.id);
     this.set('sessionObjective', sessionObjectiveModel);
     await render(hbs`<Session::ObjectiveListItemDescriptors
       @sessionObjective={{this.sessionObjective}}
@@ -60,7 +60,7 @@ module('Integration | Component | session/objective-list-item-descriptors', func
     });
     const sessionObjectiveModel = await this.owner
       .lookup('service:store')
-      .find('session-objective', sessionObjective.id);
+      .findRecord('session-objective', sessionObjective.id);
     this.set('sessionObjective', sessionObjectiveModel);
     await render(hbs`<Session::ObjectiveListItemDescriptors
       @sessionObjective={{this.sessionObjective}}
@@ -87,7 +87,7 @@ module('Integration | Component | session/objective-list-item-descriptors', func
     });
     const sessionObjectiveModel = await this.owner
       .lookup('service:store')
-      .find('session-objective', sessionObjective.id);
+      .findRecord('session-objective', sessionObjective.id);
     this.set('sessionObjective', sessionObjectiveModel);
     await render(hbs`<Session::ObjectiveListItemDescriptors
       @sessionObjective={{this.sessionObjective}}
@@ -115,7 +115,7 @@ module('Integration | Component | session/objective-list-item-descriptors', func
     });
     const sessionObjectiveModel = await this.owner
       .lookup('service:store')
-      .find('session-objective', sessionObjective.id);
+      .findRecord('session-objective', sessionObjective.id);
     this.set('sessionObjective', sessionObjectiveModel);
     this.set('save', () => {
       assert.ok(true);
@@ -142,7 +142,7 @@ module('Integration | Component | session/objective-list-item-descriptors', func
     });
     const sessionObjectiveModel = await this.owner
       .lookup('service:store')
-      .find('session-objective', sessionObjective.id);
+      .findRecord('session-objective', sessionObjective.id);
     this.set('sessionObjective', sessionObjectiveModel);
     this.set('cancel', () => {
       assert.ok(true);
@@ -169,7 +169,7 @@ module('Integration | Component | session/objective-list-item-descriptors', func
     });
     const sessionObjectiveModel = await this.owner
       .lookup('service:store')
-      .find('session-objective', sessionObjective.id);
+      .findRecord('session-objective', sessionObjective.id);
     this.set('sessionObjective', sessionObjectiveModel);
     this.set('manage', () => {
       assert.ok(true);

--- a/tests/integration/components/session/objective-list-item-parents-test.js
+++ b/tests/integration/components/session/objective-list-item-parents-test.js
@@ -35,7 +35,7 @@ module('Integration | Component | session/objective-list-item-parents', function
     });
     const sessionObjectiveModel = await this.owner
       .lookup('service:store')
-      .find('session-objective', sessionObjective.id);
+      .findRecord('session-objective', sessionObjective.id);
     this.set('sessionObjective', sessionObjectiveModel);
     await render(hbs`<Session::ObjectiveListItemParents
       @sessionObjective={{this.sessionObjective}}
@@ -63,7 +63,7 @@ module('Integration | Component | session/objective-list-item-parents', function
     });
     const sessionObjectiveModel = await this.owner
       .lookup('service:store')
-      .find('session-objective', sessionObjective.id);
+      .findRecord('session-objective', sessionObjective.id);
     this.set('sessionObjective', sessionObjectiveModel);
     await render(hbs`<Session::ObjectiveListItemParents
       @sessionObjective={{this.sessionObjective}}
@@ -93,7 +93,7 @@ module('Integration | Component | session/objective-list-item-parents', function
     });
     const sessionObjectiveModel = await this.owner
       .lookup('service:store')
-      .find('session-objective', sessionObjective.id);
+      .findRecord('session-objective', sessionObjective.id);
     this.set('sessionObjective', sessionObjectiveModel);
     await render(hbs`<Session::ObjectiveListItemParents
       @sessionObjective={{this.sessionObjective}}
@@ -121,7 +121,7 @@ module('Integration | Component | session/objective-list-item-parents', function
     });
     const sessionObjectiveModel = await this.owner
       .lookup('service:store')
-      .find('session-objective', sessionObjective.id);
+      .findRecord('session-objective', sessionObjective.id);
     this.set('sessionObjective', sessionObjectiveModel);
     this.set('save', () => {
       assert.ok(true);
@@ -148,7 +148,7 @@ module('Integration | Component | session/objective-list-item-parents', function
     });
     const sessionObjectiveModel = await this.owner
       .lookup('service:store')
-      .find('session-objective', sessionObjective.id);
+      .findRecord('session-objective', sessionObjective.id);
     this.set('sessionObjective', sessionObjectiveModel);
     this.set('cancel', () => {
       assert.ok(true);
@@ -175,7 +175,7 @@ module('Integration | Component | session/objective-list-item-parents', function
     });
     const sessionObjectiveModel = await this.owner
       .lookup('service:store')
-      .find('session-objective', sessionObjective.id);
+      .findRecord('session-objective', sessionObjective.id);
     this.set('sessionObjective', sessionObjectiveModel);
     this.set('manage', () => {
       assert.ok(true);
@@ -213,7 +213,7 @@ module('Integration | Component | session/objective-list-item-parents', function
     });
     const sessionObjectiveModel = await this.owner
       .lookup('service:store')
-      .find('session-objective', sessionObjective.id);
+      .findRecord('session-objective', sessionObjective.id);
     this.set('sessionObjective', sessionObjectiveModel);
     await render(hbs`<Session::ObjectiveListItemParents
       @sessionObjective={{this.sessionObjective}}

--- a/tests/integration/components/session/objective-list-item-test.js
+++ b/tests/integration/components/session/objective-list-item-test.js
@@ -20,7 +20,7 @@ module('Integration | Component | session/objective-list-item', function (hooks)
     });
     const sessionObjectiveModel = await this.owner
       .lookup('service:store')
-      .find('session-objective', sessionObjective.id);
+      .findRecord('session-objective', sessionObjective.id);
     this.set('sessionObjective', sessionObjectiveModel);
     await render(
       hbs`<Session::ObjectiveListItem
@@ -45,7 +45,7 @@ module('Integration | Component | session/objective-list-item', function (hooks)
     });
     const sessionObjectiveModel = await this.owner
       .lookup('service:store')
-      .find('session-objective', sessionObjective.id);
+      .findRecord('session-objective', sessionObjective.id);
     this.set('sessionObjective', sessionObjectiveModel);
     await render(
       hbs`<Session::ObjectiveListItem
@@ -70,7 +70,7 @@ module('Integration | Component | session/objective-list-item', function (hooks)
     });
     const sessionObjectiveModel = await this.owner
       .lookup('service:store')
-      .find('session-objective', sessionObjective.id);
+      .findRecord('session-objective', sessionObjective.id);
     this.set('sessionObjective', sessionObjectiveModel);
     await render(
       hbs`<Session::ObjectiveListItem
@@ -90,7 +90,7 @@ module('Integration | Component | session/objective-list-item', function (hooks)
     });
     const sessionObjectiveModel = await this.owner
       .lookup('service:store')
-      .find('session-objective', sessionObjective.id);
+      .findRecord('session-objective', sessionObjective.id);
     this.set('sessionObjective', sessionObjectiveModel);
     await render(
       hbs`<Session::ObjectiveListItem
@@ -111,7 +111,7 @@ module('Integration | Component | session/objective-list-item', function (hooks)
     });
     const sessionObjectiveModel = await this.owner
       .lookup('service:store')
-      .find('session-objective', sessionObjective.id);
+      .findRecord('session-objective', sessionObjective.id);
     this.set('sessionObjective', sessionObjectiveModel);
     await render(
       hbs`<Session::ObjectiveListItem
@@ -132,7 +132,7 @@ module('Integration | Component | session/objective-list-item', function (hooks)
     });
     const sessionObjectiveModel = await this.owner
       .lookup('service:store')
-      .find('session-objective', sessionObjective.id);
+      .findRecord('session-objective', sessionObjective.id);
     this.set('sessionObjective', sessionObjectiveModel);
     await render(
       hbs`<Session::ObjectiveListItem

--- a/tests/integration/components/session/objective-list-test.js
+++ b/tests/integration/components/session/objective-list-test.js
@@ -32,7 +32,7 @@ module('Integration | Component | session/objective-list', function (hooks) {
       position: 0,
       terms: [term2],
     });
-    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('session', sessionModel);
 
     await render(
@@ -70,7 +70,7 @@ module('Integration | Component | session/objective-list', function (hooks) {
     assert.expect(2);
     const course = this.server.create('course');
     const session = this.server.create('session', { course });
-    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('session', sessionModel);
 
     await render(
@@ -88,7 +88,7 @@ module('Integration | Component | session/objective-list', function (hooks) {
     const course = this.server.create('course');
     const session = this.server.create('session', { course });
     this.server.create('sessionObjective', { session });
-    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('session', sessionModel);
 
     await render(

--- a/tests/integration/components/session/objectives-test.js
+++ b/tests/integration/components/session/objectives-test.js
@@ -22,7 +22,7 @@ module('Integration | Component | session/objectives', function (hooks) {
       session,
       courseObjectives: [courseObjective],
     });
-    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
 
     this.set('session', sessionModel);
     await render(hbs`<Session::Objectives
@@ -66,7 +66,7 @@ module('Integration | Component | session/objectives', function (hooks) {
     const course = this.server.create('course');
     const session = this.server.create('session', { course });
     this.server.create('sessionObjective', { session });
-    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
 
     this.set('session', sessionModel);
     await render(hbs`<Session::Objectives

--- a/tests/integration/components/session/postrequisite-editor-test.js
+++ b/tests/integration/components/session/postrequisite-editor-test.js
@@ -16,7 +16,9 @@ module('Integration | Component | session/postrequisite-editor', function (hooks
     this.server.create('course', {
       sessions,
     });
-    const sessionModel = await this.owner.lookup('service:store').find('session', sessions[2].id);
+    const sessionModel = await this.owner
+      .lookup('service:store')
+      .findRecord('session', sessions[2].id);
     this.set('session', sessionModel);
 
     await render(hbs`<Session::PostrequisiteEditor
@@ -41,7 +43,7 @@ module('Integration | Component | session/postrequisite-editor', function (hooks
       postrequisite: sessions[1],
       course,
     });
-    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('session', sessionModel);
 
     await render(hbs`<Session::PostrequisiteEditor
@@ -65,7 +67,7 @@ module('Integration | Component | session/postrequisite-editor', function (hooks
       postrequisite: sessions[1],
       course,
     });
-    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('session', sessionModel);
 
     await render(hbs`<Session::PostrequisiteEditor
@@ -96,7 +98,7 @@ module('Integration | Component | session/postrequisite-editor', function (hooks
       postrequisite: sessions[1],
       course,
     });
-    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('session', sessionModel);
 
     await render(hbs`<Session::PostrequisiteEditor
@@ -123,7 +125,9 @@ module('Integration | Component | session/postrequisite-editor', function (hooks
     this.server.create('course', {
       sessions,
     });
-    const sessionModel = await this.owner.lookup('service:store').find('session', sessions[0].id);
+    const sessionModel = await this.owner
+      .lookup('service:store')
+      .findRecord('session', sessions[0].id);
     this.set('session', sessionModel);
 
     await render(hbs`<Session::PostrequisiteEditor
@@ -151,7 +155,9 @@ module('Integration | Component | session/postrequisite-editor', function (hooks
     this.server.create('course', {
       sessions,
     });
-    const sessionModel = await this.owner.lookup('service:store').find('session', sessions[0].id);
+    const sessionModel = await this.owner
+      .lookup('service:store')
+      .findRecord('session', sessions[0].id);
     this.set('close', () => {
       assert.ok(true);
     });
@@ -170,7 +176,9 @@ module('Integration | Component | session/postrequisite-editor', function (hooks
     this.server.create('course', {
       sessions,
     });
-    const sessionModel = await this.owner.lookup('service:store').find('session', sessions[0].id);
+    const sessionModel = await this.owner
+      .lookup('service:store')
+      .findRecord('session', sessions[0].id);
     this.set('close', () => {
       assert.ok(true);
     });
@@ -200,7 +208,7 @@ module('Integration | Component | session/postrequisite-editor', function (hooks
       title: 'fuzzy the cat',
       course,
     });
-    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('session', sessionModel);
 
     await render(hbs`<Session::PostrequisiteEditor

--- a/tests/integration/components/session/publication-menu-test.js
+++ b/tests/integration/components/session/publication-menu-test.js
@@ -14,7 +14,7 @@ module('Integration | Component | session/publication-menu', function (hooks) {
 
   test('it renders and is accessible for draft session', async function (assert) {
     this.server.create('session');
-    const sessionModel = await this.owner.lookup('service:store').find('session', 1);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', 1);
     this.set('session', sessionModel);
     await render(hbs`<Session::PublicationMenu @session={{this.session}} />`);
 
@@ -42,7 +42,7 @@ module('Integration | Component | session/publication-menu', function (hooks) {
       published: true,
       publishedAsTbd: true,
     });
-    const sessionModel = await this.owner.lookup('service:store').find('session', 1);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', 1);
     this.set('session', sessionModel);
     await render(hbs`<Session::PublicationMenu @session={{this.session}} />`);
 
@@ -58,7 +58,7 @@ module('Integration | Component | session/publication-menu', function (hooks) {
       published: true,
       publishedAsTbd: false,
     });
-    const sessionModel = await this.owner.lookup('service:store').find('session', 1);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', 1);
     this.set('session', sessionModel);
     await render(hbs`<Session::PublicationMenu @session={{this.session}} />`);
 
@@ -71,7 +71,7 @@ module('Integration | Component | session/publication-menu', function (hooks) {
 
   test('click opens menu', async function (assert) {
     this.server.create('session');
-    const sessionModel = await this.owner.lookup('service:store').find('session', 1);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', 1);
     this.set('session', sessionModel);
     await render(hbs`<Session::PublicationMenu @session={{this.session}} />`);
     assert.ok(component.menuClosed);
@@ -81,7 +81,7 @@ module('Integration | Component | session/publication-menu', function (hooks) {
 
   test('correct actions for unpublished session', async function (assert) {
     this.server.create('session');
-    const sessionModel = await this.owner.lookup('service:store').find('session', 1);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', 1);
     this.set('session', sessionModel);
     await render(hbs`<Session::PublicationMenu @session={{this.session}} />`);
     await component.toggle.click();
@@ -98,7 +98,7 @@ module('Integration | Component | session/publication-menu', function (hooks) {
       published: true,
       publishedAsTbd: true,
     });
-    const sessionModel = await this.owner.lookup('service:store').find('session', 1);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', 1);
     this.set('session', sessionModel);
     await render(hbs`<Session::PublicationMenu @session={{this.session}} />`);
     await component.toggle.click();
@@ -115,7 +115,7 @@ module('Integration | Component | session/publication-menu', function (hooks) {
       published: true,
       publishedAsTbd: false,
     });
-    const sessionModel = await this.owner.lookup('service:store').find('session', 1);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', 1);
     this.set('session', sessionModel);
     await render(hbs`<Session::PublicationMenu @session={{this.session}} />`);
     await component.toggle.click();
@@ -129,7 +129,7 @@ module('Integration | Component | session/publication-menu', function (hooks) {
 
   test('down opens menu', async function (assert) {
     this.server.create('session');
-    const sessionModel = await this.owner.lookup('service:store').find('session', 1);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', 1);
     this.set('session', sessionModel);
     await render(hbs`<Session::PublicationMenu @session={{this.session}} />`);
 
@@ -140,7 +140,7 @@ module('Integration | Component | session/publication-menu', function (hooks) {
 
   test('escape closes menu', async function (assert) {
     this.server.create('session');
-    const sessionModel = await this.owner.lookup('service:store').find('session', 1);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', 1);
     this.set('session', sessionModel);
     await render(hbs`<Session::PublicationMenu @session={{this.session}} />`);
 

--- a/tests/integration/components/sessions-grid-last-updated-test.js
+++ b/tests/integration/components/sessions-grid-last-updated-test.js
@@ -21,7 +21,7 @@ module('Integration | Component | sessions-grid-last-updated', function (hooks) 
       updatedAt: moment('2019-07-09 17:00:00').toDate(),
     });
 
-    const sessionModel = await this.owner.lookup('service:store').find('session', session.id);
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
 
     this.set('session', sessionModel);
     await render(hbs`<SessionsGridLastUpdated @session={{this.session}} />`);

--- a/tests/integration/components/sessions-grid-test.js
+++ b/tests/integration/components/sessions-grid-test.js
@@ -78,8 +78,12 @@ module('Integration | Component | sessions-grid', function (hooks) {
   // @see issue ilios/common#1820 [ST 2020/12/10]
   test('deletion of session is disabled if it has prerequisites', async function (assert) {
     const sessions = this.server.createList('session', 2);
-    const sessionModel1 = await this.owner.lookup('service:store').find('session', sessions[0].id);
-    const sessionModel2 = await this.owner.lookup('service:store').find('session', sessions[0].id);
+    const sessionModel1 = await this.owner
+      .lookup('service:store')
+      .findRecord('session', sessions[0].id);
+    const sessionModel2 = await this.owner
+      .lookup('service:store')
+      .findRecord('session', sessions[0].id);
 
     this.set('sessions', [
       {

--- a/tests/integration/components/taxonomy-manager-test.js
+++ b/tests/integration/components/taxonomy-manager-test.js
@@ -63,12 +63,12 @@ module('Integration | Component | taxonomy manager', function (hooks) {
       vocabulary: vocab2,
     });
 
-    this.vocabModel1 = await this.owner.lookup('service:store').find('vocabulary', vocab1.id);
-    this.vocabModel2 = await this.owner.lookup('service:store').find('vocabulary', vocab2.id);
-    this.vocabModel3 = await this.owner.lookup('service:store').find('vocabulary', vocab3.id);
-    this.termModel1 = await this.owner.lookup('service:store').find('term', term1.id);
-    this.termModel2 = await this.owner.lookup('service:store').find('term', term2.id);
-    this.termModel3 = await this.owner.lookup('service:store').find('term', term3.id);
+    this.vocabModel1 = await this.owner.lookup('service:store').findRecord('vocabulary', vocab1.id);
+    this.vocabModel2 = await this.owner.lookup('service:store').findRecord('vocabulary', vocab2.id);
+    this.vocabModel3 = await this.owner.lookup('service:store').findRecord('vocabulary', vocab3.id);
+    this.termModel1 = await this.owner.lookup('service:store').findRecord('term', term1.id);
+    this.termModel2 = await this.owner.lookup('service:store').findRecord('term', term2.id);
+    this.termModel3 = await this.owner.lookup('service:store').findRecord('term', term3.id);
   });
 
   test('it renders', async function (assert) {

--- a/tests/integration/components/user-name-info-test.js
+++ b/tests/integration/components/user-name-info-test.js
@@ -13,7 +13,7 @@ module('Integration | Component | user-name-info', function (hooks) {
 
   test('it renders', async function (assert) {
     const user = this.server.create('user');
-    const userModel = await this.owner.lookup('service:store').find('user', user.id);
+    const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
     this.set('user', userModel);
     await render(hbs`<UserNameInfo @user={{this.user}} />`);
     assert.notOk(component.hasAdditionalInfo);
@@ -23,7 +23,7 @@ module('Integration | Component | user-name-info', function (hooks) {
 
   test('it renders with additional info', async function (assert) {
     const user = this.server.create('user', { displayName: 'Clem Chowder' });
-    const userModel = await this.owner.lookup('service:store').find('user', user.id);
+    const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
     this.set('user', userModel);
     await render(hbs`<UserNameInfo @user={{this.user}} />`);
     assert.ok(component.hasAdditionalInfo);
@@ -39,7 +39,7 @@ module('Integration | Component | user-name-info', function (hooks) {
 
   test('passing in id as an attributes', async function (assert) {
     const user = this.server.create('user');
-    const userModel = await this.owner.lookup('service:store').find('user', user.id);
+    const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
     this.set('user', userModel);
     await render(hbs`<UserNameInfo id="test-id" @user={{this.user}} />`);
     assert.strictEqual(component.id, 'test-id');
@@ -49,7 +49,7 @@ module('Integration | Component | user-name-info', function (hooks) {
     const user = this.server.create('user', {
       pronouns: 'they/them/tay',
     });
-    const userModel = await this.owner.lookup('service:store').find('user', user.id);
+    const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
     this.set('user', userModel);
     await render(hbs`<UserNameInfo @user={{this.user}} />`);
     assert.ok(component.hasPronouns);

--- a/tests/integration/components/user-search-result-instructor-group-test.js
+++ b/tests/integration/components/user-search-result-instructor-group-test.js
@@ -13,7 +13,9 @@ module('Integration | Component | user-search-result-instructor-group', function
 
   test('it renders', async function (assert) {
     const group = this.server.create('instructor-group');
-    const groupModel = await this.owner.lookup('service:store').find('instructor-group', group.id);
+    const groupModel = await this.owner
+      .lookup('service:store')
+      .findRecord('instructor-group', group.id);
     this.set('group', groupModel);
     await render(hbs`<UserSearchResultInstructorGroup
       @group={{this.group}}
@@ -25,7 +27,9 @@ module('Integration | Component | user-search-result-instructor-group', function
 
   test('inactive if it is already selected', async function (assert) {
     const group = this.server.create('instructor-group');
-    const groupModel = await this.owner.lookup('service:store').find('instructor-group', group.id);
+    const groupModel = await this.owner
+      .lookup('service:store')
+      .findRecord('instructor-group', group.id);
     this.set('group', groupModel);
     this.set('activeGroups', [groupModel]);
     await render(hbs`<UserSearchResultInstructorGroup
@@ -40,7 +44,9 @@ module('Integration | Component | user-search-result-instructor-group', function
   test('click fires action', async function (assert) {
     assert.expect(3);
     const group = this.server.create('instructor-group');
-    const groupModel = await this.owner.lookup('service:store').find('instructor-group', group.id);
+    const groupModel = await this.owner
+      .lookup('service:store')
+      .findRecord('instructor-group', group.id);
     this.set('group', groupModel);
     this.set('add', (add) => {
       assert.strictEqual(add, groupModel);

--- a/tests/integration/components/user-search-result-user-test.js
+++ b/tests/integration/components/user-search-result-user-test.js
@@ -13,7 +13,7 @@ module('Integration | Component | user-search-result-user', function (hooks) {
 
   test('it renders', async function (assert) {
     const user = this.server.create('user');
-    const userModel = await this.owner.lookup('service:store').find('user', user.id);
+    const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
     this.set('user', userModel);
     await render(hbs`<UserSearchResultUser
       @user={{this.user}}
@@ -25,7 +25,7 @@ module('Integration | Component | user-search-result-user', function (hooks) {
 
   test('inactive if it is already selected', async function (assert) {
     const user = this.server.create('user');
-    const userModel = await this.owner.lookup('service:store').find('user', user.id);
+    const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
     this.set('user', userModel);
     this.set('activeUsers', [userModel]);
     await render(hbs`<UserSearchResultUser
@@ -40,7 +40,7 @@ module('Integration | Component | user-search-result-user', function (hooks) {
   test('click fires action', async function (assert) {
     assert.expect(3);
     const user = this.server.create('user');
-    const userModel = await this.owner.lookup('service:store').find('user', user.id);
+    const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
     this.set('user', userModel);
     this.set('add', (add) => {
       assert.strictEqual(add, userModel);

--- a/tests/integration/components/user-search-test.js
+++ b/tests/integration/components/user-search-test.js
@@ -65,7 +65,7 @@ module('Integration | Component | user search', function (hooks) {
   test('click user fires add user', async function (assert) {
     assert.expect(4);
     const user = this.server.create('user');
-    const userModel = await this.owner.lookup('service:store').find('user', user.id);
+    const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
     this.set('action', (passedUser) => {
       assert.strictEqual(passedUser, userModel);
     });
@@ -128,7 +128,7 @@ module('Integration | Component | user search', function (hooks) {
     this.server.get('api/users', (schema) => {
       return schema.users.all();
     });
-    const userModel = await this.owner.lookup('service:store').find('user', user.id);
+    const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
     this.set('currentlyActiveUsers', [userModel]);
     await render(hbs`<UserSearch @currentlyActiveUsers={{this.currentlyActiveUsers}} />`);
     await component.searchBox.set('foo');

--- a/tests/integration/components/visualizer-course-instructor-session-type-test.js
+++ b/tests/integration/components/visualizer-course-instructor-session-type-test.js
@@ -49,8 +49,10 @@ module('Integration | Component | visualizer-course-instructor-session-type', fu
       instructors: [instructor],
     });
 
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
-    const instructorModel = await this.owner.lookup('service:store').find('user', instructor.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
+    const instructorModel = await this.owner
+      .lookup('service:store')
+      .findRecord('user', instructor.id);
 
     this.set('course', courseModel);
     this.set('instructor', instructorModel);

--- a/tests/integration/components/visualizer-course-instructor-term-test.js
+++ b/tests/integration/components/visualizer-course-instructor-term-test.js
@@ -56,8 +56,8 @@ module('Integration | Component | visualizer-course-instructor-term', function (
       instructors: [instructor],
     });
 
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
-    const userModel = await this.owner.lookup('service:store').find('user', instructor.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
+    const userModel = await this.owner.lookup('service:store').findRecord('user', instructor.id);
 
     this.set('course', courseModel);
     this.set('instructor', userModel);

--- a/tests/integration/components/visualizer-course-instructors-test.js
+++ b/tests/integration/components/visualizer-course-instructors-test.js
@@ -47,7 +47,7 @@ module('Integration | Component | visualizer-course-instructors', function (hook
       instructors: [instructor1, instructor2, instructor3, instructor4],
     });
 
-    this.courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    this.courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
   });
 
   test('it renders', async function (assert) {

--- a/tests/integration/components/visualizer-course-objectives-test.js
+++ b/tests/integration/components/visualizer-course-objectives-test.js
@@ -57,7 +57,7 @@ module('Integration | Component | visualizer-course-objectives', function (hooks
       endDate: new Date('2019-12-05T21:00:00'),
     });
 
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
 
     this.set('course', courseModel);
 

--- a/tests/integration/components/visualizer-course-session-type-test.js
+++ b/tests/integration/components/visualizer-course-session-type-test.js
@@ -52,10 +52,10 @@ module('Integration | Component | visualizer-course-session-type', function (hoo
       endDate: new Date('2019-12-05T21:00:00'),
     });
 
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     const sessionTypeModel = await this.owner
       .lookup('service:store')
-      .find('session-type', sessionType.id);
+      .findRecord('session-type', sessionType.id);
 
     this.set('course', courseModel);
     this.set('type', sessionTypeModel);

--- a/tests/integration/components/visualizer-course-session-types-test.js
+++ b/tests/integration/components/visualizer-course-session-types-test.js
@@ -44,7 +44,7 @@ module('Integration | Component | visualizer-course-session-types', function (ho
       endDate: new Date('2019-12-05T21:00:00'),
     });
 
-    this.courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    this.courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
   });
 
   test('it renders as bar chart by default', async function (assert) {

--- a/tests/integration/components/visualizer-course-term-test.js
+++ b/tests/integration/components/visualizer-course-term-test.js
@@ -49,8 +49,8 @@ module('Integration | Component | visualizer-course-term', function (hooks) {
       endDate: new Date('2019-12-05T21:00:00'),
     });
 
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
-    const termModel = await this.owner.lookup('service:store').find('term', term.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
+    const termModel = await this.owner.lookup('service:store').findRecord('term', term.id);
 
     this.set('course', courseModel);
     this.set('term', termModel);

--- a/tests/integration/components/visualizer-course-vocabularies-test.js
+++ b/tests/integration/components/visualizer-course-vocabularies-test.js
@@ -47,7 +47,7 @@ module('Integration | Component | visualizer-course-vocabularies', function (hoo
       endDate: new Date('2019-12-05T21:00:00'),
     });
 
-    const courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
 
     this.set('course', courseModel);
 

--- a/tests/integration/components/visualizer-course-vocabulary-test.js
+++ b/tests/integration/components/visualizer-course-vocabulary-test.js
@@ -48,10 +48,10 @@ module('Integration | Component | visualizer-course-vocabulary', function (hooks
       endDate: new Date('2019-12-05T21:00:00'),
     });
 
-    this.courseModel = await this.owner.lookup('service:store').find('course', course.id);
+    this.courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.vocabularyModel = await this.owner
       .lookup('service:store')
-      .find('vocabulary', vocabulary.id);
+      .findRecord('vocabulary', vocabulary.id);
   });
 
   test('it renders', async function (assert) {

--- a/tests/unit/models/school-test.js
+++ b/tests/unit/models/school-test.js
@@ -48,7 +48,7 @@ module('Unit | Model | School', function (hooks) {
   test('cohorts', async function (assert) {
     assert.ok(true);
     const school = this.server.create('school');
-    const model = await this.store.find('school', school.id);
+    const model = await this.store.findRecord('school', school.id);
     let cohorts = await model.cohorts;
     assert.strictEqual(cohorts.length, 0);
     const program1 = this.server.create('program', {

--- a/tests/unit/services/permission-checker-test.js
+++ b/tests/unit/services/permission-checker-test.js
@@ -107,7 +107,7 @@ module('Unit | Service | permission-checker', function (hooks) {
     const programYear = this.server.create('programYear', { program });
     const cohort = this.server.create('cohort', { programYear });
     const group = this.server.create('learnerGroup', { cohort });
-    const model = await this.owner.lookup('service:store').find('learner-group', group.id);
+    const model = await this.owner.lookup('service:store').findRecord('learner-group', group.id);
 
     const currentUserMock = Service.extend({
       isRoot: false,
@@ -130,7 +130,7 @@ module('Unit | Service | permission-checker', function (hooks) {
     const programYear = this.server.create('programYear', { program });
     const cohort = this.server.create('cohort', { programYear });
     const group = this.server.create('learnerGroup', { cohort });
-    const model = await this.owner.lookup('service:store').find('learner-group', group.id);
+    const model = await this.owner.lookup('service:store').findRecord('learner-group', group.id);
 
     const currentUserMock = Service.extend({
       isRoot: false,
@@ -153,7 +153,7 @@ module('Unit | Service | permission-checker', function (hooks) {
     const programYear = this.server.create('programYear', { program });
     const cohort = this.server.create('cohort', { programYear });
     const group = this.server.create('learnerGroup', { cohort });
-    const model = await this.owner.lookup('service:store').find('learner-group', group.id);
+    const model = await this.owner.lookup('service:store').findRecord('learner-group', group.id);
 
     const currentUserMock = Service.extend({
       isRoot: false,
@@ -176,7 +176,7 @@ module('Unit | Service | permission-checker', function (hooks) {
     const programYear = this.server.create('programYear', { program });
     const cohort = this.server.create('cohort', { programYear });
     const group = this.server.create('learnerGroup', { cohort });
-    const model = await this.owner.lookup('service:store').find('learner-group', group.id);
+    const model = await this.owner.lookup('service:store').findRecord('learner-group', group.id);
 
     const currentUserMock = Service.extend({
       isRoot: false,


### PR DESCRIPTION
Apparently this has been the API for almost a decade. Whoops, cleanup.