### PR TITLE
reworks course visualizations vocabularies/terms

### DIFF
--- a/addon-test-support/ilios-common/page-objects/components/course-visualize-vocabularies.js
+++ b/addon-test-support/ilios-common/page-objects/components/course-visualize-vocabularies.js
@@ -1,14 +1,19 @@
-import { attribute, collection, create, text } from 'ember-cli-page-object';
+import { attribute, collection, create } from 'ember-cli-page-object';
+import vocabulariesChart from './visualizer-course-vocabularies';
 
 const definition = create({
   scope: '[data-test-course-visualize-vocabularies]',
-  title: text('[data-test-title]'),
+  courseTitle: {
+    scope: '[data-test-course-title]',
+    link: attribute('href', 'a'),
+  },
   breadcrumb: {
     scope: '[data-test-breadcrumb]',
     crumbs: collection('span', {
       link: attribute('href', 'a'),
     }),
   },
+  vocabulariesChart,
 });
 
 export default definition;

--- a/addon-test-support/ilios-common/page-objects/components/course-visualize-vocabulary.js
+++ b/addon-test-support/ilios-common/page-objects/components/course-visualize-vocabulary.js
@@ -1,14 +1,20 @@
 import { attribute, collection, create, text } from 'ember-cli-page-object';
+import termsChart from './visualizer-course-vocabulary';
 
 const definition = create({
   scope: '[data-test-course-visualize-vocabulary]',
-  title: text('[data-test-title]'),
+  vocabularyTitle: text('[data-test-vocabulary-title]'),
+  courseTitle: {
+    scope: '[data-test-course-title]',
+    link: attribute('href', 'a'),
+  },
   breadcrumb: {
     scope: '[data-test-breadcrumb]',
     crumbs: collection('span', {
       link: attribute('href', 'a'),
     }),
   },
+  termsChart,
 });
 
 export default definition;

--- a/addon-test-support/ilios-common/page-objects/components/visualizer-course-vocabularies.js
+++ b/addon-test-support/ilios-common/page-objects/components/visualizer-course-vocabularies.js
@@ -1,0 +1,13 @@
+import { collection, create, notHasClass } from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-visualizer-course-vocabularies]',
+  isIcon: notHasClass('no-icon'),
+  chart: {
+    scope: '.simple-chart',
+    slices: collection('svg .slice'),
+  },
+};
+
+export default definition;
+export const component = create(definition);

--- a/addon-test-support/ilios-common/page-objects/components/visualizer-course-vocabulary.js
+++ b/addon-test-support/ilios-common/page-objects/components/visualizer-course-vocabulary.js
@@ -1,0 +1,14 @@
+import { collection, create, notHasClass } from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-visualizer-course-vocabulary]',
+  isIcon: notHasClass('no-icon'),
+  chart: {
+    scope: '.simple-chart',
+    bars: collection('.bars rect'),
+    labels: collection('.bars text'),
+  },
+};
+
+export default definition;
+export const component = create(definition);

--- a/addon-test-support/ilios-common/page-objects/course-visualizations-vocabularies.js
+++ b/addon-test-support/ilios-common/page-objects/course-visualizations-vocabularies.js
@@ -1,0 +1,7 @@
+import { create, visitable } from 'ember-cli-page-object';
+import root from './components/course-visualize-vocabularies';
+
+export default create({
+  visit: visitable('/data/courses/:courseId/vocabularies'),
+  root,
+});

--- a/addon-test-support/ilios-common/page-objects/course-visualizations-vocabulary.js
+++ b/addon-test-support/ilios-common/page-objects/course-visualizations-vocabulary.js
@@ -1,0 +1,7 @@
+import { create, visitable } from 'ember-cli-page-object';
+import root from './components/course-visualize-vocabulary';
+
+export default create({
+  visit: visitable('/data/courses/:courseId/vocabularies/:vocabularyId'),
+  root,
+});

--- a/addon/components/course-visualize-vocabularies.hbs
+++ b/addon/components/course-visualize-vocabularies.hbs
@@ -21,7 +21,7 @@
   <h2>
     {{t "general.vocabularies"}}
   </h2>
-  <h3 class="clickable" data-test-title>
+  <h3 class="clickable" data-test-course-title>
     <LinkTo @route="course" @model={{@model}}>
       {{@model.title}}
       {{#if this.academicYearCrossesCalendarYearBoundaries}}

--- a/addon/components/course-visualize-vocabularies.hbs
+++ b/addon/components/course-visualize-vocabularies.hbs
@@ -1,37 +1,35 @@
 <section
   class="course-visualize-vocabularies"
   data-test-course-visualize-vocabularies
-  {{did-insert (perform this.load)}}
+  ...attributes
 >
-  {{#unless this.load.isRunning}}
-    <div class="breadcrumbs" data-test-breadcrumb>
-      <span>
-        <LinkTo @route="course" @model={{@model}}>
-          {{@model.title}}
-        </LinkTo>
-      </span>
-      <span>
-        <LinkTo @route="course-visualizations" @model={{@model}}>
-          {{t "general.visualizations"}}
-        </LinkTo>
-      </span>
-      <span>
-        {{t "general.vocabularies"}}
-      </span>
-    </div>
-    <h2>
-      {{t "general.vocabularies"}}
-    </h2>
-    <h3 class="clickable" data-test-title>
+  <div class="breadcrumbs" data-test-breadcrumb>
+    <span>
       <LinkTo @route="course" @model={{@model}}>
         {{@model.title}}
-        {{#if this.academicYearCrossesCalendarYearBoundaries}}
-          {{@model.year}} - {{add @model.year 1}}
-        {{else}}
-          {{@model.year}}
-        {{/if}}
       </LinkTo>
-    </h3>
-    <VisualizerCourseVocabularies @course={{@model}} />
-  {{/unless}}
+    </span>
+    <span>
+      <LinkTo @route="course-visualizations" @model={{@model}}>
+        {{t "general.visualizations"}}
+      </LinkTo>
+    </span>
+    <span>
+      {{t "general.vocabularies"}}
+    </span>
+  </div>
+  <h2>
+    {{t "general.vocabularies"}}
+  </h2>
+  <h3 class="clickable" data-test-title>
+    <LinkTo @route="course" @model={{@model}}>
+      {{@model.title}}
+      {{#if this.academicYearCrossesCalendarYearBoundaries}}
+        {{@model.year}} - {{add @model.year 1}}
+      {{else}}
+        {{@model.year}}
+      {{/if}}
+    </LinkTo>
+  </h3>
+  <VisualizerCourseVocabularies @course={{@model}} />
 </section>

--- a/addon/components/course-visualize-vocabularies.js
+++ b/addon/components/course-visualize-vocabularies.js
@@ -1,16 +1,12 @@
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
-import { restartableTask } from 'ember-concurrency';
+import { use } from 'ember-could-get-used-to-this';
+import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 
 export default class CourseVisualizeVocabulariesComponent extends Component {
   @service iliosConfig;
-  @tracked academicYearCrossesCalendarYearBoundaries = false;
 
-  @restartableTask
-  *load() {
-    this.academicYearCrossesCalendarYearBoundaries = yield this.iliosConfig.itemFromConfig(
-      'academicYearCrossesCalendarYearBoundaries'
-    );
-  }
+  @use academicYearCrossesCalendarYearBoundaries = new ResolveAsyncValue(() => [
+    this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries'),
+  ]);
 }

--- a/addon/components/course-visualize-vocabulary.hbs
+++ b/addon/components/course-visualize-vocabulary.hbs
@@ -1,45 +1,43 @@
 <section
   class="course-visualize-vocabulary"
   data-test-course-visualize-vocabulary
-  {{did-insert (perform this.load)}}
+  ...attributes
 >
-  {{#unless this.load.isRunning}}
-    <div class="breadcrumbs" data-test-breadcrumb>
-      <span>
-        <LinkTo @route="course" @model={{@model.course}}>
-          {{@model.course.title}}
-        </LinkTo>
-      </span>
-      <span>
-        <LinkTo @route="course-visualizations" @model={{@model.course}}>
-          {{t "general.visualizations"}}
-        </LinkTo>
-      </span>
-      <span>
-        <LinkTo @route="course-visualize-vocabularies" @model={{@model.course}}>
-          {{t "general.vocabularies"}}
-        </LinkTo>
-      </span>
-      <span>
-        {{@model.vocabulary.title}}
-      </span>
-    </div>
-    <h2>
-      {{@model.vocabulary.title}}
-    </h2>
-    <h3 class="clickable" data-test-title>
+  <div class="breadcrumbs" data-test-breadcrumb>
+    <span>
       <LinkTo @route="course" @model={{@model.course}}>
         {{@model.course.title}}
-        {{#if this.academicYearCrossesCalendarYearBoundaries}}
-          {{@model.course.year}} - {{add @model.course.year 1}}
-        {{else}}
-          {{@model.course.year}}
-        {{/if}}
       </LinkTo>
-    </h3>
-    <VisualizerCourseVocabulary
-      @course={{@model.course}}
-      @vocabulary={{@model.vocabulary}}
-    />
-  {{/unless}}
+    </span>
+    <span>
+      <LinkTo @route="course-visualizations" @model={{@model.course}}>
+        {{t "general.visualizations"}}
+      </LinkTo>
+    </span>
+    <span>
+      <LinkTo @route="course-visualize-vocabularies" @model={{@model.course}}>
+        {{t "general.vocabularies"}}
+      </LinkTo>
+    </span>
+    <span>
+      {{@model.vocabulary.title}}
+    </span>
+  </div>
+  <h2>
+    {{@model.vocabulary.title}}
+  </h2>
+  <h3 class="clickable" data-test-title>
+    <LinkTo @route="course" @model={{@model.course}}>
+      {{@model.course.title}}
+      {{#if this.academicYearCrossesCalendarYearBoundaries}}
+        {{@model.course.year}} - {{add @model.course.year 1}}
+      {{else}}
+        {{@model.course.year}}
+      {{/if}}
+    </LinkTo>
+  </h3>
+  <VisualizerCourseVocabulary
+    @course={{@model.course}}
+    @vocabulary={{@model.vocabulary}}
+  />
 </section>

--- a/addon/components/course-visualize-vocabulary.hbs
+++ b/addon/components/course-visualize-vocabulary.hbs
@@ -23,10 +23,10 @@
       {{@model.vocabulary.title}}
     </span>
   </div>
-  <h2>
+  <h2 data-test-vocabulary-title>
     {{@model.vocabulary.title}}
   </h2>
-  <h3 class="clickable" data-test-title>
+  <h3 class="clickable" data-test-course-title>
     <LinkTo @route="course" @model={{@model.course}}>
       {{@model.course.title}}
       {{#if this.academicYearCrossesCalendarYearBoundaries}}

--- a/addon/components/course-visualize-vocabulary.js
+++ b/addon/components/course-visualize-vocabulary.js
@@ -1,16 +1,12 @@
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
-import { restartableTask } from 'ember-concurrency';
+import { use } from 'ember-could-get-used-to-this';
+import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 
 export default class CourseVisualizeVocabularyComponent extends Component {
   @service iliosConfig;
-  @tracked academicYearCrossesCalendarYearBoundaries = false;
 
-  @restartableTask
-  *load() {
-    this.academicYearCrossesCalendarYearBoundaries = yield this.iliosConfig.itemFromConfig(
-      'academicYearCrossesCalendarYearBoundaries'
-    );
-  }
+  @use academicYearCrossesCalendarYearBoundaries = new ResolveAsyncValue(() => [
+    this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries'),
+  ]);
 }

--- a/addon/components/visualizer-course-vocabularies.hbs
+++ b/addon/components/visualizer-course-vocabularies.hbs
@@ -1,5 +1,7 @@
 <div
   class="visualizer-course-vocabularies {{unless @isIcon "not-icon"}}"
+  data-test-visualizer-course-vocabularies
+  ...attributes
 >
   {{#if this.isLoaded}}
     {{#if (or @isIcon this.data.length)}}

--- a/addon/components/visualizer-course-vocabulary.hbs
+++ b/addon/components/visualizer-course-vocabulary.hbs
@@ -1,5 +1,7 @@
 <div
   class="visualizer-course-vocabulary {{unless @isIcon "not-icon"}}"
+  data-test-visualizer-course-vocabulary
+  ...attributes
 >
   {{#if this.isLoaded}}
     {{#if (or @isIcon this.data.length)}}

--- a/addon/components/visualizer-course-vocabulary.js
+++ b/addon/components/visualizer-course-vocabulary.js
@@ -81,7 +81,7 @@ export default class VisualizerCourseVocabulary extends Component {
     const totalMinutes = termData.mapBy('data').reduce((total, minutes) => total + minutes, 0);
     const mappedTermsWithLabel = termData.map((obj) => {
       const percent = ((obj.data / totalMinutes) * 100).toFixed(1);
-      obj.label = `${obj.meta.termTitle} ${percent}%`;
+      obj.label = `${obj.meta.termTitle}: ${obj.data} ${this.intl.t('general.minutes')}`;
       obj.meta.totalMinutes = totalMinutes;
       obj.meta.percent = percent;
       return obj;
@@ -100,9 +100,9 @@ export default class VisualizerCourseVocabulary extends Component {
       this.tooltipContent = null;
       return;
     }
-    const { label, data, meta } = obj;
+    const { label, meta } = obj;
 
-    this.tooltipTitle = htmlSafe(`${label} ${data} ${this.intl.t('general.minutes')}`);
+    this.tooltipTitle = htmlSafe(label);
     this.tooltipContent = meta.sessions.uniq().sort().join(', ');
   }
 

--- a/addon/components/visualizer-course-vocabulary.js
+++ b/addon/components/visualizer-course-vocabulary.js
@@ -17,25 +17,23 @@ export default class VisualizerCourseVocabulary extends Component {
 
   @use sessions = new ResolveAsyncValue(() => [this.args.course.sessions, []]);
 
-  @use dataObjects = new AsyncProcess(() => [
-    this.getDataObjects.bind(this),
-    this.sessionsWithMinutes,
-  ]);
-
-  get sessionsWithMinutes() {
-    return this.sessions.map((session) => {
-      return {
-        session,
-        minutes: Math.round(session.totalSumDuration * 60),
-      };
-    });
-  }
+  @use dataObjects = new AsyncProcess(() => [this.getDataObjects.bind(this), this.sessions]);
 
   get isLoaded() {
     return !!this.dataObjects;
   }
 
-  async getDataObjects(sessionsWithMinutes) {
+  async getDataObjects(sessions) {
+    if (!sessions) {
+      return [];
+    }
+    const sessionsWithMinutes = await map(sessions.toArray(), async (session) => {
+      const hours = await session.getTotalSumDuration();
+      return {
+        session,
+        minutes: Math.round(hours * 60),
+      };
+    });
     const terms = await map(sessionsWithMinutes, async ({ session, minutes }) => {
       const sessionTerms = await session.get('terms');
       const sessionTermsInThisVocabulary = await filter(sessionTerms.toArray(), async (term) => {

--- a/addon/routes/course-visualize-vocabularies.js
+++ b/addon/routes/course-visualize-vocabularies.js
@@ -15,11 +15,7 @@ export default class CourseVisualizeVocabulariesRoute extends Route {
 
   async afterModel(course) {
     const sessions = (await course.sessions).toArray();
-    return await all([
-      course.get('school'),
-      map(sessions, (s) => s.terms),
-      map(sessions, (s) => s.totalSumDuration),
-    ]);
+    return await all([course.get('school'), map(sessions, (s) => s.terms)]);
   }
 
   beforeModel(transition) {

--- a/addon/routes/course-visualize-vocabulary.js
+++ b/addon/routes/course-visualize-vocabulary.js
@@ -18,12 +18,7 @@ export default class CourseVisualizeVocabularyRoute extends Route {
   async afterModel(model) {
     const { course, vocabulary } = model;
     const sessions = (await course.sessions).toArray();
-    return await all([
-      course.get('school'),
-      vocabulary.terms,
-      map(sessions, (s) => s.terms),
-      map(sessions, (s) => s.totalSumDuration),
-    ]);
+    return await all([course.get('school'), vocabulary.terms, map(sessions, (s) => s.terms)]);
   }
 
   beforeModel(transition) {

--- a/tests/acceptance/course-visualizations-vocabularies-test.js
+++ b/tests/acceptance/course-visualizations-vocabularies-test.js
@@ -1,0 +1,75 @@
+import { module, test } from 'qunit';
+import { currentURL, waitFor } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import page from 'ilios-common/page-objects/course-visualizations-vocabularies';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setupAuthentication } from 'ilios-common';
+import { DateTime } from 'luxon';
+
+module('Acceptance | course visualizations - vocabularies', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  hooks.beforeEach(async function () {
+    this.user = await setupAuthentication();
+  });
+
+  test('it renders', async function (assert) {
+    const sessionType = this.server.create('sessionType');
+    const vocabulary1 = this.server.create('vocabulary');
+    const vocabulary2 = this.server.create('vocabulary');
+    const term1 = this.server.create('term', {
+      vocabulary: vocabulary1,
+    });
+    const term2 = this.server.create('term', {
+      vocabulary: vocabulary1,
+    });
+    const term3 = this.server.create('term', {
+      vocabulary: vocabulary2,
+    });
+    const session1 = this.server.create('session', {
+      sessionType,
+      terms: [term1],
+    });
+    const session2 = this.server.create('session', {
+      sessionType,
+      terms: [term2, term3],
+    });
+    const session3 = this.server.create('session', {
+      sessionType,
+    });
+    this.server.create('ilmSession', {
+      session: session3,
+      hours: 2,
+    });
+    this.server.create('offering', {
+      startDate: DateTime.fromISO('2022-07-20T09:00:00').toJSDate(),
+      endDate: DateTime.fromISO('2022-07-20T10:00:00').toJSDate(),
+      session: session1,
+    });
+    this.server.create('offering', {
+      startDate: DateTime.fromISO('2022-07-20T09:00:00').toJSDate(),
+      endDate: DateTime.fromISO('2022-07-20T09:30:00').toJSDate(),
+      session: session2,
+    });
+    const course = this.server.create('course', {
+      sessions: [session1, session2, session3],
+      year: 2022,
+    });
+    await page.visit({ courseId: course.id });
+    assert.strictEqual(currentURL(), '/data/courses/1/vocabularies');
+    assert.strictEqual(page.root.courseTitle.text, 'course 0 2022');
+    assert.strictEqual(page.root.courseTitle.link, '/courses/1');
+    assert.strictEqual(page.root.breadcrumb.crumbs.length, 3);
+    assert.strictEqual(page.root.breadcrumb.crumbs[0].text, 'course 0');
+    assert.strictEqual(page.root.breadcrumb.crumbs[0].link, '/courses/1');
+    assert.strictEqual(page.root.breadcrumb.crumbs[1].text, 'Visualizations');
+    assert.strictEqual(page.root.breadcrumb.crumbs[1].link, '/data/courses/1');
+    assert.strictEqual(page.root.breadcrumb.crumbs[2].text, 'Vocabularies');
+    // wait for charts to load
+    await waitFor('.loaded');
+    await waitFor('svg .chart');
+    assert.strictEqual(page.root.vocabulariesChart.chart.slices.length, 2);
+    assert.strictEqual(page.root.vocabulariesChart.chart.slices[0].text, 'Vocabulary 1');
+    assert.strictEqual(page.root.vocabulariesChart.chart.slices[1].text, 'Vocabulary 2');
+  });
+});

--- a/tests/acceptance/course-visualizations-vocabulary-test.js
+++ b/tests/acceptance/course-visualizations-vocabulary-test.js
@@ -1,0 +1,80 @@
+import { module, test } from 'qunit';
+import { currentURL, waitFor } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import page from 'ilios-common/page-objects/course-visualizations-vocabulary';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setupAuthentication } from 'ilios-common';
+import { DateTime } from 'luxon';
+
+module('Acceptance | course visualizations - vocabulary', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  hooks.beforeEach(async function () {
+    this.user = await setupAuthentication();
+  });
+
+  test('it renders', async function (assert) {
+    const vocabulary = this.server.create('vocabulary');
+    const term1 = this.server.create('term', {
+      vocabulary,
+    });
+    const term2 = this.server.create('term', {
+      vocabulary,
+    });
+    const term3 = this.server.create('term', {
+      vocabulary,
+    });
+    const sessionType = this.server.create('sessionType');
+    const session1 = this.server.create('session', {
+      sessionType,
+      terms: [term1],
+    });
+    const session2 = this.server.create('session', {
+      sessionType,
+      terms: [term2, term3],
+    });
+    const session3 = this.server.create('session', {
+      sessionType,
+      terms: [term3],
+    });
+    this.server.create('ilmSession', {
+      session: session3,
+      hours: 2,
+    });
+    this.server.create('offering', {
+      startDate: DateTime.fromISO('2022-07-20T09:00:00').toJSDate(),
+      endDate: DateTime.fromISO('2022-07-20T10:00:00').toJSDate(),
+      session: session1,
+    });
+    this.server.create('offering', {
+      startDate: DateTime.fromISO('2022-07-20T09:00:00').toJSDate(),
+      endDate: DateTime.fromISO('2022-07-20T09:30:00').toJSDate(),
+      session: session2,
+    });
+    const course = this.server.create('course', {
+      sessions: [session1, session2, session3],
+      year: 2022,
+    });
+    await page.visit({ courseId: course.id, vocabularyId: vocabulary.id });
+    assert.strictEqual(currentURL(), '/data/courses/1/vocabularies/1');
+    assert.strictEqual(page.root.vocabularyTitle, 'Vocabulary 1');
+    assert.strictEqual(page.root.courseTitle.text, 'course 0 2022');
+    assert.strictEqual(page.root.courseTitle.link, '/courses/1');
+    assert.strictEqual(page.root.breadcrumb.crumbs.length, 4);
+    assert.strictEqual(page.root.breadcrumb.crumbs[0].text, 'course 0');
+    assert.strictEqual(page.root.breadcrumb.crumbs[0].link, '/courses/1');
+    assert.strictEqual(page.root.breadcrumb.crumbs[1].text, 'Visualizations');
+    assert.strictEqual(page.root.breadcrumb.crumbs[1].link, '/data/courses/1');
+    assert.strictEqual(page.root.breadcrumb.crumbs[2].text, 'Vocabularies');
+    assert.strictEqual(page.root.breadcrumb.crumbs[2].link, '/data/courses/1/vocabularies');
+    assert.strictEqual(page.root.breadcrumb.crumbs[3].text, 'Vocabulary 1');
+    // wait for charts to load
+    await waitFor('.loaded');
+    await waitFor('svg .bars');
+    assert.strictEqual(page.root.termsChart.chart.bars.length, 3);
+    assert.strictEqual(page.root.termsChart.chart.labels.length, 3);
+    assert.strictEqual(page.root.termsChart.chart.labels[0].text, 'term 1: 30 Minutes');
+    assert.strictEqual(page.root.termsChart.chart.labels[1].text, 'term 0: 60 Minutes');
+    assert.strictEqual(page.root.termsChart.chart.labels[2].text, 'term 2: 150 Minutes');
+  });
+});

--- a/tests/integration/components/course-visualize-vocabularies-test.js
+++ b/tests/integration/components/course-visualize-vocabularies-test.js
@@ -21,8 +21,8 @@ module('Integration | Component | course-visualize-vocabularies', function (hook
     this.set('course', this.courseModel);
 
     await render(hbs`<CourseVisualizeVocabularies @model={{this.course}} />`);
-
-    assert.strictEqual(component.title, 'course 0 2021');
+    assert.strictEqual(component.courseTitle.text, 'course 0 2021');
+    assert.strictEqual(component.courseTitle.link, '/courses/1');
   });
 
   test('course year is shown as range if applicable by configuration', async function (assert) {
@@ -36,8 +36,7 @@ module('Integration | Component | course-visualize-vocabularies', function (hook
     this.set('course', this.courseModel);
 
     await render(hbs`<CourseVisualizeVocabularies @model={{this.course}} />`);
-
-    assert.strictEqual(component.title, 'course 0 2021 - 2022');
+    assert.strictEqual(component.courseTitle.text, 'course 0 2021 - 2022');
   });
 
   test('breadcrumb', async function (assert) {

--- a/tests/integration/components/course-visualize-vocabulary-test.js
+++ b/tests/integration/components/course-visualize-vocabulary-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
-import { render } from '@ember/test-helpers';
+import { render, waitFor } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { component } from 'ilios-common/page-objects/components/course-visualize-vocabulary';
@@ -14,8 +14,26 @@ module('Integration | Component | course-visualize-vocabulary', function (hooks)
   hooks.beforeEach(async function () {
     const school = this.server.create('school');
     const vocabulary = this.server.create('vocabulary', { school });
-    const term = this.server.create('term', { vocabulary });
-    const course = this.server.create('course', { year: 2021, school, terms: [term] });
+    const term1 = this.server.create('term', { vocabulary });
+    const term2 = this.server.create('term', { vocabulary });
+    const course = this.server.create('course', { year: 2021, school });
+    const session1 = this.server.create('session', {
+      course,
+      terms: [term1],
+    });
+    const session2 = this.server.create('session', {
+      course,
+      terms: [term2],
+    });
+    this.server.create('ilmSession', {
+      session: session1,
+      hours: 2.5,
+    });
+    this.server.create('offering', {
+      session: session2,
+      startDate: new Date('2022-07-20T09:00:00'),
+      endDate: new Date('2022-07-20T10:00:00'),
+    });
     this.courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.vocabularyModel = await this.owner
       .lookup('service:store')
@@ -27,7 +45,9 @@ module('Integration | Component | course-visualize-vocabulary', function (hooks)
 
     await render(hbs`<CourseVisualizeVocabulary @model={{this.model}} />`);
 
-    assert.strictEqual(component.title, 'course 0 2021');
+    assert.strictEqual(component.vocabularyTitle, 'Vocabulary 1');
+    assert.strictEqual(component.courseTitle.text, 'course 0 2021');
+    assert.strictEqual(component.courseTitle.link, '/courses/1');
   });
 
   test('course year is shown as range if applicable by configuration', async function (assert) {
@@ -42,7 +62,7 @@ module('Integration | Component | course-visualize-vocabulary', function (hooks)
 
     await render(hbs`<CourseVisualizeVocabulary @model={{this.model}} />`);
 
-    assert.strictEqual(component.title, 'course 0 2021 - 2022');
+    assert.strictEqual(component.courseTitle.text, 'course 0 2021 - 2022');
   });
 
   test('breadcrumb', async function (assert) {
@@ -58,5 +78,18 @@ module('Integration | Component | course-visualize-vocabulary', function (hooks)
     assert.strictEqual(component.breadcrumb.crumbs[2].text, 'Vocabularies');
     assert.strictEqual(component.breadcrumb.crumbs[2].link, '/data/courses/1/vocabularies');
     assert.strictEqual(component.breadcrumb.crumbs[3].text, 'Vocabulary 1');
+  });
+
+  test('chart', async function (assert) {
+    this.set('model', { course: this.courseModel, vocabulary: this.vocabularyModel });
+
+    await render(hbs`<CourseVisualizeVocabulary @model={{this.model}} />`);
+    // wait for charts to load
+    await waitFor('.loaded');
+    await waitFor('svg .bars');
+    assert.strictEqual(component.termsChart.chart.bars.length, 2);
+    assert.strictEqual(component.termsChart.chart.labels.length, 2);
+    assert.strictEqual(component.termsChart.chart.labels[0].text, 'term 1: 60 Minutes');
+    assert.strictEqual(component.termsChart.chart.labels[1].text, 'term 0: 150 Minutes');
   });
 });

--- a/tests/integration/components/visualizer-course-vocabularies-test.js
+++ b/tests/integration/components/visualizer-course-vocabularies-test.js
@@ -4,6 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render, waitFor } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { component } from 'ilios-common/page-objects/components/visualizer-course-vocabularies';
 
 module('Integration | Component | visualizer-course-vocabularies', function (hooks) {
   setupRenderingTest(hooks);
@@ -11,7 +12,6 @@ module('Integration | Component | visualizer-course-vocabularies', function (hoo
   setupMirage(hooks);
 
   test('it renders', async function (assert) {
-    assert.expect(3);
     const vocabulary1 = this.server.create('vocabulary', {
       title: 'Standalone',
     });
@@ -55,10 +55,8 @@ module('Integration | Component | visualizer-course-vocabularies', function (hoo
     //let the chart animations finish
     await waitFor('.loaded');
     await waitFor('svg .slice');
-    const chart = 'svg';
-    const chartLabels = `${chart} .slice text`;
-    assert.dom(chartLabels).exists({ count: 2 });
-    assert.dom(chart).containsText('Standalone');
-    assert.dom(chart).containsText('Campaign');
+    assert.strictEqual(component.chart.slices.length, 2);
+    assert.strictEqual(component.chart.slices[0].text, 'Standalone');
+    assert.strictEqual(component.chart.slices[1].text, 'Campaign');
   });
 });

--- a/tests/integration/components/visualizer-course-vocabulary-test.js
+++ b/tests/integration/components/visualizer-course-vocabulary-test.js
@@ -2,9 +2,10 @@ import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
-import { click, render, findAll, waitFor } from '@ember/test-helpers';
+import { click, render, waitFor } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { component } from 'ilios-common/page-objects/components/visualizer-course-vocabulary';
 
 module('Integration | Component | visualizer-course-vocabulary', function (hooks) {
   setupRenderingTest(hooks);
@@ -65,10 +66,10 @@ module('Integration | Component | visualizer-course-vocabulary', function (hooks
     await waitFor('.loaded');
     await waitFor('svg .bars');
 
-    const chartLabels = 'svg .bars text';
-    assert.dom(chartLabels).exists({ count: 2 });
-    assert.dom(findAll(chartLabels)[0]).hasText('Campaign 22.2%');
-    assert.dom(findAll(chartLabels)[1]).hasText('Standalone 77.8%');
+    assert.strictEqual(component.chart.bars.length, 2);
+    assert.strictEqual(component.chart.labels.length, 2);
+    assert.strictEqual(component.chart.labels[0].text, 'Campaign: 180 Minutes');
+    assert.strictEqual(component.chart.labels[1].text, 'Standalone: 630 Minutes');
   });
 
   test('on-click transition fires', async function (assert) {


### PR DESCRIPTION
- use async methods instead of resources as applicable
- relabels bars and tooltips on vocabulary terms chart to show total minutes instead of the less meaningful percentage numbers
- improves test coverage