### PR TITLE
scroll LM details title back into view after saving or canceling edits/additions of LMs.

### DIFF
--- a/addon/components/detail-learning-materials.hbs
+++ b/addon/components/detail-learning-materials.hbs
@@ -5,7 +5,7 @@
   {{did-update (perform this.load) @subject.learningMaterials}}
 >
   <div class="detail-learningmaterials-header">
-    <div class="title">
+    <div class="title" {{did-insert (set this.title)}}>
       {{#if this.isManaging}}
         <span class="specific-title">
           {{t "general.learningMaterialManageTitle"}}
@@ -42,7 +42,7 @@
       <LearningmaterialManager
         @learningMaterial={{this.managingMaterial}}
         @editable={{@editable}}
-        @closeManager={{fn (set this.managingMaterial) null}}
+        @closeManager={{this.closeLearningmaterialManager}}
         @learningMaterialStatuses={{await this.learningMaterialStatuses}}
       />
     {{else if this.isSorting}}
@@ -57,7 +57,7 @@
         @learningMaterialStatuses={{await this.learningMaterialStatuses}}
         @learningMaterialUserRoles={{await this.learningMaterialUserRoles}}
         @save={{perform this.saveNewLearningMaterial}}
-        @cancel={{fn (set this.displayAddNewForm) false}}
+        @cancel={{this.closeNewLearningmaterial}}
       />
     {{else if (get (await @subject.learningMaterials) "length")}}
       {{#if (and @editable (await this.hasMoreThanOneLearningMaterial))}}

--- a/addon/components/detail-learning-materials.js
+++ b/addon/components/detail-learning-materials.js
@@ -6,6 +6,7 @@ import { dropTask, restartableTask } from 'ember-concurrency';
 import { all } from 'rsvp';
 import ObjectProxy from '@ember/object/proxy';
 import sortableByPosition from 'ilios-common/utils/sortable-by-position';
+import scrollIntoView from 'scroll-into-view';
 
 export default class DetailCohortsComponent extends Component {
   @service currentUser;
@@ -15,12 +16,12 @@ export default class DetailCohortsComponent extends Component {
   @tracked managingMaterial;
   @tracked totalMaterialsToSave;
   @tracked currentMaterialsSaved;
-
   @tracked displayAddNewForm = false;
   @tracked type;
   @tracked materialsRelationship;
   @tracked learningMaterialStatuses;
   @tracked learningMaterialUserRoles;
+  @tracked title;
 
   constructor() {
     super(...arguments);
@@ -82,6 +83,18 @@ export default class DetailCohortsComponent extends Component {
     this.displayAddNewForm = true;
   }
 
+  @action
+  closeLearningmaterialManager() {
+    this.managingMaterial = null;
+    scrollIntoView(this.title);
+  }
+
+  @action
+  closeNewLearningmaterial() {
+    this.displayAddNewForm = false;
+    scrollIntoView(this.title);
+  }
+
   @dropTask
   *saveNewLearningMaterial(lm) {
     const savedLm = yield lm.save();
@@ -106,6 +119,7 @@ export default class DetailCohortsComponent extends Component {
     yield lmSubject.save();
     this.displayAddNewForm = false;
     this.type = null;
+    scrollIntoView(this.title);
   }
 
   @dropTask
@@ -122,6 +136,7 @@ export default class DetailCohortsComponent extends Component {
 
     yield this.saveSomeMaterials(materialsToSave);
     this.isSorting = false;
+    scrollIntoView(this.title);
   }
 
   @dropTask

--- a/addon/components/detail-learning-materials.js
+++ b/addon/components/detail-learning-materials.js
@@ -86,13 +86,17 @@ export default class DetailCohortsComponent extends Component {
   @action
   closeLearningmaterialManager() {
     this.managingMaterial = null;
-    scrollIntoView(this.title);
+    scrollIntoView(this.title, {
+      align: { top: 0 },
+    });
   }
 
   @action
   closeNewLearningmaterial() {
     this.displayAddNewForm = false;
-    scrollIntoView(this.title);
+    scrollIntoView(this.title, {
+      align: { top: 0 },
+    });
   }
 
   @dropTask
@@ -119,7 +123,9 @@ export default class DetailCohortsComponent extends Component {
     yield lmSubject.save();
     this.displayAddNewForm = false;
     this.type = null;
-    scrollIntoView(this.title);
+    scrollIntoView(this.title, {
+      align: { top: 0 },
+    });
   }
 
   @dropTask
@@ -136,7 +142,9 @@ export default class DetailCohortsComponent extends Component {
 
     yield this.saveSomeMaterials(materialsToSave);
     this.isSorting = false;
-    scrollIntoView(this.title);
+    scrollIntoView(this.title, {
+      align: { top: 0 },
+    });
   }
 
   @dropTask


### PR DESCRIPTION
this scrolls back up to the top of the learning materials list.

fixes https://github.com/ilios/common/issues/3003