### PR TITLE
Load polyfills in order

### DIFF
--- a/addon/utils/load-polyfills.js
+++ b/addon/utils/load-polyfills.js
@@ -1,5 +1,7 @@
 export async function loadPolyfills() {
-  await Promise.all([intlLocale(), intlPluralRules(), intlRelativeTimeFormat()]);
+  await intlLocale();
+  await intlPluralRules();
+  await intlRelativeTimeFormat();
 }
 
 async function intlLocale() {


### PR DESCRIPTION
Both the PluralRules and RelativeTime polyfills require the intlLocale
to be already loading. This mostly worked, but sporadic network delays
could cause them to process out of order and break. Load them
sequentially for the best experience.

Fixes ilios/ilios#4363