### PR TITLE
Move material title to the left on dashboard materials

### DIFF
--- a/addon-test-support/ilios-common/page-objects/components/dashboard/materials.js
+++ b/addon-test-support/ilios-common/page-objects/components/dashboard/materials.js
@@ -51,21 +51,21 @@ const definition = {
     headers: {
       scope: 'thead',
       sessionTitle: {
-        scope: 'th:nth-of-type(2)',
-        isSortedAscending: hasClass('fa-arrow-down-a-z', 'svg'),
-        isSortedDescending: hasClass('fa-arrow-down-z-a', 'svg'),
-        isSortedOn: notHasClass('fa-sort', 'svg'),
-        click: clickable('button'),
-      },
-      courseTitle: {
         scope: 'th:nth-of-type(3)',
         isSortedAscending: hasClass('fa-arrow-down-a-z', 'svg'),
         isSortedDescending: hasClass('fa-arrow-down-z-a', 'svg'),
         isSortedOn: notHasClass('fa-sort', 'svg'),
         click: clickable('button'),
       },
-      title: {
+      courseTitle: {
         scope: 'th:nth-of-type(4)',
+        isSortedAscending: hasClass('fa-arrow-down-a-z', 'svg'),
+        isSortedDescending: hasClass('fa-arrow-down-z-a', 'svg'),
+        isSortedOn: notHasClass('fa-sort', 'svg'),
+        click: clickable('button'),
+      },
+      title: {
+        scope: 'th:nth-of-type(2)',
         isSortedAscending: hasClass('fa-arrow-down-a-z', 'svg'),
         isSortedDescending: hasClass('fa-arrow-down-z-a', 'svg'),
         isSortedOn: notHasClass('fa-sort', 'svg'),

--- a/addon/components/dashboard/materials.hbs
+++ b/addon/components/dashboard/materials.hbs
@@ -71,6 +71,14 @@
             <SortableTh
               @colspan={{6}}
               @sortedAscending={{this.sortedAscending}}
+              @sortedBy={{or (eq @sortBy "title") (eq @sortBy "title:desc")}}
+              @onClick={{fn this.sortBy "title"}}
+            >
+              {{t "general.title"}}
+            </SortableTh>
+            <SortableTh
+              @colspan={{6}}
+              @sortedAscending={{this.sortedAscending}}
               @sortedBy={{or
               (eq @sortBy "sessionTitle")
               (eq @sortBy "sessionTitle:desc")
@@ -89,14 +97,6 @@
               @onClick={{fn this.sortBy "courseTitle"}}
             >
               {{t "general.course"}}
-            </SortableTh>
-            <SortableTh
-              @colspan={{6}}
-              @sortedAscending={{this.sortedAscending}}
-              @sortedBy={{or (eq @sortBy "title") (eq @sortBy "title:desc")}}
-              @onClick={{fn this.sortBy "title"}}
-            >
-              {{t "general.title"}}
             </SortableTh>
             <th colspan="4" class="hide-from-small-screen">
               {{t "general.instructor"}}
@@ -121,12 +121,6 @@
               <tr data-test-learning-material>
                 <td>
                   <UserMaterialStatus @learningMaterial={{lmObject}} />
-                </td>
-                <td colspan="6" data-test-session-title>
-                  {{lmObject.sessionTitle}}
-                </td>
-                <td colspan="6" data-test-course-title>
-                  {{lmObject.courseTitle}}
                 </td>
                 <td colspan="6" data-test-title>
                   {{#if lmObject.isBlanked}}
@@ -191,6 +185,12 @@
                       </small>
                     {{/if}}
                   {{/if}}
+                </td>
+                <td colspan="6" data-test-session-title>
+                  {{lmObject.sessionTitle}}
+                </td>
+                <td colspan="6" data-test-course-title>
+                  {{lmObject.courseTitle}}
                 </td>
                 <td class="hide-from-small-screen" colspan="4" data-test-instructors>
                   <TruncateText


### PR DESCRIPTION
Now that the checkbox is over on the left side it makes more sense to
have the material title join it on that side of the table.

Fixes ilios/ilios#4280