### PR TITLE
adds icon to user search results to indicate disabled accounts.

### DIFF
--- a/addon/components/user-search-result-user.hbs
+++ b/addon/components/user-search-result-user.hbs
@@ -16,6 +16,13 @@
   <li class="inactive" data-test-result>
     <div class="name">
       {{@user.fullName}}
+      {{#unless @user.enabled}}
+        <FaIcon
+          @icon="user-xmark"
+          @title={{t "general.disabled"}}
+          class="error"
+        />
+      {{/unless}}
     </div>
     <div class="email">
       {{@user.email}}


### PR DESCRIPTION
fixes https://github.com/ilios/ilios/issues/4372

![image](https://user-images.githubusercontent.com/1410427/187561834-0d50f216-6c65-46f6-ac3f-5b16c6f04a3f.png)


(will need a common release in order to take affect in the frontend UI that the linked ticket is referencing)