### PR TITLE
gives visualization mixin a more generic name.

### DIFF
--- a/app/styles/ilios-common/components/course-visualizations.scss
+++ b/app/styles/ilios-common/components/course-visualizations.scss
@@ -1,5 +1,5 @@
 .course-visualizations {
-  @include course-visualization;
+  @include data-visualization;
 
   .visualizations {
     .visualizer-course-instructors,

--- a/app/styles/ilios-common/components/course-visualize-instructor.scss
+++ b/app/styles/ilios-common/components/course-visualize-instructor.scss
@@ -1,5 +1,5 @@
 .course-visualize-instructor {
-  @include course-visualization;
+  @include data-visualization;
 
   .visualizations {
     .visualizer-course-instructor-session-type,

--- a/app/styles/ilios-common/components/course-visualize-instructors.scss
+++ b/app/styles/ilios-common/components/course-visualize-instructors.scss
@@ -1,3 +1,3 @@
 .course-visualize-instructors {
-  @include course-visualization;
+  @include data-visualization;
 }

--- a/app/styles/ilios-common/components/course-visualize-objectives.scss
+++ b/app/styles/ilios-common/components/course-visualize-objectives.scss
@@ -1,3 +1,3 @@
 .course-visualize-objectives {
-  @include course-visualization;
+  @include data-visualization;
 }

--- a/app/styles/ilios-common/components/course-visualize-session-type.scss
+++ b/app/styles/ilios-common/components/course-visualize-session-type.scss
@@ -1,3 +1,3 @@
 .course-visualize-session-type {
-  @include course-visualization;
+  @include data-visualization;
 }

--- a/app/styles/ilios-common/components/course-visualize-session-types.scss
+++ b/app/styles/ilios-common/components/course-visualize-session-types.scss
@@ -1,3 +1,3 @@
 .course-visualize-session-types {
-  @include course-visualization;
+  @include data-visualization;
 }

--- a/app/styles/ilios-common/components/course-visualize-term.scss
+++ b/app/styles/ilios-common/components/course-visualize-term.scss
@@ -1,3 +1,3 @@
 .course-visualize-term {
-  @include course-visualization;
+  @include data-visualization;
 }

--- a/app/styles/ilios-common/components/course-visualize-vocabularies.scss
+++ b/app/styles/ilios-common/components/course-visualize-vocabularies.scss
@@ -1,3 +1,3 @@
 .course-visualize-vocabularies {
-  @include course-visualization;
+  @include data-visualization;
 }

--- a/app/styles/ilios-common/components/course-visualize-vocabulary.scss
+++ b/app/styles/ilios-common/components/course-visualize-vocabulary.scss
@@ -1,3 +1,3 @@
 .course-visualize-vocabulary {
-  @include course-visualization;
+  @include data-visualization;
 }

--- a/app/styles/ilios-common/mixins.scss
+++ b/app/styles/ilios-common/mixins.scss
@@ -2,6 +2,7 @@
 @import 'mixins/collapsed-container';
 @import 'mixins/critical-notice';
 @import 'mixins/dashboard';
+@import 'mixins/data-visualization';
 @import 'mixins/detail-container';
 @import 'mixins/font-size';
 @import 'mixins/icon';
@@ -29,6 +30,5 @@
 @import 'mixins/text-wrap';
 @import 'mixins/course/header';
 @import 'mixins/course/overview';
-@import 'mixins/course/visualization';
 
 

--- a/app/styles/ilios-common/mixins/data-visualization.scss
+++ b/app/styles/ilios-common/mixins/data-visualization.scss
@@ -1,4 +1,4 @@
-@mixin course-visualization {
+@mixin data-visualization {
   h2 {
     @include ilios-heading-h2;
     margin: .5rem;


### PR DESCRIPTION
we're re-using those styles for non-course related visualizations, so
let's make sure this is correctly reflected in the name of the mixin.

refs https://github.com/ilios/frontend/pull/6842