### PR TITLE
Remove array prototype extensions

### DIFF
--- a/addon-mirage-support/post-all.js
+++ b/addon-mirage-support/post-all.js
@@ -1,3 +1,4 @@
+import { mapBy } from 'ilios-common/utils/array-helpers';
 import getName from './get-name';
 import parseJsonData from './parse-json-data';
 
@@ -15,7 +16,7 @@ const postAll = function (schema, request) {
       const attrs = parseJsonData({ data: item });
       return this.serializerOrRegistry.serialize(schema[modelName].create(attrs));
     });
-    return { data: models.mapBy('data') };
+    return { data: mapBy(models, 'data') };
   }
 
   const attrs = parseJsonData(obj);

--- a/addon/classes/events-base.js
+++ b/addon/classes/events-base.js
@@ -36,14 +36,11 @@ export default class EventsBase extends Service {
    * @return {Promise.<Array>}
    */
   async getTermIdsForEvent(event) {
-    const terms = [];
     const session = await this.getSessionForEvent(event);
     const sessionTerms = await session.get('terms');
     const course = await session.get('course');
     const courseTerms = await course.get('terms');
-    terms.push(sessionTerms.slice());
-    terms.push(courseTerms.slice());
-    return uniqueValues(mapBy(terms, 'id'));
+    return uniqueValues(mapBy([...sessionTerms.slice(), ...courseTerms.slice()], 'id'));
   }
 
   /**

--- a/addon/classes/events-base.js
+++ b/addon/classes/events-base.js
@@ -41,8 +41,8 @@ export default class EventsBase extends Service {
     const sessionTerms = await session.get('terms');
     const course = await session.get('course');
     const courseTerms = await course.get('terms');
-    terms.pushObjects(sessionTerms.slice());
-    terms.pushObjects(courseTerms.slice());
+    terms.push(sessionTerms.slice());
+    terms.push(courseTerms.slice());
     return uniqueValues(mapBy(terms, 'id'));
   }
 

--- a/addon/classes/events-base.js
+++ b/addon/classes/events-base.js
@@ -1,5 +1,6 @@
 import Service from '@ember/service';
 import { DateTime } from 'luxon';
+import { mapBy, sortByDate, sortByString } from '../utils/array-helpers';
 
 export default class EventsBase extends Service {
   /**
@@ -42,7 +43,7 @@ export default class EventsBase extends Service {
     const courseTerms = await course.get('terms');
     terms.pushObjects(sessionTerms.toArray());
     terms.pushObjects(courseTerms.toArray());
-    return terms.mapBy('id').uniq();
+    return mapBy(terms, 'id').uniq();
   }
 
   /**
@@ -88,7 +89,7 @@ export default class EventsBase extends Service {
   async getCohortIdsForEvent(event) {
     const course = await this.getCourseForEvent(event);
     const cohorts = await course.get('cohorts');
-    return cohorts.toArray().mapBy('id');
+    return mapBy(cohorts.slice(), 'id');
   }
 
   /**
@@ -101,19 +102,21 @@ export default class EventsBase extends Service {
   createEventFromData(obj, isUserEvent) {
     obj.isBlanked = !obj.offering && !obj.ilmSession;
     obj.slug = isUserEvent ? this.getSlugForUserEvent(obj) : this.getSlugForSchoolEvent(obj);
-    obj.prerequisites = obj.prerequisites
-      .map((prereq) => {
-        const rhett = this.createEventFromData(prereq, isUserEvent);
-        rhett.startDate = obj.startDate;
-        rhett.postrequisiteName = obj.name;
-        rhett.postrequisiteSlug = obj.slug;
+    obj.prerequisites = obj.prerequisites.map((prereq) => {
+      const rhett = this.createEventFromData(prereq, isUserEvent);
+      rhett.startDate = obj.startDate;
+      rhett.postrequisiteName = obj.name;
+      rhett.postrequisiteSlug = obj.slug;
 
-        return rhett;
-      })
-      .sortBy('startDate', 'name');
-    obj.postrequisites = obj.postrequisites
-      .map((postreq) => this.createEventFromData(postreq, isUserEvent))
-      .sortBy('startDate', 'name');
+      return rhett;
+    });
+    obj.prerequisites = sortByDate(obj.prerequisites, 'startDate');
+    obj.prerequisites = sortByString(obj.prerequisites, 'name');
+    obj.postrequisites = obj.postrequisites.map((postreq) =>
+      this.createEventFromData(postreq, isUserEvent)
+    );
+    obj.postrequisites = sortByDate(obj.postrequisites, 'startDate');
+    obj.postrequisites = sortByString(obj.postrequisites, 'name');
     obj.isUserEvent = isUserEvent;
     return obj;
   }

--- a/addon/classes/events-base.js
+++ b/addon/classes/events-base.js
@@ -1,6 +1,6 @@
 import Service from '@ember/service';
 import { DateTime } from 'luxon';
-import { mapBy, sortByDate, sortByString, uniqueValues } from '../utils/array-helpers';
+import { mapBy, sortBy, uniqueValues } from '../utils/array-helpers';
 
 export default class EventsBase extends Service {
   /**
@@ -110,13 +110,13 @@ export default class EventsBase extends Service {
 
       return rhett;
     });
-    obj.prerequisites = sortByDate(obj.prerequisites, 'startDate');
-    obj.prerequisites = sortByString(obj.prerequisites, 'name');
+    obj.prerequisites = sortBy(obj.prerequisites, 'startDate');
+    obj.prerequisites = sortBy(obj.prerequisites, 'name');
     obj.postrequisites = obj.postrequisites.map((postreq) =>
       this.createEventFromData(postreq, isUserEvent)
     );
-    obj.postrequisites = sortByDate(obj.postrequisites, 'startDate');
-    obj.postrequisites = sortByString(obj.postrequisites, 'name');
+    obj.postrequisites = sortBy(obj.postrequisites, 'startDate');
+    obj.postrequisites = sortBy(obj.postrequisites, 'name');
     obj.isUserEvent = isUserEvent;
     return obj;
   }

--- a/addon/classes/events-base.js
+++ b/addon/classes/events-base.js
@@ -41,8 +41,8 @@ export default class EventsBase extends Service {
     const sessionTerms = await session.get('terms');
     const course = await session.get('course');
     const courseTerms = await course.get('terms');
-    terms.pushObjects(sessionTerms.toArray());
-    terms.pushObjects(courseTerms.toArray());
+    terms.pushObjects(sessionTerms.slice());
+    terms.pushObjects(courseTerms.slice());
     return uniqueValues(mapBy(terms, 'id'));
   }
 

--- a/addon/classes/events-base.js
+++ b/addon/classes/events-base.js
@@ -1,6 +1,6 @@
 import Service from '@ember/service';
 import { DateTime } from 'luxon';
-import { mapBy, sortByDate, sortByString } from '../utils/array-helpers';
+import { mapBy, sortByDate, sortByString, uniqueValues } from '../utils/array-helpers';
 
 export default class EventsBase extends Service {
   /**
@@ -43,7 +43,7 @@ export default class EventsBase extends Service {
     const courseTerms = await course.get('terms');
     terms.pushObjects(sessionTerms.toArray());
     terms.pushObjects(courseTerms.toArray());
-    return mapBy(terms, 'id').uniq();
+    return uniqueValues(mapBy(terms, 'id'));
   }
 
   /**

--- a/addon/classes/resolve-flat-map-by.js
+++ b/addon/classes/resolve-flat-map-by.js
@@ -1,5 +1,6 @@
 import { tracked } from '@glimmer/tracking';
 import { Resource } from 'ember-could-get-used-to-this';
+import { mapBy } from '../utils/array-helpers';
 
 export default class ResolveFlatMapBy extends Resource {
   @tracked data;
@@ -41,10 +42,14 @@ export default class ResolveFlatMapBy extends Resource {
     //this is also safe if arr isn't a promise.
     const resolvedArray = await Promise.resolve(arr);
     if (resolvedArray) {
-      //Ember data models return a promise from `mapBy`
-      //so we need to resolve it and then resolve the values in it
-      const mapBy = await resolvedArray.mapBy(mapByKey);
-      this.data = await Promise.all(mapBy);
+      if ('mapBy' in resolvedArray) {
+        //Ember data models return a promise from `mapBy`
+        //so we need to resolve it and then resolve the values in it
+        const mapBy = await resolvedArray.mapBy(mapByKey);
+        this.data = await Promise.all(mapBy);
+      } else {
+        this.data = await Promise.all(mapBy(resolvedArray, mapByKey));
+      }
     }
   }
 }

--- a/addon/classes/resolve-flat-map-by.js
+++ b/addon/classes/resolve-flat-map-by.js
@@ -22,7 +22,7 @@ export default class ResolveFlatMapBy extends Resource {
         return arr;
       }
       if ('toArray' in arr) {
-        return arr.toArray();
+        return arr.slice();
       }
 
       return arr;

--- a/addon/components/collapsed-competencies.js
+++ b/addon/components/collapsed-competencies.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { restartableTask } from 'ember-concurrency';
 import { inject as service } from '@ember/service';
+import { findById } from '../utils/array-helpers';
 
 export default class CollapsedCompetenciesComponent extends Component {
   @service store;
@@ -22,7 +23,7 @@ export default class CollapsedCompetenciesComponent extends Component {
       if (!(schoolId in schools)) {
         schools[schoolId] = {
           competencies: [],
-          school: this.allSchools.findBy('id', schoolId),
+          school: findById(this.allSchools, schoolId),
         };
       }
       schools[schoolId].competencies.push(competency);

--- a/addon/components/course-leadership-expanded.js
+++ b/addon/components/course-leadership-expanded.js
@@ -40,9 +40,9 @@ export default class CourseLeadershipExpandedComponent extends Component {
       directors: this.args.course.directors,
       studentAdvisors: this.args.course.studentAdvisors,
     });
-    this.administrators = obj.administrators.toArray();
-    this.directors = obj.directors.toArray();
-    this.studentAdvisors = obj.studentAdvisors.toArray();
+    this.administrators = obj.administrators.slice();
+    this.directors = obj.directors.slice();
+    this.studentAdvisors = obj.studentAdvisors.slice();
     this.args.setIsManaging(true);
   });
 

--- a/addon/components/course-overview.js
+++ b/addon/components/course-overview.js
@@ -4,6 +4,7 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { restartableTask } from 'ember-concurrency';
 import { validatable, Length, BeforeDate, AfterDate } from 'ilios-common/decorators/validation';
+import { findById } from '../utils/array-helpers';
 
 @validatable
 export default class CourseOverview extends Component {
@@ -41,7 +42,7 @@ export default class CourseOverview extends Component {
       return null;
     }
 
-    return this.clerkshipTypeOptions.findBy('id', this.clerkshipTypeId);
+    return findById(this.clerkshipTypeOptions, this.clerkshipTypeId);
   }
 
   get showRollover() {

--- a/addon/components/course-rollover.js
+++ b/addon/components/course-rollover.js
@@ -47,7 +47,7 @@ export default class CourseRolloverComponent extends Component {
         school,
       },
     });
-    this.changeSelectedYear(this.years.firstObject);
+    this.changeSelectedYear(this.years[0]);
   });
 
   @action

--- a/addon/components/course-rollover.js
+++ b/addon/components/course-rollover.js
@@ -5,7 +5,7 @@ import { action } from '@ember/object';
 import { validatable, Length, NotBlank } from 'ilios-common/decorators/validation';
 import { dropTask, restartableTask, timeout } from 'ember-concurrency';
 import { DateTime } from 'luxon';
-import { mapBy } from '../utils/array-helpers';
+import { filterBy, mapBy } from '../utils/array-helpers';
 
 @validatable
 export default class CourseRolloverComponent extends Component {
@@ -101,7 +101,7 @@ export default class CourseRolloverComponent extends Component {
     if (!this.allCourses) {
       return [];
     }
-    const existingCoursesWithTitle = this.allCourses.filterBy('title', this.title.trim());
+    const existingCoursesWithTitle = filterBy(this.allCourses, 'title', this.title.trim());
     return mapBy(existingCoursesWithTitle, 'year');
   }
 

--- a/addon/components/course-rollover.js
+++ b/addon/components/course-rollover.js
@@ -5,6 +5,7 @@ import { action } from '@ember/object';
 import { validatable, Length, NotBlank } from 'ilios-common/decorators/validation';
 import { dropTask, restartableTask, timeout } from 'ember-concurrency';
 import { DateTime } from 'luxon';
+import { mapBy } from '../utils/array-helpers';
 
 @validatable
 export default class CourseRolloverComponent extends Component {
@@ -71,7 +72,7 @@ export default class CourseRolloverComponent extends Component {
     }
     const courseId = this.args.course.id;
 
-    const selectedCohortIds = this.selectedCohorts.mapBy('id');
+    const selectedCohortIds = mapBy(this.selectedCohorts, 'id');
 
     const data = {
       year: this.selectedYear,
@@ -101,7 +102,7 @@ export default class CourseRolloverComponent extends Component {
       return [];
     }
     const existingCoursesWithTitle = this.allCourses.filterBy('title', this.title.trim());
-    return existingCoursesWithTitle.mapBy('year');
+    return mapBy(existingCoursesWithTitle, 'year');
   }
 
   @action

--- a/addon/components/course-sessions.js
+++ b/addon/components/course-sessions.js
@@ -7,6 +7,7 @@ import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from '../classes/resolve-async-value';
 import SessionObject from '../classes/session-object';
 import { getOwner } from '@ember/application';
+import { mapBy } from '../utils/array-helpers';
 
 const DEBOUNCE_DELAY = 250;
 
@@ -95,7 +96,7 @@ export default class CourseSessionsComponent extends Component {
     if (this.expandedSessionIds.length === this.sessionsWithOfferings.length) {
       this.expandedSessionIds = [];
     } else {
-      this.expandedSessionIds = this.sessionsWithOfferings.mapBy('id');
+      this.expandedSessionIds = mapBy(this.sessionsWithOfferings, 'id');
     }
   }
 }

--- a/addon/components/course-visualize-instructor.js
+++ b/addon/components/course-visualize-instructor.js
@@ -35,7 +35,7 @@ export default class CourseVisualizeInstructorComponent extends Component {
       return [];
     }
 
-    const sessionsWithUser = await filter(sessions.toArray(), async (session) => {
+    const sessionsWithUser = await filter(sessions.slice(), async (session) => {
       const instructors = await session.getAllInstructors();
       return mapBy(instructors, 'id').includes(this.args.user.id);
     });

--- a/addon/components/course-visualize-instructor.js
+++ b/addon/components/course-visualize-instructor.js
@@ -4,6 +4,7 @@ import { map, filter } from 'rsvp';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import AsyncProcess from 'ilios-common/classes/async-process';
+import { mapBy } from '../utils/array-helpers';
 
 export default class CourseVisualizeInstructorComponent extends Component {
   @service iliosConfig;
@@ -19,14 +20,14 @@ export default class CourseVisualizeInstructorComponent extends Component {
     if (!this.minutes) {
       return 0;
     }
-    return this.minutes.mapBy('offeringMinutes').reduce((total, mins) => total + mins, 0);
+    return mapBy(this.minutes, 'offeringMinutes').reduce((total, mins) => total + mins, 0);
   }
 
   get totalIlmTime() {
     if (!this.minutes) {
       return 0;
     }
-    return this.minutes.mapBy('ilmMinutes').reduce((total, mins) => total + mins, 0);
+    return mapBy(this.minutes, 'ilmMinutes').reduce((total, mins) => total + mins, 0);
   }
 
   async getMinutes(sessions) {
@@ -36,7 +37,7 @@ export default class CourseVisualizeInstructorComponent extends Component {
 
     const sessionsWithUser = await filter(sessions.toArray(), async (session) => {
       const instructors = await session.getAllInstructors();
-      return instructors.mapBy('id').includes(this.args.user.id);
+      return mapBy(instructors, 'id').includes(this.args.user.id);
     });
 
     return map(sessionsWithUser, async (session) => {

--- a/addon/components/course/collapsed-objectives.js
+++ b/addon/components/course/collapsed-objectives.js
@@ -10,7 +10,7 @@ export default class CourseCollapsedObjectivesComponent extends Component {
   });
 
   get objectives() {
-    return this.objectivesRelationship ? this.objectivesRelationship.toArray() : [];
+    return this.objectivesRelationship ? this.objectivesRelationship.slice() : [];
   }
 
   get objectivesWithParents() {

--- a/addon/components/course/manage-objective-parents.js
+++ b/addon/components/course/manage-objective-parents.js
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import { mapBy, sortByString } from '../../utils/array-helpers';
 
 export default class CourseManageObjectiveParentsComponent extends Component {
   @tracked userSelectedCohort;
@@ -27,10 +28,10 @@ export default class CourseManageObjectiveParentsComponent extends Component {
     const selectedInCohort = this.args.selected.filter(
       (obj) => obj.cohortId === this.selectedCohort.id
     );
-    return selectedInCohort.mapBy('competencyId');
+    return mapBy(selectedInCohort, 'competencyId');
   }
 
   get competenciesFromSelectedCohort() {
-    return this.selectedCohort.competencies.sortBy('title');
+    return sortByString(this.selectedCohort.competencies, 'title');
   }
 }

--- a/addon/components/course/manage-objective-parents.js
+++ b/addon/components/course/manage-objective-parents.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { findById, mapBy, sortByString } from '../../utils/array-helpers';
+import { findById, mapBy, sortBy } from '../../utils/array-helpers';
 
 export default class CourseManageObjectiveParentsComponent extends Component {
   @tracked userSelectedCohort;
@@ -32,6 +32,6 @@ export default class CourseManageObjectiveParentsComponent extends Component {
   }
 
   get competenciesFromSelectedCohort() {
-    return sortByString(this.selectedCohort.competencies, 'title');
+    return sortBy(this.selectedCohort.competencies, 'title');
   }
 }

--- a/addon/components/course/manage-objective-parents.js
+++ b/addon/components/course/manage-objective-parents.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { mapBy, sortByString } from '../../utils/array-helpers';
+import { findById, mapBy, sortByString } from '../../utils/array-helpers';
 
 export default class CourseManageObjectiveParentsComponent extends Component {
   @tracked userSelectedCohort;
@@ -21,7 +21,7 @@ export default class CourseManageObjectiveParentsComponent extends Component {
   @action
   chooseCohort(event) {
     const cohortId = event.target.value;
-    this.userSelectedCohort = this.args.cohortObjectives.findBy('id', cohortId);
+    this.userSelectedCohort = findById(this.args.cohortObjectives, cohortId);
   }
 
   get selectedCompetencyIdsInSelectedCohort() {

--- a/addon/components/course/objective-list-item.js
+++ b/addon/components/course/objective-list-item.js
@@ -4,7 +4,7 @@ import { action } from '@ember/object';
 import { dropTask, restartableTask, timeout } from 'ember-concurrency';
 import { inject as service } from '@ember/service';
 import { validatable, Length, HtmlNotBlank } from 'ilios-common/decorators/validation';
-import { mapBy } from '../../utils/array-helpers';
+import { findById, mapBy } from '../../utils/array-helpers';
 
 @validatable
 export default class CourseObjectiveListItemComponent extends Component {
@@ -49,7 +49,7 @@ export default class CourseObjectiveListItemComponent extends Component {
     }, []);
     const parents = await this.args.courseObjective.programYearObjectives;
     this.parentsBuffer = parents.slice().map((objective) => {
-      return objectives.findBy('id', objective.id);
+      return findById(objectives, objective.id);
     });
     this.isManagingParents = true;
   });

--- a/addon/components/course/objective-list-item.js
+++ b/addon/components/course/objective-list-item.js
@@ -4,6 +4,7 @@ import { action } from '@ember/object';
 import { dropTask, restartableTask, timeout } from 'ember-concurrency';
 import { inject as service } from '@ember/service';
 import { validatable, Length, HtmlNotBlank } from 'ilios-common/decorators/validation';
+import { mapBy } from '../../utils/array-helpers';
 
 @validatable
 export default class CourseObjectiveListItemComponent extends Component {
@@ -43,7 +44,7 @@ export default class CourseObjectiveListItemComponent extends Component {
 
   manageParents = dropTask(async () => {
     const objectives = this.args.cohortObjectives.reduce((set, cohortObject) => {
-      const cohortObjectives = cohortObject.competencies.mapBy('objectives');
+      const cohortObjectives = mapBy(cohortObject.competencies, 'objectives');
       return [...set, ...cohortObjectives.flat()];
     }, []);
     const parents = await this.args.courseObjective.programYearObjectives;
@@ -117,8 +118,8 @@ export default class CourseObjectiveListItemComponent extends Component {
   }
   @action
   removeParentsWithCohortFromBuffer(cohort) {
-    const cohortObjectives = cohort.competencies.mapBy('objectives');
-    const ids = [...cohortObjectives.flat()].mapBy('id');
+    const cohortObjectives = mapBy(cohort.competencies, 'objectives');
+    const ids = mapBy([...cohortObjectives.flat()], 'id');
     this.parentsBuffer = this.parentsBuffer.filter((obj) => {
       return !ids.includes(obj.id);
     });

--- a/addon/components/course/objective-list-item.js
+++ b/addon/components/course/objective-list-item.js
@@ -48,7 +48,7 @@ export default class CourseObjectiveListItemComponent extends Component {
       return [...set, ...cohortObjectives.flat()];
     }, []);
     const parents = await this.args.courseObjective.programYearObjectives;
-    this.parentsBuffer = parents.toArray().map((objective) => {
+    this.parentsBuffer = parents.slice().map((objective) => {
       return objectives.findBy('id', objective.id);
     });
     this.isManagingParents = true;
@@ -56,14 +56,14 @@ export default class CourseObjectiveListItemComponent extends Component {
 
   manageDescriptors = dropTask(async () => {
     const meshDescriptors = await this.args.courseObjective.meshDescriptors;
-    this.descriptorsBuffer = meshDescriptors.toArray();
+    this.descriptorsBuffer = meshDescriptors.slice();
     this.isManagingDescriptors = true;
   });
 
   manageTerms = dropTask(async (vocabulary) => {
     this.selectedVocabulary = vocabulary;
     const terms = await this.args.courseObjective.terms;
-    this.termsBuffer = terms.toArray();
+    this.termsBuffer = terms.slice();
     this.isManagingTerms = true;
   });
 

--- a/addon/components/course/objective-list.js
+++ b/addon/components/course/objective-list.js
@@ -19,7 +19,7 @@ export default class CourseObjectiveListComponent extends Component {
 
   get courseObjectives() {
     if (this.load.lastSuccessful && this.courseObjectivesAsync) {
-      return this.courseObjectivesAsync.toArray().sort(sortableByPosition);
+      return this.courseObjectivesAsync.slice().sort(sortableByPosition);
     }
 
     return undefined;
@@ -29,7 +29,7 @@ export default class CourseObjectiveListComponent extends Component {
 
   get courseCohorts() {
     if (this.load.lastSuccessful && this.courseCohortsAsync) {
-      return this.courseCohortsAsync.toArray();
+      return this.courseCohortsAsync.slice();
     }
 
     return [];
@@ -70,7 +70,7 @@ export default class CourseObjectiveListComponent extends Component {
         'allowMultipleCourseObjectiveParents'
       );
       const objectives = await programYear.programYearObjectives;
-      const objectiveObjects = await map(objectives.toArray(), async (objective) => {
+      const objectiveObjects = await map(objectives.slice(), async (objective) => {
         let competencyId = 0;
         let competencyTitle = intl.t('general.noAssociatedCompetency');
         const competency = await objective.competency;

--- a/addon/components/course/objective-list.js
+++ b/addon/components/course/objective-list.js
@@ -7,6 +7,7 @@ import { use } from 'ember-could-get-used-to-this';
 import AsyncProcess from '../../classes/async-process';
 import ResolveAsyncValue from '../../classes/resolve-async-value';
 import sortableByPosition from 'ilios-common/utils/sortable-by-position';
+import { findById } from '../../utils/array-helpers';
 
 export default class CourseObjectiveListComponent extends Component {
   @service store;
@@ -88,7 +89,7 @@ export default class CourseObjectiveListComponent extends Component {
         };
       });
       const competencies = objectiveObjects.reduce((set, obj) => {
-        let existing = set.findBy('id', obj.competencyId);
+        let existing = findById(set, obj.competencyId);
         if (!existing) {
           existing = {
             id: obj.competencyId,

--- a/addon/components/course/objectives.js
+++ b/addon/components/course/objectives.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { dropTask, restartableTask } from 'ember-concurrency';
 import { action } from '@ember/object';
+import { mapBy } from '../../utils/array-helpers';
 
 export default class CourseObjectivesComponent extends Component {
   @service store;
@@ -33,7 +34,8 @@ export default class CourseObjectivesComponent extends Component {
     let position = 0;
     const courseObjectives = await this.args.course.courseObjectives;
     if (courseObjectives.length) {
-      position = courseObjectives.sortBy('position').lastObject.position + 1;
+      const positions = mapBy(courseObjectives, 'position');
+      position = Math.max(...positions) + 1;
     }
 
     newCourseObjective.set('title', title);

--- a/addon/components/daily-calendar.js
+++ b/addon/components/daily-calendar.js
@@ -3,7 +3,7 @@ import { inject as service } from '@ember/service';
 import moment from 'moment';
 import { restartableTask, timeout } from 'ember-concurrency';
 import { action, set } from '@ember/object';
-import { sortByDate, sortByString } from '../utils/array-helpers';
+import { sortBy } from '../utils/array-helpers';
 
 export default class DailyCalendarComponent extends Component {
   @service intl;
@@ -41,7 +41,7 @@ export default class DailyCalendarComponent extends Component {
       return [];
     }
 
-    return sortByDate(sortByDate(sortByString(this.args.events, 'name'), 'endDate'), 'startDate');
+    return sortBy(this.args.events, ['name', 'endDate', 'startDate']);
   }
 
   get hours() {

--- a/addon/components/daily-calendar.js
+++ b/addon/components/daily-calendar.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import moment from 'moment';
 import { restartableTask, timeout } from 'ember-concurrency';
 import { action, set } from '@ember/object';
+import { sortByDate, sortByString } from '../utils/array-helpers';
 
 export default class DailyCalendarComponent extends Component {
   @service intl;
@@ -40,7 +41,7 @@ export default class DailyCalendarComponent extends Component {
       return [];
     }
 
-    return this.args.events.sortBy('startDate', 'endDate', 'name');
+    return sortByDate(sortByDate(sortByString(this.args.events, 'name'), 'endDate'), 'startDate');
   }
 
   get hours() {

--- a/addon/components/daily-calendar.js
+++ b/addon/components/daily-calendar.js
@@ -41,7 +41,7 @@ export default class DailyCalendarComponent extends Component {
       return [];
     }
 
-    return sortBy(this.args.events, ['name', 'endDate', 'startDate']);
+    return sortBy(this.args.events, ['startDate', 'endDate', 'name']);
   }
 
   get hours() {

--- a/addon/components/dashboard/calendar.js
+++ b/addon/components/dashboard/calendar.js
@@ -5,7 +5,7 @@ import { action } from '@ember/object';
 import { dropTask, restartableTask } from 'ember-concurrency';
 import moment from 'moment';
 import { all, map, hash } from 'rsvp';
-import { mapBy, sortByString } from '../../utils/array-helpers';
+import { mapBy, sortBy } from '../../utils/array-helpers';
 
 export default class DashboardCalendarComponent extends Component {
   @service userEvents;
@@ -114,7 +114,7 @@ export default class DashboardCalendarComponent extends Component {
       };
     });
 
-    return sortByString(cohortProxies, 'displayTitle');
+    return sortBy(cohortProxies, 'displayTitle');
   }
 
   async getSchoolCohorts(school) {
@@ -129,13 +129,13 @@ export default class DashboardCalendarComponent extends Component {
 
   async getSessionTypes(school) {
     const types = await school.sessionTypes;
-    return sortByString(types.slice(), 'title');
+    return sortBy(types.slice(), 'title');
   }
 
   async getVocabularies(school) {
     const vocabularies = await school.vocabularies;
     await all(mapBy(vocabularies, 'terms'));
-    return sortByString(vocabularies.slice(), 'title');
+    return sortBy(vocabularies.slice(), 'title');
   }
 
   get filteredEvents() {

--- a/addon/components/dashboard/calendar.js
+++ b/addon/components/dashboard/calendar.js
@@ -5,6 +5,7 @@ import { action } from '@ember/object';
 import { dropTask, restartableTask } from 'ember-concurrency';
 import moment from 'moment';
 import { all, map, hash } from 'rsvp';
+import { mapBy, sortByString } from '../../utils/array-helpers';
 
 export default class DashboardCalendarComponent extends Component {
   @service userEvents;
@@ -113,7 +114,7 @@ export default class DashboardCalendarComponent extends Component {
       };
     });
 
-    return cohortProxies.sortBy('displayTitle');
+    return sortByString(cohortProxies, 'displayTitle');
   }
 
   async getSchoolCohorts(school) {
@@ -122,19 +123,19 @@ export default class DashboardCalendarComponent extends Component {
       const programYears = await program.programYears;
       return programYears.toArray();
     });
-    const cohorts = await all(programYears.flat().mapBy('cohort'));
+    const cohorts = await all(mapBy(programYears.flat(), 'cohort'));
     return cohorts.filter(Boolean);
   }
 
   async getSessionTypes(school) {
     const types = await school.sessionTypes;
-    return types.toArray().sortBy('title');
+    return sortByString(types.slice(), 'title');
   }
 
   async getVocabularies(school) {
     const vocabularies = await school.vocabularies;
-    await all(vocabularies.mapBy('terms'));
-    return vocabularies.toArray().sortBy('title');
+    await all(mapBy(vocabularies, 'terms'));
+    return sortByString(vocabularies.slice(), 'title');
   }
 
   get filteredEvents() {
@@ -215,7 +216,7 @@ export default class DashboardCalendarComponent extends Component {
     }
     const selectedIds = this.args.selectedTermIds.map(Number);
     return this.ourEvents.filter((event) => {
-      const allTerms = [].concat(event.sessionTerms || [], event.courseTerms || []).mapBy('id');
+      const allTerms = mapBy([].concat(event.sessionTerms || [], event.courseTerms || []), 'id');
       const matchingTerms = allTerms.filter((id) => selectedIds.includes(id));
       return matchingTerms.length > 0;
     });

--- a/addon/components/dashboard/calendar.js
+++ b/addon/components/dashboard/calendar.js
@@ -119,9 +119,9 @@ export default class DashboardCalendarComponent extends Component {
 
   async getSchoolCohorts(school) {
     const programs = await school.programs;
-    const programYears = await map(programs.toArray(), async (program) => {
+    const programYears = await map(programs.slice(), async (program) => {
       const programYears = await program.programYears;
-      return programYears.toArray();
+      return programYears.slice();
     });
     const cohorts = await all(mapBy(programYears.flat(), 'cohort'));
     return cohorts.filter(Boolean);

--- a/addon/components/dashboard/courses-calendar-filter.js
+++ b/addon/components/dashboard/courses-calendar-filter.js
@@ -41,7 +41,7 @@ export default class DashboardCoursesCalendarFilterComponent extends Component {
   }
 
   get courses() {
-    return this.coursesRelationship ? this.coursesRelationship.toArray() : [];
+    return this.coursesRelationship ? this.coursesRelationship.slice() : [];
   }
 
   get courseYears() {

--- a/addon/components/dashboard/courses-calendar-filter.js
+++ b/addon/components/dashboard/courses-calendar-filter.js
@@ -4,7 +4,7 @@ import { restartableTask } from 'ember-concurrency';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import moment from 'moment';
-import { findBy } from '../../utils/array-helpers';
+import { findBy, sortBy } from '../../utils/array-helpers';
 
 export default class DashboardCoursesCalendarFilterComponent extends Component {
   @service dataLoader;
@@ -46,25 +46,25 @@ export default class DashboardCoursesCalendarFilterComponent extends Component {
   }
 
   get courseYears() {
-    return this.courses
-      .reduce((acc, course) => {
-        let year = acc.find(({ year }) => year === course.year);
-        const label = this.academicYearCrossesCalendarYearBoundaries
-          ? `${course.year} - ${course.year + 1}`
-          : course.year.toString();
-        if (!year) {
-          year = {
-            label,
-            year: course.year,
-            courses: [],
-          };
-          acc.push(year);
-        }
-        year.courses.push(course);
+    const courseYears = this.courses.reduce((acc, course) => {
+      let year = acc.find(({ year }) => year === course.year);
+      const label = this.academicYearCrossesCalendarYearBoundaries
+        ? `${course.year} - ${course.year + 1}`
+        : course.year.toString();
+      if (!year) {
+        year = {
+          label,
+          year: course.year,
+          courses: [],
+        };
+        acc.push(year);
+      }
+      year.courses.push(course);
 
-        return acc;
-      }, [])
-      .sortBy('year');
+      return acc;
+    }, []);
+
+    return sortBy(courseYears, 'year');
   }
 
   get expandedYears() {

--- a/addon/components/dashboard/courses-calendar-filter.js
+++ b/addon/components/dashboard/courses-calendar-filter.js
@@ -4,6 +4,7 @@ import { restartableTask } from 'ember-concurrency';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import moment from 'moment';
+import { findBy } from '../../utils/array-helpers';
 
 export default class DashboardCoursesCalendarFilterComponent extends Component {
   @service dataLoader;
@@ -71,7 +72,7 @@ export default class DashboardCoursesCalendarFilterComponent extends Component {
       return this._expandedYears;
     }
     if (this.courseYears.length) {
-      const coursesThisYear = this.courseYears.findBy('year', this.academicYear);
+      const coursesThisYear = findBy(this.courseYears, 'year', this.academicYear);
       if (coursesThisYear) {
         return [this.academicYear];
       } else {

--- a/addon/components/dashboard/filter-tags.js
+++ b/addon/components/dashboard/filter-tags.js
@@ -3,6 +3,7 @@ import { restartableTask } from 'ember-concurrency';
 import { all, map } from 'rsvp';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
+import { findById } from '../../utils/array-helpers';
 
 export default class DashboardFilterTagsComponent extends Component {
   @service store;
@@ -58,7 +59,7 @@ export default class DashboardFilterTagsComponent extends Component {
   }
   getCohortTags() {
     return this.args.selectedCohortIds.map((id) => {
-      const proxy = this.args.cohortProxies.findBy('id', id);
+      const proxy = findById(this.args.cohortProxies, id);
       return {
         id,
         class: 'tag-cohort',

--- a/addon/components/dashboard/materials.js
+++ b/addon/components/dashboard/materials.js
@@ -8,7 +8,7 @@ import { use } from 'ember-could-get-used-to-this';
 import AsyncProcess from 'ilios-common/classes/async-process';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import moment from 'moment';
-import { filterBy, sortBy, uniqueValues } from '../../utils/array-helpers';
+import { filterBy, sortBy, uniqueById } from '../../utils/array-helpers';
 
 const DEBOUNCE_DELAY = 250;
 
@@ -140,7 +140,7 @@ export default class DashboardMaterialsComponent extends Component {
       };
     });
 
-    return sortBy(uniqueValues(arr), ['year', 'title']);
+    return sortBy(uniqueById(arr), ['year', 'title']);
   }
 
   get sortedAscending() {

--- a/addon/components/dashboard/materials.js
+++ b/addon/components/dashboard/materials.js
@@ -8,7 +8,7 @@ import { use } from 'ember-could-get-used-to-this';
 import AsyncProcess from 'ilios-common/classes/async-process';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import moment from 'moment';
-import { filterBy, sortBy, uniqueById } from '../../utils/array-helpers';
+import { filterBy, sortBy, uniqueValues } from '../../utils/array-helpers';
 
 const DEBOUNCE_DELAY = 250;
 
@@ -140,7 +140,7 @@ export default class DashboardMaterialsComponent extends Component {
       };
     });
 
-    return sortBy(uniqueById(arr), ['year', 'title']);
+    return sortBy(uniqueValues(arr), ['year', 'title']);
   }
 
   get sortedAscending() {

--- a/addon/components/dashboard/materials.js
+++ b/addon/components/dashboard/materials.js
@@ -8,7 +8,7 @@ import { use } from 'ember-could-get-used-to-this';
 import AsyncProcess from 'ilios-common/classes/async-process';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import moment from 'moment';
-import { filterBy } from '../../utils/array-helpers';
+import { filterBy, sortBy, uniqueById } from '../../utils/array-helpers';
 
 const DEBOUNCE_DELAY = 250;
 
@@ -101,7 +101,7 @@ export default class DashboardMaterialsComponent extends Component {
       });
     }
 
-    const sortedMaterials = materials.sortBy(this.sortInfo.column);
+    const sortedMaterials = sortBy(materials, this.sortInfo.column);
     if (this.sortInfo.descending) {
       return sortedMaterials.reverse();
     }
@@ -131,17 +131,16 @@ export default class DashboardMaterialsComponent extends Component {
     if (!this.materials) {
       return [];
     }
-    return this.materials
-      .map((material) => {
-        return {
-          id: material.course,
-          title: material.courseTitle,
-          externalId: material.courseExternalId,
-          year: material.courseYear,
-        };
-      })
-      .uniqBy('id')
-      .sortBy('year', 'title');
+    const arr = this.materials.map((material) => {
+      return {
+        id: material.course,
+        title: material.courseTitle,
+        externalId: material.courseExternalId,
+        year: material.courseYear,
+      };
+    });
+
+    return sortBy(uniqueById(arr), ['year', 'title']);
   }
 
   get sortedAscending() {

--- a/addon/components/dashboard/materials.js
+++ b/addon/components/dashboard/materials.js
@@ -8,6 +8,7 @@ import { use } from 'ember-could-get-used-to-this';
 import AsyncProcess from 'ilios-common/classes/async-process';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import moment from 'moment';
+import { filterBy } from '../../utils/array-helpers';
 
 const DEBOUNCE_DELAY = 250;
 
@@ -80,7 +81,7 @@ export default class DashboardMaterialsComponent extends Component {
 
   get materialsFilteredByCourse() {
     if (isPresent(this.args.courseIdFilter)) {
-      return this.materials.filterBy('course', this.args.courseIdFilter);
+      return filterBy(this.materials, 'course', this.args.courseIdFilter);
     }
     return this.materials;
   }

--- a/addon/components/detail-cohort-list.js
+++ b/addon/components/detail-cohort-list.js
@@ -14,7 +14,7 @@ export default class DetailCohortListComponent extends Component {
       return false;
     }
 
-    const sortProxies = await map(cohorts.toArray(), async (cohort) => {
+    const sortProxies = await map(cohorts.slice(), async (cohort) => {
       const programYear = await cohort.programYear;
       const program = await programYear.program;
       const school = await program.school;

--- a/addon/components/detail-cohort-list.js
+++ b/addon/components/detail-cohort-list.js
@@ -3,7 +3,7 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { restartableTask } from 'ember-concurrency';
 import { map } from 'rsvp';
-import { mapBy, sortByString } from '../utils/array-helpers';
+import { mapBy, sortBy } from '../utils/array-helpers';
 
 export default class DetailCohortListComponent extends Component {
   @service intl;
@@ -32,9 +32,6 @@ export default class DetailCohortListComponent extends Component {
       };
     });
 
-    this.sortedCohorts = mapBy(
-      sortByString(sortByString(sortProxies, 'schoolTitle'), 'displayTitle'),
-      'cohort'
-    );
+    this.sortedCohorts = mapBy(sortBy(sortProxies, ['schoolTitle', 'displayTitle']), 'cohort');
   });
 }

--- a/addon/components/detail-cohort-list.js
+++ b/addon/components/detail-cohort-list.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { restartableTask } from 'ember-concurrency';
 import { map } from 'rsvp';
+import { mapBy, sortByString } from '../utils/array-helpers';
 
 export default class DetailCohortListComponent extends Component {
   @service intl;
@@ -31,6 +32,9 @@ export default class DetailCohortListComponent extends Component {
       };
     });
 
-    this.sortedCohorts = sortProxies.sortBy('schoolTitle', 'displayTitle').mapBy('cohort');
+    this.sortedCohorts = mapBy(
+      sortByString(sortByString(sortProxies, 'schoolTitle'), 'displayTitle'),
+      'cohort'
+    );
   });
 }

--- a/addon/components/detail-cohort-manager.js
+++ b/addon/components/detail-cohort-manager.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { restartableTask } from 'ember-concurrency';
 import { map, filter } from 'rsvp';
+import { mapBy } from '../utils/array-helpers';
 
 export default class DetailCohortManagerComponent extends Component {
   @service intl;
@@ -79,6 +80,6 @@ export default class DetailCohortManagerComponent extends Component {
       return compare;
     });
 
-    return objects.mapBy('cohort');
+    return mapBy(objects, 'cohort');
   }
 }

--- a/addon/components/detail-cohort-manager.js
+++ b/addon/components/detail-cohort-manager.js
@@ -18,7 +18,7 @@ export default class DetailCohortManagerComponent extends Component {
       return false;
     }
     const allCohorts = await this.store.findAll('cohort');
-    const cohortProxies = await map(allCohorts.toArray(), async (cohort) => {
+    const cohortProxies = await map(allCohorts.slice(), async (cohort) => {
       const programYear = await cohort.programYear;
       const program = await programYear.program;
       const school = await program.school;

--- a/addon/components/detail-cohorts.js
+++ b/addon/components/detail-cohorts.js
@@ -10,7 +10,7 @@ export default class DetailCohortsComponent extends Component {
 
   manage = dropTask(async () => {
     const cohorts = await this.args.course.cohorts;
-    this.bufferedCohorts = [...cohorts.toArray()];
+    this.bufferedCohorts = [...cohorts.slice()];
     this.isManaging = true;
   });
 

--- a/addon/components/detail-cohorts.js
+++ b/addon/components/detail-cohorts.js
@@ -23,7 +23,9 @@ export default class DetailCohortsComponent extends Component {
     if (removedCohorts.length) {
       const programYearsToRemove = await map(removedCohorts, async (cohort) => cohort.programYear);
       const objectives = await course.courseObjectives;
-      await all(objectives.invoke('removeParentWithProgramYears', programYearsToRemove));
+      await all(
+        objectives.map((objective) => objective.removeParentWithProgramYears(programYearsToRemove))
+      );
     }
     course.set('cohorts', this.bufferedCohorts);
     await course.save();

--- a/addon/components/detail-instructors.js
+++ b/addon/components/detail-instructors.js
@@ -30,8 +30,8 @@ export default class DetailInstructorsComponent extends Component {
       instructors: ilmSession.instructors,
     });
 
-    this.instructorGroupBuffer = instructorGroups.toArray();
-    this.instructorBuffer = instructors.toArray();
+    this.instructorGroupBuffer = instructorGroups.slice();
+    this.instructorBuffer = instructors.slice();
     this.isManaging = true;
   });
 

--- a/addon/components/detail-learnergroups-list.js
+++ b/addon/components/detail-learnergroups-list.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { filter, map } from 'rsvp';
 import { use } from 'ember-could-get-used-to-this';
 import AsyncProcess from 'ilios-common/classes/async-process';
-import { mapBy } from '../utils/array-helpers';
+import { mapBy, uniqueById } from '../utils/array-helpers';
 
 export default class DetailLearnerGroupsListComponent extends Component {
   @use cohortTrees = new AsyncProcess(() => [this.loadCohorts.bind(this)]);
@@ -22,11 +22,11 @@ export default class DetailLearnerGroupsListComponent extends Component {
     if (!this.args.learnerGroups) {
       return [];
     }
-    const cohorts = (
+    const cohorts = uniqueById(
       await map(this.args.learnerGroups.slice(), async (learnerGroup) => {
         return learnerGroup.cohort;
       })
-    ).uniq();
+    );
     return map(cohorts, async (cohort) => {
       const groups = await filter(this.args.learnerGroups.slice(), async (group) => {
         const groupCohort = await group.cohort;

--- a/addon/components/detail-learnergroups-list.js
+++ b/addon/components/detail-learnergroups-list.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { filter, map } from 'rsvp';
 import { use } from 'ember-could-get-used-to-this';
 import AsyncProcess from 'ilios-common/classes/async-process';
+import { mapBy } from '../utils/array-helpers';
 
 export default class DetailLearnerGroupsListComponent extends Component {
   @use cohortTrees = new AsyncProcess(() => [this.loadCohorts.bind(this)]);
@@ -21,14 +22,13 @@ export default class DetailLearnerGroupsListComponent extends Component {
     if (!this.args.learnerGroups) {
       return [];
     }
-    const learnerGroups = this.args.learnerGroups.toArray();
     const cohorts = (
-      await map(learnerGroups, async (learnerGroup) => {
+      await map(this.args.learnerGroups.slice(), async (learnerGroup) => {
         return learnerGroup.cohort;
       })
     ).uniq();
     return map(cohorts, async (cohort) => {
-      const groups = await filter(learnerGroups, async (group) => {
+      const groups = await filter(this.args.learnerGroups.slice(), async (group) => {
         const groupCohort = await group.cohort;
         return groupCohort === cohort;
       });
@@ -46,7 +46,7 @@ export default class DetailLearnerGroupsListComponent extends Component {
 
       return {
         cohort,
-        groups: sortedProxies.mapBy('group'),
+        groups: mapBy(sortedProxies, 'group'),
       };
     });
   }

--- a/addon/components/detail-learnergroups-list.js
+++ b/addon/components/detail-learnergroups-list.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { filter, map } from 'rsvp';
 import { use } from 'ember-could-get-used-to-this';
 import AsyncProcess from 'ilios-common/classes/async-process';
-import { mapBy, uniqueById } from '../utils/array-helpers';
+import { mapBy, uniqueValues } from '../utils/array-helpers';
 
 export default class DetailLearnerGroupsListComponent extends Component {
   @use cohortTrees = new AsyncProcess(() => [this.loadCohorts.bind(this)]);
@@ -22,7 +22,7 @@ export default class DetailLearnerGroupsListComponent extends Component {
     if (!this.args.learnerGroups) {
       return [];
     }
-    const cohorts = uniqueById(
+    const cohorts = uniqueValues(
       await map(this.args.learnerGroups.slice(), async (learnerGroup) => {
         return learnerGroup.cohort;
       })

--- a/addon/components/detail-learners-and-learner-groups.js
+++ b/addon/components/detail-learners-and-learner-groups.js
@@ -4,6 +4,7 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { dropTask } from 'ember-concurrency';
 import { hash } from 'rsvp';
+import { uniqueValues } from '../utils/array-helpers';
 
 export default class DetailLearnersAndLearnerGroupsComponent extends Component {
   @service currentUser;
@@ -55,9 +56,13 @@ export default class DetailLearnersAndLearnerGroupsComponent extends Component {
   async addLearnerGroupToBuffer(learnerGroup, cascade) {
     if (cascade) {
       const descendants = await learnerGroup.getAllDescendants();
-      this.learnerGroupBuffer = [...this.learnerGroupBuffer, ...descendants, learnerGroup].uniq();
+      this.learnerGroupBuffer = uniqueValues([
+        ...this.learnerGroupBuffer,
+        ...descendants,
+        learnerGroup,
+      ]);
     } else {
-      this.learnerGroupBuffer = [...this.learnerGroupBuffer, learnerGroup].uniq();
+      this.learnerGroupBuffer = uniqueValues([...this.learnerGroupBuffer, learnerGroup]);
     }
   }
 
@@ -68,9 +73,9 @@ export default class DetailLearnersAndLearnerGroupsComponent extends Component {
       const descendants = await learnerGroup.getAllDescendants();
       groupsToRemove = [...descendants, learnerGroup];
     }
-    this.learnerGroupBuffer = this.learnerGroupBuffer
-      .filter((g) => !groupsToRemove.includes(g))
-      .uniq();
+    this.learnerGroupBuffer = uniqueValues(
+      this.learnerGroupBuffer.filter((g) => !groupsToRemove.includes(g))
+    );
   }
 
   @action

--- a/addon/components/detail-learners-and-learner-groups.js
+++ b/addon/components/detail-learners-and-learner-groups.js
@@ -18,8 +18,8 @@ export default class DetailLearnersAndLearnerGroupsComponent extends Component {
       learners: ilmSession.learners,
     });
 
-    this.learnerGroupBuffer = learnerGroups.toArray();
-    this.learnerBuffer = learners.toArray();
+    this.learnerGroupBuffer = learnerGroups.slice();
+    this.learnerBuffer = learners.slice();
     this.isManaging = true;
   });
 

--- a/addon/components/detail-learning-materials.js
+++ b/addon/components/detail-learning-materials.js
@@ -179,7 +179,7 @@ export default class DetailCohortsComponent extends Component {
 
   async saveSomeMaterials(arr) {
     const chunk = arr.splice(0, 5);
-    const savedMaterials = await all(chunk.invoke('save'));
+    const savedMaterials = await all(chunk.map((o) => o.save()));
     let moreMaterials = [];
     if (arr.length) {
       moreMaterials = await this.saveSomeMaterials(arr);

--- a/addon/components/detail-learning-materials.js
+++ b/addon/components/detail-learning-materials.js
@@ -7,6 +7,7 @@ import { all } from 'rsvp';
 import ObjectProxy from '@ember/object/proxy';
 import sortableByPosition from 'ilios-common/utils/sortable-by-position';
 import scrollIntoView from 'scroll-into-view';
+import { mapBy } from '../utils/array-helpers';
 
 export default class DetailCohortsComponent extends Component {
   @service currentUser;
@@ -104,7 +105,8 @@ export default class DetailCohortsComponent extends Component {
     let lmSubject;
     let position = 0;
     if (this.materials && this.materials.length) {
-      position = this.materials.sortBy('position').reverse()[0].get('position') + 1;
+      const positions = mapBy(this.materials, 'position');
+      position = Math.max(...positions) + 1;
     }
     if (this.args.isCourse) {
       lmSubject = this.store.createRecord('course-learning-material', {
@@ -162,7 +164,8 @@ export default class DetailCohortsComponent extends Component {
     }
     let position = 0;
     if (this.materials && this.materials.length > 1) {
-      position = this.materials.sortBy('position').reverse()[0].get('position') + 1;
+      const positions = mapBy(this.materials, 'position');
+      position = Math.max(...positions) + 1;
     }
     newLearningMaterial.set('position', position);
     await newLearningMaterial.save();

--- a/addon/components/detail-learning-materials.js
+++ b/addon/components/detail-learning-materials.js
@@ -39,7 +39,7 @@ export default class DetailCohortsComponent extends Component {
       return [];
     }
 
-    return this.materialsRelationship.toArray();
+    return this.materialsRelationship.slice();
   }
 
   get parentMaterialIds() {

--- a/addon/components/detail-mesh.hbs
+++ b/addon/components/detail-mesh.hbs
@@ -53,7 +53,7 @@
                     ({{t "general.deprecatedAbbreviation"}})
                   </span>
                 {{else if term.trees}}
-                  - {{term.trees.lastObject.treeNumber}}
+                  - {{get (object-at 0 (reverse term.trees)) "treeNumber"}}
                 {{/if}}
               </span>
             </li>

--- a/addon/components/detail-mesh.js
+++ b/addon/components/detail-mesh.js
@@ -21,7 +21,7 @@ export default class DetailMeshComponent extends Component {
       return [];
     }
 
-    return this.meshDescriptorRelationship.toArray();
+    return this.meshDescriptorRelationship.slice();
   }
   @action
   manage() {

--- a/addon/components/detail-taxonomies.js
+++ b/addon/components/detail-taxonomies.js
@@ -20,7 +20,7 @@ export default class DetailTaxonomiesComponent extends Component {
   manage = dropTask(async () => {
     this.args.expand();
     const terms = await this.args.subject.terms;
-    this.bufferedTerms = [...terms.toArray()];
+    this.bufferedTerms = [...terms.slice()];
     this.isManaging = true;
   });
 

--- a/addon/components/detail-terms-list.js
+++ b/addon/components/detail-terms-list.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { dropTask } from 'ember-concurrency';
 import { all } from 'rsvp';
+import { mapBy } from '../utils/array-helpers';
 
 export default class DetailTermsListComponent extends Component {
   @tracked sortedTerms;
@@ -27,6 +28,6 @@ export default class DetailTermsListComponent extends Component {
       return titleA > titleB ? 1 : titleA < titleB ? -1 : 0;
     });
 
-    this.sortedTerms = sortedProxies.mapBy('term');
+    this.sortedTerms = mapBy(sortedProxies, 'term');
   });
 }

--- a/addon/components/ilios-calendar-day.js
+++ b/addon/components/ilios-calendar-day.js
@@ -17,7 +17,7 @@ export default class IliosCalendarDayComponent extends Component {
   get ilmPreWorkEvents() {
     const preWork = this.args.calendarEvents.reduce((arr, ev) => {
       if (!ev.isBlanked && ev.isPublished && !ev.isScheduled) {
-        arr.pushObjects(ev.prerequisites);
+        arr.push(ev.prerequisites);
       }
       return arr;
     }, []);

--- a/addon/components/ilios-calendar-day.js
+++ b/addon/components/ilios-calendar-day.js
@@ -17,7 +17,7 @@ export default class IliosCalendarDayComponent extends Component {
   get ilmPreWorkEvents() {
     const preWork = this.args.calendarEvents.reduce((arr, ev) => {
       if (!ev.isBlanked && ev.isPublished && !ev.isScheduled) {
-        arr.push(ev.prerequisites);
+        arr = [...arr, ...ev.prerequisites];
       }
       return arr;
     }, []);

--- a/addon/components/ilios-calendar-month.js
+++ b/addon/components/ilios-calendar-month.js
@@ -6,7 +6,7 @@ export default class IliosCalendarMonthComponent extends Component {
   get ilmPreWorkEvents() {
     const preWork = this.args.calendarEvents.reduce((arr, ev) => {
       if (!ev.isBlanked && ev.isPublished && !ev.isScheduled) {
-        arr.pushObjects(ev.prerequisites);
+        arr.push(ev.prerequisites);
       }
       return arr;
     }, []);

--- a/addon/components/ilios-calendar-month.js
+++ b/addon/components/ilios-calendar-month.js
@@ -6,7 +6,7 @@ export default class IliosCalendarMonthComponent extends Component {
   get ilmPreWorkEvents() {
     const preWork = this.args.calendarEvents.reduce((arr, ev) => {
       if (!ev.isBlanked && ev.isPublished && !ev.isScheduled) {
-        arr.push(ev.prerequisites);
+        arr = [...arr, ...ev.prerequisites];
       }
       return arr;
     }, []);

--- a/addon/components/ilios-calendar-week.js
+++ b/addon/components/ilios-calendar-week.js
@@ -9,7 +9,7 @@ export default class IliosCalendarWeekComponent extends Component {
   get ilmPreWorkEvents() {
     const preWork = this.args.calendarEvents.reduce((arr, ev) => {
       if (!ev.isBlanked && ev.isPublished && !ev.isScheduled) {
-        arr.pushObjects(ev.prerequisites);
+        arr.push(ev.prerequisites);
       }
       return arr;
     }, []);

--- a/addon/components/ilios-calendar-week.js
+++ b/addon/components/ilios-calendar-week.js
@@ -9,7 +9,7 @@ export default class IliosCalendarWeekComponent extends Component {
   get ilmPreWorkEvents() {
     const preWork = this.args.calendarEvents.reduce((arr, ev) => {
       if (!ev.isBlanked && ev.isPublished && !ev.isScheduled) {
-        arr.push(ev.prerequisites);
+        arr = [...arr, ...ev.prerequisites];
       }
       return arr;
     }, []);

--- a/addon/components/ilios-calendar.js
+++ b/addon/components/ilios-calendar.js
@@ -32,7 +32,7 @@ export default class IliosCalendarComponent extends Component {
           hashedEvents[hash] = [];
         }
         //clone our event so we don't trample on the original when we change location
-        hashedEvents[hash].pushObject(Object.assign({}, event));
+        hashedEvents[hash].push(Object.assign({}, event));
       });
       const compiledEvents = [];
       let hash;
@@ -42,7 +42,7 @@ export default class IliosCalendarComponent extends Component {
         if (arr.length > 1) {
           event.isMulti = true;
         }
-        compiledEvents.pushObject(event);
+        compiledEvents.push(event);
       }
       return compiledEvents;
     }

--- a/addon/components/leadership-search.js
+++ b/addon/components/leadership-search.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import { dropTask, restartableTask, timeout } from 'ember-concurrency';
 import { cleanQuery } from 'ilios-common/utils/query-utils';
 import { tracked } from '@glimmer/tracking';
+import { mapBy } from '../utils/array-helpers';
 
 const DEBOUNCE_MS = 250;
 const MIN_INPUT = 3;
@@ -13,7 +14,7 @@ export default class LeadershipSearchComponent extends Component {
   @tracked searchValue = null;
 
   get existingUserIds() {
-    return this.args.existingUsers.mapBy('id');
+    return mapBy(this.args.existingUsers, 'id');
   }
 
   searchForUsers = restartableTask(async (query) => {

--- a/addon/components/leadership-search.js
+++ b/addon/components/leadership-search.js
@@ -56,17 +56,14 @@ export default class LeadershipSearchComponent extends Component {
         user,
       };
     });
-    const results = [
-      {
-        type: 'summary',
-        text: this.intl.t('general.resultsCount', {
-          count: mappedResults.length,
-        }),
-      },
-    ];
-    results.push(...mappedResults);
+    const result = {
+      type: 'summary',
+      text: this.intl.t('general.resultsCount', {
+        count: mappedResults.length,
+      }),
+    };
 
-    return results;
+    return [result, ...mappedResults];
   });
 
   clickUser = dropTask(async (user) => {

--- a/addon/components/leadership-search.js
+++ b/addon/components/leadership-search.js
@@ -64,7 +64,7 @@ export default class LeadershipSearchComponent extends Component {
         }),
       },
     ];
-    results.pushObjects(mappedResults);
+    results.push(mappedResults);
 
     return results;
   });

--- a/addon/components/leadership-search.js
+++ b/addon/components/leadership-search.js
@@ -64,7 +64,7 @@ export default class LeadershipSearchComponent extends Component {
         }),
       },
     ];
-    results.push(mappedResults);
+    results.push(...mappedResults);
 
     return results;
   });

--- a/addon/components/learnergroup-tree.js
+++ b/addon/components/learnergroup-tree.js
@@ -42,13 +42,13 @@ export default class LearnergroupTree extends Component {
    * Recursively search a group tree to see if there are any children which have not been selected.
    **/
   async getHasUnSelectedChildren(children, selectedGroups) {
-    const arr = children?.toArray() ?? [];
+    const arr = children?.slice() ?? [];
     const unselectedChildren = await filter(arr, async (child) => {
       if (!selectedGroups.includes(child)) {
         return true;
       }
       const childChildren = await child.children;
-      return this.getHasUnSelectedChildren(childChildren.toArray(), selectedGroups);
+      return this.getHasUnSelectedChildren(childChildren.slice(), selectedGroups);
     });
     return unselectedChildren.length > 0;
   }

--- a/addon/components/learning-material-uploader.js
+++ b/addon/components/learning-material-uploader.js
@@ -23,7 +23,7 @@ export default class LearningMaterialUploaderComponent extends Component {
         maxSize,
       });
       const queue = this.fileQueue.find(this.uploadQueueName);
-      queue.files.removeObject(file);
+      queue.files.splice(queue.files.indexOf(file), 1);
       return false;
     }
     const response = await file.upload(`${this.fetch.host}/upload`, {

--- a/addon/components/learning-materials-sort-manager.js
+++ b/addon/components/learning-materials-sort-manager.js
@@ -15,7 +15,7 @@ export default class LearningMaterialsSortManagerComponent extends Component {
 
   @use learningMaterials = new ResolveAsyncValue(() => [this.args.subject.learningMaterials]);
   get sortedLearningMaterials() {
-    return this.learningMaterials?.toArray().sort(sortableByPosition) ?? [];
+    return this.learningMaterials?.slice().sort(sortableByPosition) ?? [];
   }
 
   get items() {

--- a/addon/components/learningmaterial-manager.js
+++ b/addon/components/learningmaterial-manager.js
@@ -135,7 +135,7 @@ export default class LearningMaterialManagerComponent extends Component {
     this.endDate = learningMaterial.endDate;
 
     const meshDescriptors = await learningMaterial.get('meshDescriptors');
-    this.terms = meshDescriptors.toArray();
+    this.terms = meshDescriptors.slice();
 
     this.parentMaterial = parentMaterial;
     this.type = parentMaterial.type;

--- a/addon/components/learningmaterial-manager.js
+++ b/addon/components/learningmaterial-manager.js
@@ -5,6 +5,7 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { DateTime } from 'luxon';
 import { validatable, Length, AfterDate, NotBlank } from 'ilios-common/decorators/validation';
+import { findById } from '../utils/array-helpers';
 
 @validatable
 export default class LearningMaterialManagerComponent extends Component {
@@ -121,7 +122,7 @@ export default class LearningMaterialManagerComponent extends Component {
   }
 
   get currentStatus() {
-    return this.args.learningMaterialStatuses.findBy('id', this.statusId);
+    return findById(this.args.learningMaterialStatuses, this.statusId);
   }
 
   load = restartableTask(async (element, [learningMaterial, parentMaterial]) => {

--- a/addon/components/learningmaterial-search.js
+++ b/addon/components/learningmaterial-search.js
@@ -31,7 +31,7 @@ export default class LearningMaterialSearchComponent extends Component {
       'order_by[title]': 'ASC',
     });
 
-    const lms = results.toArray();
+    const lms = results.slice();
     this.searchReturned = true;
     this.searching = false;
     this.searchPage = 1;
@@ -59,7 +59,7 @@ export default class LearningMaterialSearchComponent extends Component {
       offset: this.searchPage * this.searchResultsPerPage,
       'order_by[title]': 'ASC',
     });
-    const lms = results.toArray();
+    const lms = results.slice();
     this.searchPage = this.searchPage + 1;
     this.hasMoreSearchResults = lms.length > this.searchResultsPerPage;
     if (this.hasMoreSearchResults) {

--- a/addon/components/mesh-manager.hbs
+++ b/addon/components/mesh-manager.hbs
@@ -24,7 +24,7 @@
                 {{#if term.deleted}}
                   - <span class="deprecated">({{t "general.deprecatedAbbreviation"}})</span>
                 {{else if term.trees}}
-                  - {{term.trees.lastObject.treeNumber}}
+                  - {{get (object-at 0 (reverse term.trees)) "treeNumber"}}
                 {{/if}}
               </span>
               <FaIcon @icon="xmark" class="remove" />
@@ -38,7 +38,7 @@
               {{#if term.deleted}}
                 - <span class="deprecated">({{t "general.deprecatedAbbreviation"}})</span>
               {{else if term.trees}}
-                - {{term.trees.lastObject.treeNumber}}
+                - {{get (object-at 0 (reverse term.trees)) "treeNumber"}}
               {{/if}}
             </span>
           {{/if}}
@@ -91,7 +91,7 @@
                 <span class="descriptor-id">
                   {{term.id}}
                   {{#if term.trees}}
-                    -{{term.trees.lastObject.treeNumber}}
+                    - {{get (object-at 0 (reverse term.trees)) "treeNumber"}}
                   {{/if}}
                 </span>
                 <ul class="mesh-concepts">

--- a/addon/components/mesh-manager.js
+++ b/addon/components/mesh-manager.js
@@ -83,7 +83,7 @@ export default class MeshManagerComponent extends Component {
         q: this.query,
         limit: SEARCH_RESULTS_PER_PAGE + 1,
       })
-    ).toArray();
+    ).slice();
 
     this.searchPage = 1;
     this.hasMoreSearchResults = descriptors.length > SEARCH_RESULTS_PER_PAGE;
@@ -100,7 +100,7 @@ export default class MeshManagerComponent extends Component {
         limit: SEARCH_RESULTS_PER_PAGE + 1,
         offset: this.searchPage * SEARCH_RESULTS_PER_PAGE,
       })
-    ).toArray();
+    ).slice();
     this.searchPage = this.searchPage + 1;
     this.hasMoreSearchResults = descriptors.length > SEARCH_RESULTS_PER_PAGE;
     if (this.hasMoreSearchResults) {

--- a/addon/components/mesh-manager.js
+++ b/addon/components/mesh-manager.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { dropTask, restartableTask, timeout } from 'ember-concurrency';
 import { action } from '@ember/object';
+import { mapBy, sortByString } from '../utils/array-helpers';
 
 const DEBOUNCE_TIMEOUT = 250;
 const MIN_INPUT = 3;
@@ -29,7 +30,7 @@ export default class MeshManagerComponent extends Component {
     if (!this.terms || this.terms.length === 0) {
       return [];
     }
-    return this.args.terms.sortBy('name');
+    return sortByString(this.args.terms, 'name');
   }
 
   @action
@@ -46,7 +47,7 @@ export default class MeshManagerComponent extends Component {
       return;
     }
 
-    if (this.terms.mapBy('id').includes(term.id)) {
+    if (mapBy(this.terms, 'id').includes(term.id)) {
       return;
     }
     this.args.add(term);

--- a/addon/components/mesh-manager.js
+++ b/addon/components/mesh-manager.js
@@ -3,7 +3,7 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { dropTask, restartableTask, timeout } from 'ember-concurrency';
 import { action } from '@ember/object';
-import { mapBy, sortByString } from '../utils/array-helpers';
+import { mapBy, sortBy } from '../utils/array-helpers';
 
 const DEBOUNCE_TIMEOUT = 250;
 const MIN_INPUT = 3;
@@ -30,7 +30,7 @@ export default class MeshManagerComponent extends Component {
     if (!this.terms || this.terms.length === 0) {
       return [];
     }
-    return sortByString(this.args.terms, 'name');
+    return sortBy(this.args.terms, 'name');
   }
 
   @action

--- a/addon/components/monthly-calendar.js
+++ b/addon/components/monthly-calendar.js
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import moment from 'moment';
 import { inject as service } from '@ember/service';
+import { sortByDate, sortByString } from '../utils/array-helpers';
 
 export default class MonthlyCalendarComponent extends Component {
   @service intl;
@@ -11,7 +12,7 @@ export default class MonthlyCalendarComponent extends Component {
       return [];
     }
 
-    return this.args.events.sortBy('startDate', 'endDate', 'name');
+    return sortByDate(sortByDate(sortByString(this.args.events, 'name'), 'endDate'), 'startDate');
   }
 
   get firstDayOfMonth() {

--- a/addon/components/monthly-calendar.js
+++ b/addon/components/monthly-calendar.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import moment from 'moment';
 import { inject as service } from '@ember/service';
-import { sortByDate, sortByString } from '../utils/array-helpers';
+import { sortBy } from '../utils/array-helpers';
 
 export default class MonthlyCalendarComponent extends Component {
   @service intl;
@@ -12,7 +12,7 @@ export default class MonthlyCalendarComponent extends Component {
       return [];
     }
 
-    return sortByDate(sortByDate(sortByString(this.args.events, 'name'), 'endDate'), 'startDate');
+    return sortBy(this.args.events, ['name', 'endDate', 'startDate']);
   }
 
   get firstDayOfMonth() {

--- a/addon/components/monthly-calendar.js
+++ b/addon/components/monthly-calendar.js
@@ -12,7 +12,7 @@ export default class MonthlyCalendarComponent extends Component {
       return [];
     }
 
-    return sortBy(this.args.events, ['name', 'endDate', 'startDate']);
+    return sortBy(this.args.events, ['startDate', 'endDate', 'name']);
   }
 
   get firstDayOfMonth() {

--- a/addon/components/new-learningmaterial.js
+++ b/addon/components/new-learningmaterial.js
@@ -14,6 +14,7 @@ import {
 import { ValidateIf } from 'class-validator';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from '../classes/resolve-async-value';
+import { findBy, findById } from '../utils/array-helpers';
 
 const DEFAULT_URL_VALUE = 'https://';
 
@@ -68,10 +69,10 @@ export default class NewLearningmaterialComponent extends Component {
     }
 
     if (this.statusId) {
-      return this.args.learningMaterialStatuses.findBy('id', this.statusId);
+      return findById(this.args.learningMaterialStatuses, this.statusId);
     }
 
-    return this.args.learningMaterialStatuses.findBy('title', 'Final');
+    return findBy(this.args.learningMaterialStatuses, 'title', 'Final');
   }
 
   get selectedUserRole() {
@@ -80,7 +81,7 @@ export default class NewLearningmaterialComponent extends Component {
     }
 
     if (this.userRoleId) {
-      return this.args.learningMaterialUserRoles.findBy('id', this.userRoleId);
+      return findById(this.args.learningMaterialUserRoles, this.userRoleId);
     }
 
     return this.args.learningMaterialUserRoles.get('firstObject');

--- a/addon/components/new-learningmaterial.js
+++ b/addon/components/new-learningmaterial.js
@@ -84,7 +84,7 @@ export default class NewLearningmaterialComponent extends Component {
       return findById(this.args.learningMaterialUserRoles, this.userRoleId);
     }
 
-    return this.args.learningMaterialUserRoles.get('firstObject');
+    return this.args.learningMaterialUserRoles[0];
   }
 
   get bestLink() {

--- a/addon/components/new-session.js
+++ b/addon/components/new-session.js
@@ -4,6 +4,7 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { dropTask } from 'ember-concurrency';
 import { validatable, Length, NotBlank } from 'ilios-common/decorators/validation';
+import { filterBy } from '../utils/array-helpers';
 
 @validatable
 export default class NewSessionComponent extends Component {
@@ -13,7 +14,7 @@ export default class NewSessionComponent extends Component {
   @tracked selectedSessionTypeId;
 
   get activeSessionTypes() {
-    return this.args.sessionTypes.filterBy('active', true);
+    return filterBy(this.args.sessionTypes, 'active');
   }
 
   get selectedSessionType() {

--- a/addon/components/new-session.js
+++ b/addon/components/new-session.js
@@ -32,7 +32,7 @@ export default class NewSessionComponent extends Component {
     }
 
     if (!selectedSessionType) {
-      selectedSessionType = this.args.sessionTypes.firstObject;
+      selectedSessionType = this.args.sessionTypes[0];
     }
 
     return selectedSessionType;

--- a/addon/components/new-session.js
+++ b/addon/components/new-session.js
@@ -4,7 +4,7 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { dropTask } from 'ember-concurrency';
 import { validatable, Length, NotBlank } from 'ilios-common/decorators/validation';
-import { filterBy } from '../utils/array-helpers';
+import { filterBy, findBy } from '../utils/array-helpers';
 
 @validatable
 export default class NewSessionComponent extends Component {
@@ -28,7 +28,7 @@ export default class NewSessionComponent extends Component {
 
     if (!selectedSessionType) {
       // try and default to a type names 'Lecture';
-      selectedSessionType = this.args.sessionTypes.findBy('title', 'Lecture');
+      selectedSessionType = findBy(this.args.sessionTypes, 'title', 'Lecture');
     }
 
     if (!selectedSessionType) {

--- a/addon/components/objective-list-item-terms.js
+++ b/addon/components/objective-list-item-terms.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { dropTask } from 'ember-concurrency';
 import { all } from 'rsvp';
+import { mapBy } from '../utils/array-helpers';
 
 export default class ObjectiveListItemTerms extends Component {
   @tracked sortedTerms;
@@ -19,7 +20,7 @@ export default class ObjectiveListItemTerms extends Component {
       return titleA > titleB ? 1 : titleA < titleB ? -1 : 0;
     });
 
-    this.sortedTerms = sortedProxies.mapBy('term');
+    this.sortedTerms = mapBy(sortedProxies, 'term');
   });
 
   get filteredTerms() {

--- a/addon/components/objective-sort-manager.js
+++ b/addon/components/objective-sort-manager.js
@@ -32,7 +32,7 @@ export default class ObjectiveSortManagerComponent extends Component {
 
   async saveSomeObjectives(arr) {
     const chunk = arr.splice(0, 5);
-    await all(chunk.invoke('save'));
+    await await all(chunk.map((o) => o.save()));
     if (arr.length) {
       this.currentObjectivesSaved += chunk.length;
       await this.saveSomeObjectives(arr);

--- a/addon/components/objective-sort-manager.js
+++ b/addon/components/objective-sort-manager.js
@@ -17,7 +17,7 @@ export default class ObjectiveSortManagerComponent extends Component {
 
   @use objectives = new ResolveAsyncValue(() => [this.args.subject.xObjectives]);
   get sortedObjectives() {
-    return this.objectives?.toArray().sort(sortableByPosition) ?? [];
+    return this.objectives?.slice().sort(sortableByPosition) ?? [];
   }
 
   get items() {

--- a/addon/components/offering-calendar.js
+++ b/addon/components/offering-calendar.js
@@ -40,7 +40,7 @@ export default class OfferingCalendar extends Component {
     } else {
       const data = await map(learnerGroups, async (learnerGroup) => {
         const offerings = await learnerGroup.offerings;
-        return await map(offerings.toArray(), async (offering) => {
+        return await map(offerings.slice(), async (offering) => {
           const session = await offering.session;
           const course = await session.course;
           return {
@@ -58,7 +58,7 @@ export default class OfferingCalendar extends Component {
       });
 
       this.learnerGroupEvents = data.reduce((flattened, obj) => {
-        return [...flattened, ...obj.toArray()];
+        return [...flattened, ...obj.slice()];
       }, []);
     }
 
@@ -69,7 +69,7 @@ export default class OfferingCalendar extends Component {
       const offerings = await session.offerings;
       const sessionType = await session.sessionType;
       const course = await session.course;
-      this.sessionEvents = await map(offerings.toArray(), async (offering) => {
+      this.sessionEvents = await map(offerings.slice(), async (offering) => {
         return {
           startDate: offering.startDate,
           endDate: offering.endDate,

--- a/addon/components/offering-form.js
+++ b/addon/components/offering-form.js
@@ -298,7 +298,7 @@ export default class OfferingForm extends Component {
     if (isEmpty(cohorts)) {
       associatedSchools = [];
     } else {
-      const cohortSchools = await map(cohorts.toArray(), (cohort) => {
+      const cohortSchools = await map(cohorts.slice(), (cohort) => {
         return cohort.get('school');
       });
       const schools = [];
@@ -309,7 +309,7 @@ export default class OfferingForm extends Component {
       return school.get('instructorGroups');
     });
     return allInstructorGroups.reduce((flattened, obj) => {
-      return flattened.pushObjects(obj.toArray());
+      return flattened.pushObjects(obj.slice());
     }, []);
   }
 
@@ -342,10 +342,10 @@ export default class OfferingForm extends Component {
       instructors: offering.get('instructors'),
       instructorGroups: offering.get('instructorGroups'),
     });
-    this.learnerGroups = obj.learnerGroups.toArray();
-    this.learners = obj.learners.toArray();
-    this.instructors = obj.instructors.toArray();
-    this.instructorGroups = obj.instructorGroups.toArray();
+    this.learnerGroups = obj.learnerGroups.slice();
+    this.learners = obj.learners.slice();
+    this.instructors = obj.instructors.slice();
+    this.instructorGroups = obj.instructorGroups.slice();
     this.loaded = true;
   });
 
@@ -503,8 +503,8 @@ export default class OfferingForm extends Component {
         if (isPresent(defaultLocation)) {
           room = defaultLocation;
         }
-        const instructors = (await learnerGroup.instructors).toArray();
-        const instructorGroups = (await learnerGroup.instructorGroups).toArray();
+        const instructors = (await learnerGroup.instructors).slice();
+        const instructorGroups = (await learnerGroup.instructorGroups).slice();
         const offering = {
           startDate,
           endDate,

--- a/addon/components/offering-form.js
+++ b/addon/components/offering-form.js
@@ -18,7 +18,7 @@ import {
   validatable,
 } from 'ilios-common/decorators/validation';
 import { ValidateIf } from 'class-validator';
-import { mapBy, uniqueValues } from '../utils/array-helpers';
+import { uniqueValues } from '../utils/array-helpers';
 
 const DEBOUNCE_DELAY = 600;
 const DEFAULT_URL_VALUE = 'https://';
@@ -300,19 +300,12 @@ export default class OfferingForm extends Component {
     if (isEmpty(cohorts)) {
       associatedSchools = [];
     } else {
-      const cohortSchools = await map(cohorts.slice(), (cohort) => {
-        return cohort.get('school');
-      });
-      const schools = [];
-      schools.push(cohortSchools);
-      associatedSchools = uniqueValues(schools.slice());
+      const cohortSchools = await map(cohorts.slice(), (cohort) => cohort.school);
+      associatedSchools = uniqueValues(cohortSchools);
     }
-    const allInstructorGroups = await map(associatedSchools, (schools) => {
-      return Promise.all(mapBy(schools, 'instructorGroups'));
-    });
-    return allInstructorGroups.reduce((flattened, obj) => {
-      flattened.push(...obj.slice());
-      return flattened;
+    const allInstructorGroups = await map(associatedSchools, (school) => school.instructorGroups);
+    return allInstructorGroups.reduce((flattened, arr) => {
+      return [...flattened, ...arr.slice()];
     }, []);
   }
 

--- a/addon/components/offering-form.js
+++ b/addon/components/offering-form.js
@@ -309,7 +309,8 @@ export default class OfferingForm extends Component {
       return school.get('instructorGroups');
     });
     return allInstructorGroups.reduce((flattened, obj) => {
-      return flattened.push(obj.slice());
+      flattened.push(...obj.slice());
+      return flattened;
     }, []);
   }
 
@@ -464,7 +465,7 @@ export default class OfferingForm extends Component {
         offerings.push(obj);
       }
     });
-    recurringDayInts.pushObject(userPickedDay);
+    recurringDayInts.push(userPickedDay);
     recurringDayInts.sort();
 
     for (let i = 1; i < this.numberOfWeeks; i++) {
@@ -516,7 +517,7 @@ export default class OfferingForm extends Component {
         };
         offering.learnerGroups = [learnerGroup];
 
-        smallGroupOfferings.pushObject(offering);
+        smallGroupOfferings.push(offering);
       }
     }
 

--- a/addon/components/offering-form.js
+++ b/addon/components/offering-form.js
@@ -18,7 +18,7 @@ import {
   validatable,
 } from 'ilios-common/decorators/validation';
 import { ValidateIf } from 'class-validator';
-import { uniqueById } from '../utils/array-helpers';
+import { mapBy, uniqueValues } from '../utils/array-helpers';
 
 const DEBOUNCE_DELAY = 600;
 const DEFAULT_URL_VALUE = 'https://';
@@ -171,9 +171,9 @@ export default class OfferingForm extends Component {
   async addLearnerGroup(learnerGroup, cascade) {
     if (cascade) {
       const descendants = await learnerGroup.getAllDescendants();
-      this.learnerGroups = [...this.learnerGroups, ...descendants, learnerGroup].uniq();
+      this.learnerGroups = uniqueValues([...this.learnerGroups, ...descendants, learnerGroup]);
     } else {
-      this.learnerGroups = [...this.learnerGroups, learnerGroup].uniq();
+      this.learnerGroups = uniqueValues([...this.learnerGroups, learnerGroup]);
     }
   }
 
@@ -184,7 +184,9 @@ export default class OfferingForm extends Component {
       const descendants = await learnerGroup.getAllDescendants();
       groupsToRemove = [...descendants, learnerGroup];
     }
-    this.learnerGroups = this.learnerGroups.filter((g) => !groupsToRemove.includes(g)).uniq();
+    this.learnerGroups = uniqueValues(
+      this.learnerGroups.filter((g) => !groupsToRemove.includes(g))
+    );
   }
 
   @action
@@ -303,10 +305,10 @@ export default class OfferingForm extends Component {
       });
       const schools = [];
       schools.push(cohortSchools);
-      associatedSchools = uniqueById(schools.slice());
+      associatedSchools = uniqueValues(schools.slice());
     }
-    const allInstructorGroups = await map(associatedSchools, (school) => {
-      return school.get('instructorGroups');
+    const allInstructorGroups = await map(associatedSchools, (schools) => {
+      return Promise.all(mapBy(schools, 'instructorGroups'));
     });
     return allInstructorGroups.reduce((flattened, obj) => {
       flattened.push(...obj.slice());

--- a/addon/components/offering-form.js
+++ b/addon/components/offering-form.js
@@ -18,6 +18,7 @@ import {
   validatable,
 } from 'ilios-common/decorators/validation';
 import { ValidateIf } from 'class-validator';
+import { uniqueById } from '../utils/array-helpers';
 
 const DEBOUNCE_DELAY = 600;
 const DEFAULT_URL_VALUE = 'https://';
@@ -302,7 +303,7 @@ export default class OfferingForm extends Component {
       });
       const schools = [];
       schools.pushObjects(cohortSchools);
-      associatedSchools = schools.uniq().toArray();
+      associatedSchools = uniqueById(schools.slice());
     }
     const allInstructorGroups = await map(associatedSchools, (school) => {
       return school.get('instructorGroups');

--- a/addon/components/offering-form.js
+++ b/addon/components/offering-form.js
@@ -302,14 +302,14 @@ export default class OfferingForm extends Component {
         return cohort.get('school');
       });
       const schools = [];
-      schools.pushObjects(cohortSchools);
+      schools.push(cohortSchools);
       associatedSchools = uniqueById(schools.slice());
     }
     const allInstructorGroups = await map(associatedSchools, (school) => {
       return school.get('instructorGroups');
     });
     return allInstructorGroups.reduce((flattened, obj) => {
-      return flattened.pushObjects(obj.slice());
+      return flattened.push(obj.slice());
     }, []);
   }
 

--- a/addon/components/offering-manager.js
+++ b/addon/components/offering-manager.js
@@ -34,7 +34,7 @@ export default class OfferingManagerComponent extends Component {
     if (!this.learnerGroups) {
       return [];
     }
-    return this.learnerGroups.toArray().sort((learnerGroupA, learnerGroupB) => {
+    return this.learnerGroups.slice().sort((learnerGroupA, learnerGroupB) => {
       const locale = this.intl.get('locale');
       if ('title:desc' === this.sortBy) {
         return learnerGroupB.title.localeCompare(learnerGroupA.title, locale, { numeric: true });

--- a/addon/components/print-course.js
+++ b/addon/components/print-course.js
@@ -27,7 +27,7 @@ export default class PrintCourseComponent extends Component {
       return [];
     }
 
-    return this.courseLearningMaterialsRelationship.toArray().sort(sortableByPosition);
+    return this.courseLearningMaterialsRelationship.slice().sort(sortableByPosition);
   }
 
   get sessions() {
@@ -39,6 +39,6 @@ export default class PrintCourseComponent extends Component {
       return this.sessionsRelationship.filterBy('isPublishedOrScheduled');
     }
 
-    return this.sessionsRelationship.toArray();
+    return this.sessionsRelationship.slice();
   }
 }

--- a/addon/components/print-course.js
+++ b/addon/components/print-course.js
@@ -3,6 +3,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { dropTask } from 'ember-concurrency';
 import sortableByPosition from 'ilios-common/utils/sortable-by-position';
+import { filterBy } from '../utils/array-helpers';
 
 export default class PrintCourseComponent extends Component {
   @service store;
@@ -36,7 +37,7 @@ export default class PrintCourseComponent extends Component {
     }
 
     if (!this.args.includeUnpublishedSessions) {
-      return this.sessionsRelationship.filterBy('isPublishedOrScheduled');
+      return filterBy(this.sessionsRelationship, 'isPublishedOrScheduled');
     }
 
     return this.sessionsRelationship.slice();

--- a/addon/components/publish-all-sessions.js
+++ b/addon/components/publish-all-sessions.js
@@ -147,7 +147,7 @@ export default class PublishAllSessionsComponent extends Component {
   async saveSomeSessions(sessions) {
     const chunk = sessions.splice(0, 6);
 
-    await all(chunk.invoke('save'));
+    await await all(chunk.map((o) => o.save()));
     this.currentSessionsSaved += chunk.length;
     if (sessions.length) {
       await this.saveSomeSessions(sessions);

--- a/addon/components/publish-all-sessions.js
+++ b/addon/components/publish-all-sessions.js
@@ -77,7 +77,7 @@ export default class PublishAllSessionsComponent extends Component {
       return false;
     }
 
-    return this.courseObjectives.toArray().any((objective) => {
+    return this.courseObjectives.slice().any((objective) => {
       return objective.programYearObjectives.length === 0;
     });
   }

--- a/addon/components/publish-all-sessions.js
+++ b/addon/components/publish-all-sessions.js
@@ -6,6 +6,7 @@ import { all } from 'rsvp';
 import { dropTask, timeout } from 'ember-concurrency';
 import ResolveAsyncValue from '../classes/resolve-async-value';
 import { use } from 'ember-could-get-used-to-this';
+import { uniqueById } from '../utils/array-helpers';
 
 export default class PublishAllSessionsComponent extends Component {
   @service router;
@@ -39,13 +40,17 @@ export default class PublishAllSessionsComponent extends Component {
   get sessionsToPublish() {
     const sessionsToPublish = [...this.publishedSessions, ...this.userSelectedSessionsToPublish];
 
-    return sessionsToPublish.filter((s) => !this.userSelectedSessionsToSchedule.includes(s)).uniq();
+    return uniqueById(
+      sessionsToPublish.filter((s) => !this.userSelectedSessionsToSchedule.includes(s))
+    );
   }
 
   get sessionsToSchedule() {
     const sessionsToPublish = [...this.unpublishedSessions, ...this.userSelectedSessionsToSchedule];
 
-    return sessionsToPublish.filter((s) => !this.userSelectedSessionsToPublish.includes(s)).uniq();
+    return uniqueById(
+      sessionsToPublish.filter((s) => !this.userSelectedSessionsToPublish.includes(s))
+    );
   }
 
   get allSessionsScheduled() {

--- a/addon/components/publish-all-sessions.js
+++ b/addon/components/publish-all-sessions.js
@@ -6,7 +6,7 @@ import { all } from 'rsvp';
 import { dropTask, timeout } from 'ember-concurrency';
 import ResolveAsyncValue from '../classes/resolve-async-value';
 import { use } from 'ember-could-get-used-to-this';
-import { uniqueById } from '../utils/array-helpers';
+import { uniqueValues } from '../utils/array-helpers';
 
 export default class PublishAllSessionsComponent extends Component {
   @service router;
@@ -40,7 +40,7 @@ export default class PublishAllSessionsComponent extends Component {
   get sessionsToPublish() {
     const sessionsToPublish = [...this.publishedSessions, ...this.userSelectedSessionsToPublish];
 
-    return uniqueById(
+    return uniqueValues(
       sessionsToPublish.filter((s) => !this.userSelectedSessionsToSchedule.includes(s))
     );
   }
@@ -48,7 +48,7 @@ export default class PublishAllSessionsComponent extends Component {
   get sessionsToSchedule() {
     const sessionsToPublish = [...this.unpublishedSessions, ...this.userSelectedSessionsToSchedule];
 
-    return uniqueById(
+    return uniqueValues(
       sessionsToPublish.filter((s) => !this.userSelectedSessionsToPublish.includes(s))
     );
   }

--- a/addon/components/publish-all-sessions.js
+++ b/addon/components/publish-all-sessions.js
@@ -77,9 +77,11 @@ export default class PublishAllSessionsComponent extends Component {
       return false;
     }
 
-    return this.courseObjectives.slice().any((objective) => {
-      return objective.programYearObjectives.length === 0;
-    });
+    return Boolean(
+      this.courseObjectives.find((objective) => {
+        return objective.programYearObjectives.length === 0;
+      })
+    );
   }
 
   get publishableSessions() {

--- a/addon/components/selectable-terms-list.js
+++ b/addon/components/selectable-terms-list.js
@@ -13,9 +13,9 @@ export default class SelectableTermsList extends Component {
   loadFilteredTerms = restartableTask(async () => {
     let terms = [];
     if (this.topLevelTermsRelationshipPromise) {
-      terms = (await this.topLevelTermsRelationshipPromise).toArray();
+      terms = (await this.topLevelTermsRelationshipPromise).slice();
     } else if (this.args.terms) {
-      terms = this.args.terms.toArray();
+      terms = this.args.terms.slice();
     }
 
     if (this.args.termFilter) {

--- a/addon/components/session-copy.js
+++ b/addon/components/session-copy.js
@@ -5,7 +5,7 @@ import { dropTask, restartableTask, timeout } from 'ember-concurrency';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import moment from 'moment';
-import { sortByNumber, sortByString } from '../utils/array-helpers';
+import { findById, sortByNumber, sortByString } from '../utils/array-helpers';
 
 export default class SessionCopyComponent extends Component {
   @service store;
@@ -59,7 +59,7 @@ export default class SessionCopyComponent extends Component {
 
   get bestSelectedCourse() {
     if (this.selectedCourseId) {
-      const course = this.courses.findBy('id', this.selectedCourseId);
+      const course = findById(this.courses, this.selectedCourseId);
       if (course) {
         return course;
       }

--- a/addon/components/session-copy.js
+++ b/addon/components/session-copy.js
@@ -37,7 +37,7 @@ export default class SessionCopyComponent extends Component {
       .map((year) => Number(year.id))
       .filter((year) => year >= thisYear - 1)
       .sort();
-    this.allCourses = await filter(schoolCourses.toArray(), async (co) => {
+    this.allCourses = await filter(schoolCourses.slice(), async (co) => {
       return this.permissionChecker.canCreateSession(co);
     });
   });
@@ -99,8 +99,8 @@ export default class SessionCopyComponent extends Component {
     );
 
     session.set('course', newCourse);
-    session.set('meshDescriptors', (await sessionToCopy.meshDescriptors).toArray());
-    session.set('terms', (await sessionToCopy.terms).toArray());
+    session.set('meshDescriptors', (await sessionToCopy.meshDescriptors).slice());
+    session.set('terms', (await sessionToCopy.terms).slice());
     session.set('sessionType', await sessionToCopy.sessionType);
 
     const ilmToCopy = await sessionToCopy.ilmSession;
@@ -115,7 +115,7 @@ export default class SessionCopyComponent extends Component {
 
     const learningMaterialsToCopy = await sessionToCopy.learningMaterials;
     for (let i = 0; i < learningMaterialsToCopy.length; i++) {
-      const learningMaterialToCopy = learningMaterialsToCopy.toArray()[i];
+      const learningMaterialToCopy = learningMaterialsToCopy.slice()[i];
       const lm = await learningMaterialToCopy.learningMaterial;
       const learningMaterial = this.store.createRecord(
         'sessionLearningMaterial',
@@ -142,8 +142,8 @@ export default class SessionCopyComponent extends Component {
     const sessionObjectivesToCopy = sortByNumber(relatedSessionObjectives, 'id').slice();
     for (let i = 0, n = sessionObjectivesToCopy.length; i < n; i++) {
       const sessionObjectiveToCopy = sessionObjectivesToCopy[i];
-      const meshDescriptors = (await sessionObjectiveToCopy.meshDescriptors).toArray();
-      const terms = (await sessionObjectiveToCopy.terms).toArray();
+      const meshDescriptors = (await sessionObjectiveToCopy.meshDescriptors).slice();
+      const terms = (await sessionObjectiveToCopy.terms).slice();
       const sessionObjective = this.store.createRecord('session-objective', {
         session,
         position: sessionObjectiveToCopy.position,

--- a/addon/components/session-copy.js
+++ b/addon/components/session-copy.js
@@ -5,7 +5,7 @@ import { dropTask, restartableTask, timeout } from 'ember-concurrency';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import moment from 'moment';
-import { findById, sortByNumber, sortByString } from '../utils/array-helpers';
+import { filterBy, findById, sortByNumber, sortByString } from '../utils/array-helpers';
 
 export default class SessionCopyComponent extends Component {
   @service store;
@@ -54,7 +54,7 @@ export default class SessionCopyComponent extends Component {
     if (!this.allCourses) {
       return null;
     }
-    return sortByString(this.allCourses.filterBy('year', this.bestSelectedYear), 'title');
+    return sortByString(filterBy(this.allCourses, 'year', this.bestSelectedYear), 'title');
   }
 
   get bestSelectedCourse() {

--- a/addon/components/session-copy.js
+++ b/addon/components/session-copy.js
@@ -134,7 +134,7 @@ export default class SessionCopyComponent extends Component {
 
     // save the session first to fill out relationships with the session id
     await session.save();
-    await all(toSave.invoke('save'));
+    await await all(toSave.map((o) => o.save()));
 
     //parse objectives last because it is a many2many relationship
     //and ember data tries to save it too soon

--- a/addon/components/session-copy.js
+++ b/addon/components/session-copy.js
@@ -5,7 +5,7 @@ import { dropTask, restartableTask, timeout } from 'ember-concurrency';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import moment from 'moment';
-import { filterBy, findById, sortByNumber, sortByString } from '../utils/array-helpers';
+import { filterBy, findById, sortBy } from '../utils/array-helpers';
 
 export default class SessionCopyComponent extends Component {
   @service store;
@@ -54,7 +54,7 @@ export default class SessionCopyComponent extends Component {
     if (!this.allCourses) {
       return null;
     }
-    return sortByString(filterBy(this.allCourses, 'year', this.bestSelectedYear), 'title');
+    return sortBy(filterBy(this.allCourses, 'year', this.bestSelectedYear), 'title');
   }
 
   get bestSelectedCourse() {
@@ -139,7 +139,7 @@ export default class SessionCopyComponent extends Component {
     //parse objectives last because it is a many2many relationship
     //and ember data tries to save it too soon
     const relatedSessionObjectives = await sessionToCopy.sessionObjectives;
-    const sessionObjectivesToCopy = sortByNumber(relatedSessionObjectives, 'id').slice();
+    const sessionObjectivesToCopy = sortBy(relatedSessionObjectives, 'id').slice();
     for (let i = 0, n = sessionObjectivesToCopy.length; i < n; i++) {
       const sessionObjectiveToCopy = sessionObjectivesToCopy[i];
       const meshDescriptors = (await sessionObjectiveToCopy.meshDescriptors).slice();

--- a/addon/components/session-copy.js
+++ b/addon/components/session-copy.js
@@ -47,7 +47,7 @@ export default class SessionCopyComponent extends Component {
       return this.selectedYear;
     }
 
-    return this.years.get('firstObject');
+    return this.years[0];
   }
 
   get courses() {
@@ -65,7 +65,7 @@ export default class SessionCopyComponent extends Component {
       }
     }
 
-    return this.courses.get('firstObject');
+    return this.courses[0];
   }
 
   @action

--- a/addon/components/session-copy.js
+++ b/addon/components/session-copy.js
@@ -110,7 +110,7 @@ export default class SessionCopyComponent extends Component {
         ilmToCopy.getProperties('hours', 'dueDate')
       );
       ilm.set('session', session);
-      toSave.pushObject(ilm);
+      toSave.push(ilm);
     }
 
     const learningMaterialsToCopy = await sessionToCopy.learningMaterials;
@@ -123,7 +123,7 @@ export default class SessionCopyComponent extends Component {
       );
       learningMaterial.set('learningMaterial', lm);
       learningMaterial.set('session', session);
-      toSave.pushObject(learningMaterial);
+      toSave.push(learningMaterial);
     }
 
     const originalCourse = await sessionToCopy.course;

--- a/addon/components/session-copy.js
+++ b/addon/components/session-copy.js
@@ -5,6 +5,7 @@ import { dropTask, restartableTask, timeout } from 'ember-concurrency';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import moment from 'moment';
+import { sortByNumber, sortByString } from '../utils/array-helpers';
 
 export default class SessionCopyComponent extends Component {
   @service store;
@@ -53,7 +54,7 @@ export default class SessionCopyComponent extends Component {
     if (!this.allCourses) {
       return null;
     }
-    return this.allCourses.filterBy('year', this.bestSelectedYear).sortBy('title');
+    return sortByString(this.allCourses.filterBy('year', this.bestSelectedYear), 'title');
   }
 
   get bestSelectedCourse() {
@@ -138,7 +139,7 @@ export default class SessionCopyComponent extends Component {
     //parse objectives last because it is a many2many relationship
     //and ember data tries to save it too soon
     const relatedSessionObjectives = await sessionToCopy.sessionObjectives;
-    const sessionObjectivesToCopy = relatedSessionObjectives.sortBy('id').toArray();
+    const sessionObjectivesToCopy = sortByNumber(relatedSessionObjectives, 'id').slice();
     for (let i = 0, n = sessionObjectivesToCopy.length; i < n; i++) {
       const sessionObjectiveToCopy = sessionObjectivesToCopy[i];
       const meshDescriptors = (await sessionObjectiveToCopy.meshDescriptors).toArray();

--- a/addon/components/session-leadership-expanded.js
+++ b/addon/components/session-leadership-expanded.js
@@ -30,8 +30,8 @@ export default class CourseLeadershipExpandedComponent extends Component {
       administrators: this.args.session.administrators,
       studentAdvisors: this.args.session.studentAdvisors,
     });
-    this.administrators = obj.administrators.toArray();
-    this.studentAdvisors = obj.studentAdvisors.toArray();
+    this.administrators = obj.administrators.slice();
+    this.studentAdvisors = obj.studentAdvisors.slice();
     this.args.setIsManaging(true);
   });
 

--- a/addon/components/session-offerings-list.js
+++ b/addon/components/session-offerings-list.js
@@ -4,6 +4,7 @@ import { action } from '@ember/object';
 import OfferingDateBlock from 'ilios-common/utils/offering-date-block';
 import { tracked } from '@glimmer/tracking';
 import { restartableTask } from 'ember-concurrency';
+import { sortByNumber } from '../utils/array-helpers';
 
 export default class SessionOfferingsListComponent extends Component {
   @service store;
@@ -34,7 +35,7 @@ export default class SessionOfferingsListComponent extends Component {
     for (key in dateBlocks) {
       dateBlockArray.pushObject(dateBlocks[key]);
     }
-    return dateBlockArray.sortBy('dateStamp');
+    return sortByNumber(dateBlockArray, 'dateStamp');
   }
 
   @action

--- a/addon/components/session-offerings-list.js
+++ b/addon/components/session-offerings-list.js
@@ -15,7 +15,7 @@ export default class SessionOfferingsListComponent extends Component {
   });
 
   get offerings() {
-    return this.offeringsRelationship ? this.offeringsRelationship.toArray() : [];
+    return this.offeringsRelationship ? this.offeringsRelationship.slice() : [];
   }
 
   get offeringBlocks() {

--- a/addon/components/session-offerings-list.js
+++ b/addon/components/session-offerings-list.js
@@ -4,7 +4,7 @@ import { action } from '@ember/object';
 import OfferingDateBlock from 'ilios-common/utils/offering-date-block';
 import { tracked } from '@glimmer/tracking';
 import { restartableTask } from 'ember-concurrency';
-import { sortByNumber } from '../utils/array-helpers';
+import { sortBy } from '../utils/array-helpers';
 
 export default class SessionOfferingsListComponent extends Component {
   @service store;
@@ -35,7 +35,7 @@ export default class SessionOfferingsListComponent extends Component {
     for (key in dateBlocks) {
       dateBlockArray.push(dateBlocks[key]);
     }
-    return sortByNumber(dateBlockArray, 'dateStamp');
+    return sortBy(dateBlockArray, 'dateStamp');
   }
 
   @action

--- a/addon/components/session-offerings-list.js
+++ b/addon/components/session-offerings-list.js
@@ -33,7 +33,7 @@ export default class SessionOfferingsListComponent extends Component {
     const dateBlockArray = [];
     let key;
     for (key in dateBlocks) {
-      dateBlockArray.pushObject(dateBlocks[key]);
+      dateBlockArray.push(dateBlocks[key]);
     }
     return sortByNumber(dateBlockArray, 'dateStamp');
   }

--- a/addon/components/session-overview.hbs
+++ b/addon/components/session-overview.hbs
@@ -266,7 +266,12 @@
               <label>{{t "general.prerequisites"}}:</label>
               {{#if @session.hasPrerequisites}}
                 <span>
-                  {{#each (await @session.prerequisites) as |prerequisite|~}}<LinkTo @route="session.index" @models={{array (await prerequisite.course) prerequisite}}><FaIcon @icon="square-up-right" /> {{prerequisite.title}}</LinkTo>{{#unless (eq prerequisite @session.prerequisites.lastObject)}}, {{/unless}}{{~/each}}
+                  {{#each (await @session.prerequisites) as |prerequisite|~}}
+                    <LinkTo @route="session.index" @models={{array (await prerequisite.course) prerequisite}}>
+                      <FaIcon @icon="square-up-right" /> {{prerequisite.title}}
+                    </LinkTo>
+                    {{#unless (eq prerequisite (object-at 0 (reverse @session.prerequisites)))}}, {{/unless}}
+                  {{~/each}}
                 </span>
               {{else}}
                 {{t "general.none"}}

--- a/addon/components/session-overview.hbs
+++ b/addon/components/session-overview.hbs
@@ -266,12 +266,7 @@
               <label>{{t "general.prerequisites"}}:</label>
               {{#if @session.hasPrerequisites}}
                 <span>
-                  {{#each (await @session.prerequisites) as |prerequisite|~}}
-                    <LinkTo @route="session.index" @models={{array (await prerequisite.course) prerequisite}}>
-                      <FaIcon @icon="square-up-right" /> {{prerequisite.title}}
-                    </LinkTo>
-                    {{#unless (eq prerequisite (object-at 0 (reverse @session.prerequisites)))}}, {{/unless}}
-                  {{~/each}}
+                  {{#each (await @session.prerequisites) as |prerequisite|~}}<LinkTo @route="session.index" @models={{array (await prerequisite.course) prerequisite}}><FaIcon @icon="square-up-right" /> {{prerequisite.title}}</LinkTo>{{#unless (eq prerequisite (object-at 0 (reverse @session.prerequisites)))}}, {{/unless}}{{~/each}}
                 </span>
               {{else}}
                 {{t "general.none"}}

--- a/addon/components/session-overview.js
+++ b/addon/components/session-overview.js
@@ -7,7 +7,7 @@ import { task, restartableTask, dropTask } from 'ember-concurrency';
 import moment from 'moment';
 import { validatable, Length, Gte, NotBlank } from 'ilios-common/decorators/validation';
 import { hash } from 'rsvp';
-import { sortByString } from '../utils/array-helpers';
+import { findById, sortByString } from '../utils/array-helpers';
 
 @validatable
 export default class SessionOverview extends Component {
@@ -171,7 +171,7 @@ export default class SessionOverview extends Component {
 
   @action
   setSessionType(event) {
-    this.sessionType = this.sessionTypes.findBy('id', event.target.value);
+    this.sessionType = findById(this.sessionTypes, event.target.value);
   }
 
   @action

--- a/addon/components/session-overview.js
+++ b/addon/components/session-overview.js
@@ -7,6 +7,7 @@ import { task, restartableTask, dropTask } from 'ember-concurrency';
 import moment from 'moment';
 import { validatable, Length, Gte, NotBlank } from 'ilios-common/decorators/validation';
 import { hash } from 'rsvp';
+import { sortByString } from '../utils/array-helpers';
 
 @validatable
 export default class SessionOverview extends Component {
@@ -42,7 +43,7 @@ export default class SessionOverview extends Component {
   }
 
   get sortedSessionTypes() {
-    return this.filteredSessionTypes.sortBy('title');
+    return sortByString(this.filteredSessionTypes, 'title');
   }
 
   load = restartableTask(async (element, [session, sessionTypes]) => {

--- a/addon/components/session-overview.js
+++ b/addon/components/session-overview.js
@@ -113,7 +113,7 @@ export default class SessionOverview extends Component {
       }
     }
     const school = await course.school;
-    const schoolCourses = (await school.courses).toArray();
+    const schoolCourses = (await school.courses).slice();
     let schoolCourse;
     for (schoolCourse of schoolCourses) {
       if (await this.permissionChecker.canCreateSession(schoolCourse)) {

--- a/addon/components/session-overview.js
+++ b/addon/components/session-overview.js
@@ -7,7 +7,7 @@ import { task, restartableTask, dropTask } from 'ember-concurrency';
 import moment from 'moment';
 import { validatable, Length, Gte, NotBlank } from 'ilios-common/decorators/validation';
 import { hash } from 'rsvp';
-import { findById, sortByString } from '../utils/array-helpers';
+import { findById, sortBy } from '../utils/array-helpers';
 
 @validatable
 export default class SessionOverview extends Component {
@@ -43,7 +43,7 @@ export default class SessionOverview extends Component {
   }
 
   get sortedSessionTypes() {
-    return sortByString(this.filteredSessionTypes, 'title');
+    return sortBy(this.filteredSessionTypes, 'title');
   }
 
   load = restartableTask(async (element, [session, sessionTypes]) => {

--- a/addon/components/session-publicationcheck.js
+++ b/addon/components/session-publicationcheck.js
@@ -14,7 +14,7 @@ export default class SessionPublicationCheckComponent extends Component {
     if (!this.objectivesRelationship) {
       return false;
     }
-    return this.objectivesRelationship.toArray().any((objective) => {
+    return this.objectivesRelationship.slice().any((objective) => {
       const parentIds = objective.hasMany('courseObjectives').ids();
       return parentIds.length === 0;
     });

--- a/addon/components/session-publicationcheck.js
+++ b/addon/components/session-publicationcheck.js
@@ -14,10 +14,12 @@ export default class SessionPublicationCheckComponent extends Component {
     if (!this.objectivesRelationship) {
       return false;
     }
-    return this.objectivesRelationship.slice().any((objective) => {
-      const parentIds = objective.hasMany('courseObjectives').ids();
-      return parentIds.length === 0;
-    });
+    return Boolean(
+      this.objectivesRelationship.find((objective) => {
+        const parentIds = objective.hasMany('courseObjectives').ids();
+        return parentIds.length === 0;
+      })
+    );
   }
 
   load = restartableTask(async () => {

--- a/addon/components/session/collapsed-objectives.js
+++ b/addon/components/session/collapsed-objectives.js
@@ -10,7 +10,7 @@ export default class SessionCollapsedObjectivesComponent extends Component {
   });
 
   get objectives() {
-    return this.objectivesRelationship ? this.objectivesRelationship.toArray() : [];
+    return this.objectivesRelationship ? this.objectivesRelationship.slice() : [];
   }
 
   get objectivesWithParents() {

--- a/addon/components/session/objective-list-item.js
+++ b/addon/components/session/objective-list-item.js
@@ -43,20 +43,20 @@ export default class SessionObjectiveListItemComponent extends Component {
 
   manageParents = dropTask(async () => {
     const parents = await this.args.sessionObjective.courseObjectives;
-    this.parentsBuffer = parents.toArray();
+    this.parentsBuffer = parents.slice();
     this.isManagingParents = true;
   });
 
   manageDescriptors = dropTask(async () => {
     const meshDescriptors = await this.args.sessionObjective.meshDescriptors;
-    this.descriptorsBuffer = meshDescriptors.toArray();
+    this.descriptorsBuffer = meshDescriptors.slice();
     this.isManagingDescriptors = true;
   });
 
   manageTerms = dropTask(async (vocabulary) => {
     this.selectedVocabulary = vocabulary;
     const terms = await this.args.sessionObjective.terms;
-    this.termsBuffer = terms.toArray();
+    this.termsBuffer = terms.slice();
     this.isManagingTerms = true;
   });
 

--- a/addon/components/session/objectives.js
+++ b/addon/components/session/objectives.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { dropTask, restartableTask } from 'ember-concurrency';
 import { action } from '@ember/object';
+import { mapBy } from '../../utils/array-helpers';
 
 export default class SessionObjectivesComponent extends Component {
   @service store;
@@ -33,7 +34,8 @@ export default class SessionObjectivesComponent extends Component {
     let position = 0;
     const sessionObjectives = await this.args.session.sessionObjectives;
     if (sessionObjectives.length) {
-      position = sessionObjectives.sortBy('position').lastObject.position + 1;
+      const positions = mapBy(sessionObjectives, 'position');
+      position = Math.max(...positions) + 1;
     }
 
     newSessionObjective.set('title', title);

--- a/addon/components/session/postrequisite-editor.js
+++ b/addon/components/session/postrequisite-editor.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
 import escapeRegExp from 'ilios-common/utils/escape-reg-exp';
+import { sortBy } from '../../utils/array-helpers';
 
 export default class SessionPostrequisiteEditorComponent extends Component {
   @tracked filter = '';
@@ -19,9 +20,9 @@ export default class SessionPostrequisiteEditorComponent extends Component {
     const { session } = this.args;
     const course = await session.course;
     const sessions = await course.sessions;
-    this.linkablePostrequisites = sessions
-      .sortBy('title')
-      .filter((sessionInCourse) => sessionInCourse.id !== session.id);
+    this.linkablePostrequisites = sortBy(sessions, 'title').filter(
+      (sessionInCourse) => sessionInCourse.id !== session.id
+    );
   });
 
   save = task(async () => {

--- a/addon/components/sessions-grid-offering-table.js
+++ b/addon/components/sessions-grid-offering-table.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import OfferingDateBlock from 'ilios-common/utils/offering-date-block';
+import { sortByNumber } from '../utils/array-helpers';
 
 export default class SessionsGridOfferingTable extends Component {
   get offeringBlocks() {
@@ -22,6 +23,6 @@ export default class SessionsGridOfferingTable extends Component {
     for (key in dateBlocks) {
       dateBlockArray.pushObject(dateBlocks[key]);
     }
-    return dateBlockArray.sortBy('dateStamp');
+    return sortByNumber(dateBlockArray, 'dateStamp');
   }
 }

--- a/addon/components/sessions-grid-offering-table.js
+++ b/addon/components/sessions-grid-offering-table.js
@@ -21,7 +21,7 @@ export default class SessionsGridOfferingTable extends Component {
     const dateBlockArray = [];
     let key;
     for (key in dateBlocks) {
-      dateBlockArray.pushObject(dateBlocks[key]);
+      dateBlockArray.push(dateBlocks[key]);
     }
     return sortByNumber(dateBlockArray, 'dateStamp');
   }

--- a/addon/components/sessions-grid-offering-table.js
+++ b/addon/components/sessions-grid-offering-table.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import OfferingDateBlock from 'ilios-common/utils/offering-date-block';
-import { sortByNumber } from '../utils/array-helpers';
+import { sortBy } from '../utils/array-helpers';
 
 export default class SessionsGridOfferingTable extends Component {
   get offeringBlocks() {
@@ -23,6 +23,6 @@ export default class SessionsGridOfferingTable extends Component {
     for (key in dateBlocks) {
       dateBlockArray.push(dateBlocks[key]);
     }
-    return sortByNumber(dateBlockArray, 'dateStamp');
+    return sortBy(dateBlockArray, 'dateStamp');
   }
 }

--- a/addon/components/sessions-grid.js
+++ b/addon/components/sessions-grid.js
@@ -71,7 +71,7 @@ export default class SessionsGrid extends Component {
 
   @action
   cancelDelete(sessionId) {
-    this.confirmDeleteSessionIds.removeObject(sessionId);
+    this.confirmDeleteSessionIds = this.confirmDeleteSessionIds.filter((id) => id !== sessionId);
   }
 
   @action

--- a/addon/components/sessions-grid.js
+++ b/addon/components/sessions-grid.js
@@ -66,7 +66,7 @@ export default class SessionsGrid extends Component {
 
   @action
   confirmDelete(sessionId) {
-    this.confirmDeleteSessionIds.push(sessionId);
+    this.confirmDeleteSessionIds = [...this.confirmDeleteSessionIds, sessionId];
   }
 
   @action

--- a/addon/components/sessions-grid.js
+++ b/addon/components/sessions-grid.js
@@ -6,6 +6,7 @@ import { inject as service } from '@ember/service';
 import { next } from '@ember/runloop';
 import escapeRegExp from '../utils/escape-reg-exp';
 import { dropTask } from 'ember-concurrency';
+import { sortBy } from '../utils/array-helpers';
 
 export default class SessionsGrid extends Component {
   @service router;
@@ -40,9 +41,9 @@ export default class SessionsGrid extends Component {
 
   get sortedSessions() {
     if (this.sortInfo.descending) {
-      return this.filteredSessions.sortBy(this.sortInfo.column).reverse();
+      return sortBy(this.filteredSessions, this.sortInfo.column).reverse();
     }
-    return this.filteredSessions.sortBy(this.sortInfo.column);
+    return sortBy(this.filteredSessions, this.sortInfo.column);
   }
 
   get sortInfo() {

--- a/addon/components/sessions-grid.js
+++ b/addon/components/sessions-grid.js
@@ -65,7 +65,7 @@ export default class SessionsGrid extends Component {
 
   @action
   confirmDelete(sessionId) {
-    this.confirmDeleteSessionIds.pushObject(sessionId);
+    this.confirmDeleteSessionIds.push(sessionId);
   }
 
   @action

--- a/addon/components/single-event-objective-list.js
+++ b/addon/components/single-event-objective-list.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { sortByString, uniqueValues } from '../utils/array-helpers';
+import { sortBy, uniqueValues } from '../utils/array-helpers';
 
 export default class SingleEventObjectiveList extends Component {
   @tracked groupByCompetencies = true;
@@ -38,11 +38,11 @@ export default class SingleEventObjectiveList extends Component {
         .map((obj) => {
           return obj.title;
         });
-      domain.objectives = sortByString(filteredObjectives, 'title');
+      domain.objectives = sortBy(filteredObjectives, 'title');
 
       return domain;
     });
 
-    return sortByString(domains, 'title');
+    return sortBy(domains, 'title');
   }
 }

--- a/addon/components/single-event-objective-list.js
+++ b/addon/components/single-event-objective-list.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { sortByString } from '../utils/array-helpers';
+import { sortByString, uniqueValues } from '../utils/array-helpers';
 
 export default class SingleEventObjectiveList extends Component {
   @tracked groupByCompetencies = true;
@@ -24,7 +24,7 @@ export default class SingleEventObjectiveList extends Component {
       return obj.domain.toString();
     });
 
-    domainTitles = domainTitles.uniq();
+    domainTitles = uniqueValues(domainTitles);
 
     const domains = domainTitles.map((title) => {
       const domain = {

--- a/addon/components/single-event-objective-list.js
+++ b/addon/components/single-event-objective-list.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { sortByString } from '../utils/array-helpers';
 
 export default class SingleEventObjectiveList extends Component {
   @tracked groupByCompetencies = true;
@@ -37,11 +38,11 @@ export default class SingleEventObjectiveList extends Component {
         .map((obj) => {
           return obj.title;
         });
-      domain.objectives = filteredObjectives.sortBy('title');
+      domain.objectives = sortByString(filteredObjectives, 'title');
 
       return domain;
     });
 
-    return domains.sortBy('title');
+    return sortByString(domains, 'title');
   }
 }

--- a/addon/components/single-event.js
+++ b/addon/components/single-event.js
@@ -4,6 +4,7 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { isBlank, isEmpty } from '@ember/utils';
 import moment from 'moment';
+import { findById } from '../utils/array-helpers';
 
 export default class SingleEvent extends Component {
   @service currentUser;
@@ -59,11 +60,11 @@ export default class SingleEvent extends Component {
           };
         }
         const competencyId = objective.competencies[0];
-        const competency = competencies.findBy('id', competencyId);
+        const competency = findById(competencies, competencyId);
         const parentId = competency.parent;
         let domain = competency;
         if (!isEmpty(parentId)) {
-          domain = competencies.findBy('id', parentId);
+          domain = findById(competencies, parentId);
         }
         return {
           id: objective.id,
@@ -120,11 +121,11 @@ export default class SingleEvent extends Component {
           };
         }
         const competencyId = objective.competencies[0];
-        const competency = competencies.findBy('id', competencyId);
+        const competency = findById(competencies, competencyId);
         const parentId = competency.parent;
         let domain = competency;
         if (!isEmpty(parentId)) {
-          domain = competencies.findBy('id', parentId);
+          domain = findById(competencies, parentId);
         }
         return {
           id: objective.id,

--- a/addon/components/single-event.js
+++ b/addon/components/single-event.js
@@ -4,7 +4,7 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { isBlank, isEmpty } from '@ember/utils';
 import moment from 'moment';
-import { findById } from '../utils/array-helpers';
+import { filterBy, findById } from '../utils/array-helpers';
 
 export default class SingleEvent extends Component {
   @service currentUser;
@@ -83,7 +83,7 @@ export default class SingleEvent extends Component {
 
   get courseLearningMaterials() {
     const eventLms = this.typedLearningMaterials;
-    return eventLms.filterBy('courseLearningMaterial').sort((lm1, lm2) => {
+    return filterBy(eventLms, 'courseLearningMaterial').sort((lm1, lm2) => {
       const pos1 = parseInt(lm1.position, 10) || 0;
       const pos2 = parseInt(lm2.position, 10) || 0;
 
@@ -139,9 +139,9 @@ export default class SingleEvent extends Component {
 
   get sessionLearningMaterials() {
     const eventLms = this.typedLearningMaterials;
-    return eventLms
-      .filterBy('sessionLearningMaterial')
-      .sort(this.sessionLearningMaterialSortingCalling);
+    return filterBy(eventLms, 'sessionLearningMaterial').sort(
+      this.sessionLearningMaterialSortingCalling
+    );
   }
 
   get preworkMaterials() {
@@ -154,9 +154,10 @@ export default class SingleEvent extends Component {
         slug: ev.slug,
         learningMaterials: [],
       };
-      rhett.learningMaterials = this.getTypedLearningMaterialProxies(ev.learningMaterials)
-        .filterBy('sessionLearningMaterial')
-        .sort(this.sessionLearningMaterialSortingCalling);
+      rhett.learningMaterials = filterBy(
+        this.getTypedLearningMaterialProxies(ev.learningMaterials),
+        'sessionLearningMaterial'
+      ).sort(this.sessionLearningMaterialSortingCalling);
       return rhett;
     });
   }

--- a/addon/components/taxonomy-manager.js
+++ b/addon/components/taxonomy-manager.js
@@ -25,7 +25,7 @@ export default class TaxonomyManager extends Component {
       return [];
     } else {
       return this.args.vocabularies.slice().filter((vocab) => {
-        return vocab.get('termCount') > 0;
+        return vocab.termCount > 0;
       });
     }
   }

--- a/addon/components/taxonomy-manager.js
+++ b/addon/components/taxonomy-manager.js
@@ -63,7 +63,7 @@ export default class TaxonomyManager extends Component {
         return vocab;
       }
     }
-    return this.assignableVocabularies.get('firstObject');
+    return this.assignableVocabularies[0];
   }
 
   @action

--- a/addon/components/taxonomy-manager.js
+++ b/addon/components/taxonomy-manager.js
@@ -24,7 +24,7 @@ export default class TaxonomyManager extends Component {
     if (!this.args.vocabularies) {
       return [];
     } else {
-      return this.args.vocabularies.toArray().filter((vocab) => {
+      return this.args.vocabularies.slice().filter((vocab) => {
         return vocab.get('termCount') > 0;
       });
     }

--- a/addon/components/visualizer-course-instructor-session-type.js
+++ b/addon/components/visualizer-course-instructor-session-type.js
@@ -8,6 +8,7 @@ import { tracked } from '@glimmer/tracking';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import AsyncProcess from 'ilios-common/classes/async-process';
+import { mapBy } from '../utils/array-helpers';
 
 export default class VisualizerCourseInstructorSessionType extends Component {
   @service router;
@@ -32,7 +33,7 @@ export default class VisualizerCourseInstructorSessionType extends Component {
 
     const sessionsWithUser = await filter(sessions.toArray(), async (session) => {
       const allInstructors = await session.getAllOfferingInstructors();
-      return allInstructors.mapBy('id').includes(this.args.user.id);
+      return mapBy(allInstructors, 'id').includes(this.args.user.id);
     });
 
     const sessionsWithSessionType = await map(sessionsWithUser.toArray(), async (session) => {
@@ -71,9 +72,10 @@ export default class VisualizerCourseInstructorSessionType extends Component {
       return set;
     }, []);
 
-    const totalMinutes = sessionTypeData
-      .mapBy('data')
-      .reduce((total, minutes) => total + minutes, 0);
+    const totalMinutes = mapBy(sessionTypeData, 'data').reduce(
+      (total, minutes) => total + minutes,
+      0
+    );
 
     return sessionTypeData.map((obj) => {
       const percent = ((obj.data / totalMinutes) * 100).toFixed(1);

--- a/addon/components/visualizer-course-instructor-session-type.js
+++ b/addon/components/visualizer-course-instructor-session-type.js
@@ -31,12 +31,12 @@ export default class VisualizerCourseInstructorSessionType extends Component {
       return [];
     }
 
-    const sessionsWithUser = await filter(sessions.toArray(), async (session) => {
+    const sessionsWithUser = await filter(sessions.slice(), async (session) => {
       const allInstructors = await session.getAllOfferingInstructors();
       return mapBy(allInstructors, 'id').includes(this.args.user.id);
     });
 
-    const sessionsWithSessionType = await map(sessionsWithUser.toArray(), async (session) => {
+    const sessionsWithSessionType = await map(sessionsWithUser.slice(), async (session) => {
       const sessionType = await session.sessionType;
       return {
         session,

--- a/addon/components/visualizer-course-instructor-session-type.js
+++ b/addon/components/visualizer-course-instructor-session-type.js
@@ -64,10 +64,10 @@ export default class VisualizerCourseInstructorSessionType extends Component {
             sessions: [],
           },
         };
-        set.pushObject(existing);
+        set.push(existing);
       }
       existing.data += obj.minutes;
-      existing.meta.sessions.pushObject(obj.sessionTitle);
+      existing.meta.sessions.push(obj.sessionTitle);
 
       return set;
     }, []);

--- a/addon/components/visualizer-course-instructor-session-type.js
+++ b/addon/components/visualizer-course-instructor-session-type.js
@@ -8,7 +8,7 @@ import { tracked } from '@glimmer/tracking';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import AsyncProcess from 'ilios-common/classes/async-process';
-import { mapBy } from '../utils/array-helpers';
+import { mapBy, uniqueValues } from '../utils/array-helpers';
 
 export default class VisualizerCourseInstructorSessionType extends Component {
   @service router;
@@ -96,6 +96,6 @@ export default class VisualizerCourseInstructorSessionType extends Component {
     const { label, data, meta } = obj;
 
     this.tooltipTitle = htmlSafe(`${label} ${data} ${this.intl.t('general.minutes')}`);
-    this.tooltipContent = meta.sessions.uniq().sort().join(', ');
+    this.tooltipContent = uniqueValues(meta.sessions).sort().join(', ');
   });
 }

--- a/addon/components/visualizer-course-instructor-session-type.js
+++ b/addon/components/visualizer-course-instructor-session-type.js
@@ -8,7 +8,7 @@ import { tracked } from '@glimmer/tracking';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import AsyncProcess from 'ilios-common/classes/async-process';
-import { mapBy, uniqueValues } from '../utils/array-helpers';
+import { findBy, mapBy, uniqueValues } from '../utils/array-helpers';
 
 export default class VisualizerCourseInstructorSessionType extends Component {
   @service router;
@@ -55,7 +55,7 @@ export default class VisualizerCourseInstructorSessionType extends Component {
 
     const sessionTypeData = dataMap.reduce((set, obj) => {
       const name = obj.sessionTypeTitle;
-      let existing = set.findBy('label', name);
+      let existing = findBy(set, 'label', name);
       if (!existing) {
         existing = {
           data: 0,

--- a/addon/components/visualizer-course-instructor-term.js
+++ b/addon/components/visualizer-course-instructor-term.js
@@ -8,7 +8,7 @@ import { tracked } from '@glimmer/tracking';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import AsyncProcess from 'ilios-common/classes/async-process';
-import { mapBy, uniqueValues } from '../utils/array-helpers';
+import { findBy, mapBy, uniqueValues } from '../utils/array-helpers';
 
 export default class VisualizerCourseInstructorTerm extends Component {
   @service router;
@@ -75,7 +75,7 @@ export default class VisualizerCourseInstructorTerm extends Component {
 
     const sessionTermData = flat.reduce((set, obj) => {
       const name = `${obj.vocabularyTitle} > ${obj.termTitle}`;
-      let existing = set.findBy('label', name);
+      let existing = findBy(set, 'label', name);
       if (!existing) {
         existing = {
           data: 0,

--- a/addon/components/visualizer-course-instructor-term.js
+++ b/addon/components/visualizer-course-instructor-term.js
@@ -8,7 +8,7 @@ import { tracked } from '@glimmer/tracking';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import AsyncProcess from 'ilios-common/classes/async-process';
-import { mapBy } from '../utils/array-helpers';
+import { mapBy, uniqueValues } from '../utils/array-helpers';
 
 export default class VisualizerCourseInstructorTerm extends Component {
   @service router;
@@ -119,6 +119,6 @@ export default class VisualizerCourseInstructorTerm extends Component {
     const { label, meta } = obj;
 
     this.tooltipTitle = htmlSafe(label);
-    this.tooltipContent = meta.sessions.uniq().sort().join(', ');
+    this.tooltipContent = uniqueValues(meta.sessions).sort().join(', ');
   });
 }

--- a/addon/components/visualizer-course-instructor-term.js
+++ b/addon/components/visualizer-course-instructor-term.js
@@ -69,9 +69,8 @@ export default class VisualizerCourseInstructorTerm extends Component {
       });
     });
 
-    const flat = dataMap.reduce((flattened, obj) => {
-      flattened.push(...obj);
-      return flattened;
+    const flat = dataMap.reduce((flattened, arr) => {
+      return [...flattened, ...arr];
     }, []);
 
     const sessionTermData = flat.reduce((set, obj) => {

--- a/addon/components/visualizer-course-instructor-term.js
+++ b/addon/components/visualizer-course-instructor-term.js
@@ -70,7 +70,8 @@ export default class VisualizerCourseInstructorTerm extends Component {
     });
 
     const flat = dataMap.reduce((flattened, obj) => {
-      return flattened.push(obj);
+      flattened.push(...obj);
+      return flattened;
     }, []);
 
     const sessionTermData = flat.reduce((set, obj) => {
@@ -85,10 +86,10 @@ export default class VisualizerCourseInstructorTerm extends Component {
             vocabularyTitle: obj.vocabularyTitle,
           },
         };
-        set.pushObject(existing);
+        set.push(existing);
       }
       existing.data += obj.minutes;
-      existing.meta.sessions.pushObject(obj.sessionTitle);
+      existing.meta.sessions.push(obj.sessionTitle);
 
       return set;
     }, []);

--- a/addon/components/visualizer-course-instructor-term.js
+++ b/addon/components/visualizer-course-instructor-term.js
@@ -8,6 +8,7 @@ import { tracked } from '@glimmer/tracking';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import AsyncProcess from 'ilios-common/classes/async-process';
+import { mapBy } from '../utils/array-helpers';
 
 export default class VisualizerCourseInstructorTerm extends Component {
   @service router;
@@ -32,7 +33,7 @@ export default class VisualizerCourseInstructorTerm extends Component {
 
     const sessionsWithUser = await filter(sessions.toArray(), async (session) => {
       const allInstructors = await session.getAllOfferingInstructors();
-      return allInstructors.mapBy('id').includes(this.args.user.id);
+      return mapBy(allInstructors, 'id').includes(this.args.user.id);
     });
 
     const sessionsWithTerms = await map(sessionsWithUser, async (session) => {

--- a/addon/components/visualizer-course-instructor-term.js
+++ b/addon/components/visualizer-course-instructor-term.js
@@ -70,7 +70,7 @@ export default class VisualizerCourseInstructorTerm extends Component {
     });
 
     const flat = dataMap.reduce((flattened, obj) => {
-      return flattened.pushObjects(obj);
+      return flattened.push(obj);
     }, []);
 
     const sessionTermData = flat.reduce((set, obj) => {

--- a/addon/components/visualizer-course-instructor-term.js
+++ b/addon/components/visualizer-course-instructor-term.js
@@ -31,13 +31,13 @@ export default class VisualizerCourseInstructorTerm extends Component {
       return [];
     }
 
-    const sessionsWithUser = await filter(sessions.toArray(), async (session) => {
+    const sessionsWithUser = await filter(sessions.slice(), async (session) => {
       const allInstructors = await session.getAllOfferingInstructors();
       return mapBy(allInstructors, 'id').includes(this.args.user.id);
     });
 
     const sessionsWithTerms = await map(sessionsWithUser, async (session) => {
-      const terms = await map((await session.terms).toArray(), async (term) => {
+      const terms = await map((await session.terms).slice(), async (term) => {
         const vocabulary = await term.vocabulary;
         return {
           termTitle: term.title,

--- a/addon/components/visualizer-course-instructors.js
+++ b/addon/components/visualizer-course-instructors.js
@@ -10,7 +10,7 @@ import { cleanQuery } from 'ilios-common/utils/query-utils';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import AsyncProcess from 'ilios-common/classes/async-process';
-import { mapBy, uniqueValues } from '../utils/array-helpers';
+import { findBy, mapBy, uniqueValues } from '../utils/array-helpers';
 
 export default class VisualizerCourseInstructors extends Component {
   @service router;
@@ -75,7 +75,7 @@ export default class VisualizerCourseInstructors extends Component {
       obj.instructorsWithInstructionalTime.forEach((instructorWithInstructionalTime) => {
         const name = instructorWithInstructionalTime.instructor.get('fullName');
         const id = instructorWithInstructionalTime.instructor.get('id');
-        let existing = set.findBy('label', name);
+        let existing = findBy(set, 'label', name);
         if (!existing) {
           existing = {
             data: 0,

--- a/addon/components/visualizer-course-instructors.js
+++ b/addon/components/visualizer-course-instructors.js
@@ -54,7 +54,7 @@ export default class VisualizerCourseInstructors extends Component {
       return [];
     }
 
-    const sessionsWithInstructors = await map(this.sessions.toArray(), async (session) => {
+    const sessionsWithInstructors = await map(this.sessions.slice(), async (session) => {
       const instructors = await session.getAllInstructors();
       const totalInstructionalTime = await session.getTotalSumOfferingsDuration();
       const instructorsWithInstructionalTime = await map(instructors, async (instructor) => {

--- a/addon/components/visualizer-course-instructors.js
+++ b/addon/components/visualizer-course-instructors.js
@@ -85,10 +85,10 @@ export default class VisualizerCourseInstructors extends Component {
               sessions: [],
             },
           };
-          set.pushObject(existing);
+          set.push(existing);
         }
         existing.data += instructorWithInstructionalTime.minutes;
-        existing.meta.sessions.pushObject(obj.sessionTitle);
+        existing.meta.sessions.push(obj.sessionTitle);
       });
 
       return set;

--- a/addon/components/visualizer-course-instructors.js
+++ b/addon/components/visualizer-course-instructors.js
@@ -10,6 +10,7 @@ import { cleanQuery } from 'ilios-common/utils/query-utils';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import AsyncProcess from 'ilios-common/classes/async-process';
+import { mapBy } from '../utils/array-helpers';
 
 export default class VisualizerCourseInstructors extends Component {
   @service router;
@@ -93,9 +94,10 @@ export default class VisualizerCourseInstructors extends Component {
       return set;
     }, []);
 
-    const totalMinutes = sessionsWithInstructors
-      .mapBy('totalInstructionalTime')
-      .reduce((total, minutes) => total + minutes, 0);
+    const totalMinutes = mapBy(sessionsWithInstructors, 'totalInstructionalTime').reduce(
+      (total, minutes) => total + minutes,
+      0
+    );
     return instructorData.map((obj) => {
       const percent = ((obj.data / totalMinutes) * 100).toFixed(1);
       obj.label = `${obj.label}: ${obj.data} ${this.intl.t('general.minutes')}`;

--- a/addon/components/visualizer-course-instructors.js
+++ b/addon/components/visualizer-course-instructors.js
@@ -10,7 +10,7 @@ import { cleanQuery } from 'ilios-common/utils/query-utils';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import AsyncProcess from 'ilios-common/classes/async-process';
-import { mapBy } from '../utils/array-helpers';
+import { mapBy, uniqueValues } from '../utils/array-helpers';
 
 export default class VisualizerCourseInstructors extends Component {
   @service router;
@@ -115,7 +115,7 @@ export default class VisualizerCourseInstructors extends Component {
       return;
     }
     const { label, meta } = obj;
-    const sessions = meta.sessions.uniq().sort().join(', ');
+    const sessions = uniqueValues(meta.sessions).sort().join(', ');
     this.tooltipTitle = htmlSafe(label);
     this.tooltipContent = htmlSafe(sessions + '<br /><br />' + this.intl.t('general.clickForMore'));
   });

--- a/addon/components/visualizer-course-objectives.js
+++ b/addon/components/visualizer-course-objectives.js
@@ -70,9 +70,8 @@ export default class VisualizerCourseObjectives extends Component {
             return mapBy(parents.slice(), 'id');
           }
         );
-        const flatObjectives = courseSessionObjectives.reduce((flattened, obj) => {
-          flattened.push(...obj.slice());
-          return flattened;
+        const flatObjectives = courseSessionObjectives.reduce((flattened, arr) => {
+          return [...flattened, ...arr];
         }, []);
 
         return {

--- a/addon/components/visualizer-course-objectives.js
+++ b/addon/components/visualizer-course-objectives.js
@@ -71,7 +71,7 @@ export default class VisualizerCourseObjectives extends Component {
           }
         );
         const flatObjectives = courseSessionObjectives.reduce((flattened, obj) => {
-          return flattened.pushObjects(obj.slice());
+          return flattened.push(obj.slice());
         }, []);
 
         return {

--- a/addon/components/visualizer-course-objectives.js
+++ b/addon/components/visualizer-course-objectives.js
@@ -71,7 +71,8 @@ export default class VisualizerCourseObjectives extends Component {
           }
         );
         const flatObjectives = courseSessionObjectives.reduce((flattened, obj) => {
-          return flattened.push(obj.slice());
+          flattened.push(...obj.slice());
+          return flattened;
         }, []);
 
         return {

--- a/addon/components/visualizer-course-objectives.js
+++ b/addon/components/visualizer-course-objectives.js
@@ -7,6 +7,7 @@ import { tracked } from '@glimmer/tracking';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import AsyncProcess from 'ilios-common/classes/async-process';
+import { mapBy } from '../utils/array-helpers';
 
 export default class VisualizerCourseObjectives extends Component {
   @service router;
@@ -66,7 +67,7 @@ export default class VisualizerCourseObjectives extends Component {
           sessionObjectivesWithParents,
           async (sessionObjective) => {
             const parents = await sessionObjective.courseObjectives;
-            return parents.mapBy('id');
+            return mapBy(parents.slice(), 'id');
           }
         );
         const flatObjectives = courseSessionObjectives.reduce((flattened, obj) => {
@@ -106,9 +107,10 @@ export default class VisualizerCourseObjectives extends Component {
       };
     });
 
-    const totalMinutes = mappedObjectives
-      .mapBy('data')
-      .reduce((total, minutes) => total + minutes, 0);
+    const totalMinutes = mapBy(mappedObjectives, 'data').reduce(
+      (total, minutes) => total + minutes,
+      0
+    );
 
     return mappedObjectives.map((obj) => {
       const percent = ((obj.data / totalMinutes) * 100).toFixed(1);
@@ -136,7 +138,7 @@ export default class VisualizerCourseObjectives extends Component {
     }
 
     const title = htmlSafe(`${objectiveTitle} &bull; ${data} ${this.intl.t('general.minutes')}`);
-    const sessionTitles = meta.sessionObjectives.mapBy('sessionTitle');
+    const sessionTitles = mapBy(meta.sessionObjectives, 'sessionTitle');
     const content = sessionTitles.join(', ');
 
     this.tooltipTitle = title;

--- a/addon/components/visualizer-course-objectives.js
+++ b/addon/components/visualizer-course-objectives.js
@@ -7,7 +7,7 @@ import { tracked } from '@glimmer/tracking';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import AsyncProcess from 'ilios-common/classes/async-process';
-import { mapBy } from '../utils/array-helpers';
+import { filterBy, mapBy } from '../utils/array-helpers';
 
 export default class VisualizerCourseObjectives extends Component {
   @service router;
@@ -33,7 +33,7 @@ export default class VisualizerCourseObjectives extends Component {
   }
 
   get objectiveWithoutMinutes() {
-    return this.dataObjects?.filterBy('data', 0);
+    return filterBy(this.dataObjects, 'data', 0);
   }
 
   get isLoaded() {

--- a/addon/components/visualizer-course-objectives.js
+++ b/addon/components/visualizer-course-objectives.js
@@ -25,7 +25,7 @@ export default class VisualizerCourseObjectives extends Component {
       return [];
     }
 
-    return this.courseSessions.toArray();
+    return this.courseSessions.slice();
   }
 
   get objectiveWithMinutes() {
@@ -57,7 +57,7 @@ export default class VisualizerCourseObjectives extends Component {
       async ({ session, minutes }) => {
         const sessionObjectives = await session.sessionObjectives;
         const sessionObjectivesWithParents = await filter(
-          sessionObjectives.toArray(),
+          sessionObjectives.slice(),
           async (sessionObjective) => {
             const parents = await sessionObjective.courseObjectives;
             return parents.length;
@@ -71,7 +71,7 @@ export default class VisualizerCourseObjectives extends Component {
           }
         );
         const flatObjectives = courseSessionObjectives.reduce((flattened, obj) => {
-          return flattened.pushObjects(obj.toArray());
+          return flattened.pushObjects(obj.slice());
         }, []);
 
         return {
@@ -84,7 +84,7 @@ export default class VisualizerCourseObjectives extends Component {
 
     // condensed objectives map
     const courseObjectives = await this.args.course.courseObjectives;
-    const mappedObjectives = courseObjectives.toArray().map((courseObjective) => {
+    const mappedObjectives = courseObjectives.slice().map((courseObjective) => {
       const minutes = sessionCourseObjectiveMap.map((obj) => {
         if (obj.objectives.includes(courseObjective.get('id'))) {
           return obj.minutes;
@@ -128,7 +128,7 @@ export default class VisualizerCourseObjectives extends Component {
     const { data, meta } = obj;
 
     let objectiveTitle = meta.courseObjective.title;
-    const programYearObjectives = (await meta.courseObjective.programYearObjectives).toArray();
+    const programYearObjectives = (await meta.courseObjective.programYearObjectives).slice();
     let competency;
     if (programYearObjectives.length) {
       competency = await programYearObjectives[0].competency;

--- a/addon/components/visualizer-course-session-type.js
+++ b/addon/components/visualizer-course-session-type.js
@@ -65,7 +65,7 @@ export default class VisualizerCourseSessionType extends Component {
     });
 
     return termData.reduce((flattened, obj) => {
-      return flattened.pushObjects(obj.slice());
+      return flattened.push(obj.slice());
     }, []);
   }
 

--- a/addon/components/visualizer-course-session-type.js
+++ b/addon/components/visualizer-course-session-type.js
@@ -9,7 +9,7 @@ import { tracked } from '@glimmer/tracking';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import AsyncProcess from 'ilios-common/classes/async-process';
-import { mapBy } from '../utils/array-helpers';
+import { mapBy, uniqueValues } from '../utils/array-helpers';
 
 export default class VisualizerCourseSessionType extends Component {
   @service router;
@@ -121,6 +121,6 @@ export default class VisualizerCourseSessionType extends Component {
     const { label, meta } = obj;
 
     this.tooltipTitle = htmlSafe(label);
-    this.tooltipContent = meta.sessions.uniq().sort().join(', ');
+    this.tooltipContent = uniqueValues(meta.sessions).sort().join(', ');
   });
 }

--- a/addon/components/visualizer-course-session-type.js
+++ b/addon/components/visualizer-course-session-type.js
@@ -9,7 +9,7 @@ import { tracked } from '@glimmer/tracking';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import AsyncProcess from 'ilios-common/classes/async-process';
-import { mapBy, uniqueValues } from '../utils/array-helpers';
+import { findBy, mapBy, uniqueValues } from '../utils/array-helpers';
 
 export default class VisualizerCourseSessionType extends Component {
   @service router;
@@ -72,7 +72,7 @@ export default class VisualizerCourseSessionType extends Component {
   get data() {
     const data = this.dataObjects.reduce((set, obj) => {
       const label = obj.vocabularyTitle + ' - ' + obj.termTitle;
-      let existing = set.findBy('label', label);
+      let existing = findBy(set, 'label', label);
       if (!existing) {
         existing = {
           data: 0,

--- a/addon/components/visualizer-course-session-type.js
+++ b/addon/components/visualizer-course-session-type.js
@@ -65,7 +65,8 @@ export default class VisualizerCourseSessionType extends Component {
     });
 
     return termData.reduce((flattened, obj) => {
-      return flattened.push(obj.slice());
+      flattened.push(...obj.slice());
+      return flattened;
     }, []);
   }
 
@@ -82,10 +83,10 @@ export default class VisualizerCourseSessionType extends Component {
             sessions: [],
           },
         };
-        set.pushObject(existing);
+        set.push(existing);
       }
       existing.data += obj.minutes;
-      existing.meta.sessions.pushObject(obj.sessionTitle);
+      existing.meta.sessions.push(obj.sessionTitle);
 
       return set;
     }, []);

--- a/addon/components/visualizer-course-session-type.js
+++ b/addon/components/visualizer-course-session-type.js
@@ -64,9 +64,8 @@ export default class VisualizerCourseSessionType extends Component {
       });
     });
 
-    return termData.reduce((flattened, obj) => {
-      flattened.push(...obj.slice());
-      return flattened;
+    return termData.reduce((flattened, arr) => {
+      return [...flattened, ...arr];
     }, []);
   }
 

--- a/addon/components/visualizer-course-session-type.js
+++ b/addon/components/visualizer-course-session-type.js
@@ -30,8 +30,8 @@ export default class VisualizerCourseSessionType extends Component {
       sessionTypeSessions: [],
     };
     if (this.sessions && this.sessionTypeSessions) {
-      rhett.sessions = this.sessions.toArray();
-      rhett.sessionTypeSessions = this.sessionTypeSessions.toArray();
+      rhett.sessions = this.sessions.slice();
+      rhett.sessionTypeSessions = this.sessionTypeSessions.slice();
     }
     return rhett;
   }
@@ -52,7 +52,7 @@ export default class VisualizerCourseSessionType extends Component {
     });
 
     const termData = await map(sessionsWithMinutes, async ({ session, minutes }) => {
-      const terms = (await session.terms).toArray();
+      const terms = (await session.terms).slice();
       return map(terms, async (term) => {
         const vocabulary = await term.vocabulary;
         return {
@@ -65,7 +65,7 @@ export default class VisualizerCourseSessionType extends Component {
     });
 
     return termData.reduce((flattened, obj) => {
-      return flattened.pushObjects(obj.toArray());
+      return flattened.pushObjects(obj.slice());
     }, []);
   }
 

--- a/addon/components/visualizer-course-session-type.js
+++ b/addon/components/visualizer-course-session-type.js
@@ -9,6 +9,7 @@ import { tracked } from '@glimmer/tracking';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import AsyncProcess from 'ilios-common/classes/async-process';
+import { mapBy } from '../utils/array-helpers';
 
 export default class VisualizerCourseSessionType extends Component {
   @service router;
@@ -89,7 +90,7 @@ export default class VisualizerCourseSessionType extends Component {
       return set;
     }, []);
 
-    const totalMinutes = data.mapBy('data').reduce((total, minutes) => total + minutes, 0);
+    const totalMinutes = mapBy(data, 'data').reduce((total, minutes) => total + minutes, 0);
     return data
       .map((obj) => {
         const percent = ((obj.data / totalMinutes) * 100).toFixed(1);

--- a/addon/components/visualizer-course-session-types.js
+++ b/addon/components/visualizer-course-session-types.js
@@ -51,7 +51,7 @@ export default class VisualizerCourseSessionTypes extends Component {
       return [];
     }
 
-    const dataMap = await map(sessions.toArray(), async (session) => {
+    const dataMap = await map(sessions.slice(), async (session) => {
       const hours = await session.getTotalSumDuration();
       const minutes = Math.round(hours * 60);
       const sessionType = await session.sessionType;

--- a/addon/components/visualizer-course-session-types.js
+++ b/addon/components/visualizer-course-session-types.js
@@ -9,6 +9,7 @@ import { map } from 'rsvp';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import AsyncProcess from 'ilios-common/classes/async-process';
+import { mapBy } from '../utils/array-helpers';
 
 export default class VisualizerCourseSessionTypes extends Component {
   @service router;
@@ -82,9 +83,10 @@ export default class VisualizerCourseSessionTypes extends Component {
       return set;
     }, []);
 
-    const totalMinutes = mappedSessionTypes
-      .mapBy('data')
-      .reduce((total, minutes) => total + minutes, 0);
+    const totalMinutes = mapBy(mappedSessionTypes, 'data').reduce(
+      (total, minutes) => total + minutes,
+      0
+    );
     return mappedSessionTypes
       .map((obj) => {
         const percent = ((obj.data / totalMinutes) * 100).toFixed(1);

--- a/addon/components/visualizer-course-session-types.js
+++ b/addon/components/visualizer-course-session-types.js
@@ -75,10 +75,10 @@ export default class VisualizerCourseSessionTypes extends Component {
             sessions: [],
           },
         };
-        set.pushObject(existing);
+        set.push(existing);
       }
       existing.data += obj.minutes;
-      existing.meta.sessions.pushObject(obj.sessionTitle);
+      existing.meta.sessions.push(obj.sessionTitle);
 
       return set;
     }, []);

--- a/addon/components/visualizer-course-session-types.js
+++ b/addon/components/visualizer-course-session-types.js
@@ -9,7 +9,7 @@ import { map } from 'rsvp';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import AsyncProcess from 'ilios-common/classes/async-process';
-import { mapBy } from '../utils/array-helpers';
+import { mapBy, uniqueValues } from '../utils/array-helpers';
 
 export default class VisualizerCourseSessionTypes extends Component {
   @service router;
@@ -110,7 +110,7 @@ export default class VisualizerCourseSessionTypes extends Component {
     const { label, meta } = obj;
 
     const title = htmlSafe(label);
-    const sessions = meta.sessions.uniq().sort().join(', ');
+    const sessions = uniqueValues(meta.sessions).sort().join(', ');
 
     this.tooltipTitle = title;
     this.tooltipContent = sessions;

--- a/addon/components/visualizer-course-session-types.js
+++ b/addon/components/visualizer-course-session-types.js
@@ -9,7 +9,7 @@ import { map } from 'rsvp';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import AsyncProcess from 'ilios-common/classes/async-process';
-import { mapBy, uniqueValues } from '../utils/array-helpers';
+import { findBy, mapBy, uniqueValues } from '../utils/array-helpers';
 
 export default class VisualizerCourseSessionTypes extends Component {
   @service router;
@@ -64,7 +64,7 @@ export default class VisualizerCourseSessionTypes extends Component {
     });
 
     const mappedSessionTypes = dataMap.reduce((set, obj) => {
-      let existing = set.findBy('label', obj.sessionTypeTitle);
+      let existing = findBy(set, 'label', obj.sessionTypeTitle);
       if (!existing) {
         existing = {
           data: 0,

--- a/addon/components/visualizer-course-term.js
+++ b/addon/components/visualizer-course-term.js
@@ -6,7 +6,7 @@ import { tracked } from '@glimmer/tracking';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
-import { mapBy, uniqueValues } from '../utils/array-helpers';
+import { findBy, findById, mapBy, uniqueValues } from '../utils/array-helpers';
 
 export default class VisualizerCourseTerm extends Component {
   @service router;
@@ -32,7 +32,7 @@ export default class VisualizerCourseTerm extends Component {
   get data() {
     const sessionTypeData = this.termSessionsInCourse.map((session) => {
       const minutes = Math.round(session.totalSumDuration * 60);
-      const sessionType = this.sessionTypes.findBy('id', session.belongsTo('sessionType').id());
+      const sessionType = findById(this.sessionTypes, session.belongsTo('sessionType').id());
       return {
         sessionTitle: session.title,
         sessionTypeTitle: sessionType.title,
@@ -41,7 +41,7 @@ export default class VisualizerCourseTerm extends Component {
     });
 
     const data = sessionTypeData.reduce((set, obj) => {
-      let existing = set.findBy('label', obj.sessionTypeTitle);
+      let existing = findBy(set, 'label', obj.sessionTypeTitle);
       if (!existing) {
         existing = {
           data: 0,

--- a/addon/components/visualizer-course-term.js
+++ b/addon/components/visualizer-course-term.js
@@ -6,7 +6,7 @@ import { tracked } from '@glimmer/tracking';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
-import { mapBy } from '../utils/array-helpers';
+import { mapBy, uniqueValues } from '../utils/array-helpers';
 
 export default class VisualizerCourseTerm extends Component {
   @service router;
@@ -80,6 +80,6 @@ export default class VisualizerCourseTerm extends Component {
     const { label, data, meta } = obj;
 
     this.tooltipTitle = htmlSafe(`${label} ${data} ${this.intl.t('general.minutes')}`);
-    this.tooltipContent = meta.sessions.uniq().sort().join(', ');
+    this.tooltipContent = uniqueValues(meta.sessions).sort().join(', ');
   });
 }

--- a/addon/components/visualizer-course-term.js
+++ b/addon/components/visualizer-course-term.js
@@ -6,6 +6,7 @@ import { tracked } from '@glimmer/tracking';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
+import { mapBy } from '../utils/array-helpers';
 
 export default class VisualizerCourseTerm extends Component {
   @service router;
@@ -58,7 +59,7 @@ export default class VisualizerCourseTerm extends Component {
       return set;
     }, []);
 
-    const totalMinutes = data.mapBy('data').reduce((total, minutes) => total + minutes, 0);
+    const totalMinutes = mapBy(data, 'data').reduce((total, minutes) => total + minutes, 0);
 
     return data.map((obj) => {
       const percent = ((obj.data / totalMinutes) * 100).toFixed(1);

--- a/addon/components/visualizer-course-term.js
+++ b/addon/components/visualizer-course-term.js
@@ -51,10 +51,10 @@ export default class VisualizerCourseTerm extends Component {
             sessions: [],
           },
         };
-        set.pushObject(existing);
+        set.push(existing);
       }
       existing.data += obj.minutes;
-      existing.meta.sessions.pushObject(obj.sessionTitle);
+      existing.meta.sessions.push(obj.sessionTitle);
 
       return set;
     }, []);

--- a/addon/components/visualizer-course-vocabularies.js
+++ b/addon/components/visualizer-course-vocabularies.js
@@ -8,7 +8,7 @@ import { action } from '@ember/object';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import AsyncProcess from 'ilios-common/classes/async-process';
-import { mapBy } from '../utils/array-helpers';
+import { findBy, mapBy } from '../utils/array-helpers';
 
 export default class VisualizerCourseVocabularies extends Component {
   @service router;
@@ -50,7 +50,7 @@ export default class VisualizerCourseVocabularies extends Component {
     return this.dataObjects.reduce((set, obj) => {
       obj.vocabularies.forEach((vocabulary) => {
         const vocabularyTitle = vocabulary.get('title');
-        let existing = set.findBy('label', vocabularyTitle);
+        let existing = findBy(set, 'label', vocabularyTitle);
         if (!existing) {
           existing = {
             data: 0,

--- a/addon/components/visualizer-course-vocabularies.js
+++ b/addon/components/visualizer-course-vocabularies.js
@@ -28,7 +28,7 @@ export default class VisualizerCourseVocabularies extends Component {
     if (!sessions) {
       return [];
     }
-    const sessionsWithMinutes = await map(sessions.toArray(), async (session) => {
+    const sessionsWithMinutes = await map(sessions.slice(), async (session) => {
       const hours = await session.getTotalSumDuration();
       return {
         session,

--- a/addon/components/visualizer-course-vocabularies.js
+++ b/addon/components/visualizer-course-vocabularies.js
@@ -8,6 +8,7 @@ import { action } from '@ember/object';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import AsyncProcess from 'ilios-common/classes/async-process';
+import { mapBy } from '../utils/array-helpers';
 
 export default class VisualizerCourseVocabularies extends Component {
   @service router;
@@ -35,8 +36,8 @@ export default class VisualizerCourseVocabularies extends Component {
       };
     });
     return map(sessionsWithMinutes, async ({ session, minutes }) => {
-      const terms = await session.terms;
-      const vocabularies = await all(terms.mapBy('vocabulary'));
+      const terms = (await session.terms).slice();
+      const vocabularies = await all(mapBy(terms, 'vocabulary'));
       return {
         sessionTitle: session.title,
         vocabularies,

--- a/addon/components/visualizer-course-vocabularies.js
+++ b/addon/components/visualizer-course-vocabularies.js
@@ -60,10 +60,10 @@ export default class VisualizerCourseVocabularies extends Component {
               sessions: [],
             },
           };
-          set.pushObject(existing);
+          set.push(existing);
         }
         existing.data += obj.minutes;
-        existing.meta.sessions.pushObject(obj.sessionTitle);
+        existing.meta.sessions.push(obj.sessionTitle);
       });
 
       return set;

--- a/addon/components/visualizer-course-vocabulary.js
+++ b/addon/components/visualizer-course-vocabulary.js
@@ -53,7 +53,8 @@ export default class VisualizerCourseVocabulary extends Component {
     });
 
     return terms.reduce((flattened, obj) => {
-      return flattened.push(obj.slice());
+      flattened.push(...obj.slice());
+      return flattened;
     }, []);
   }
 
@@ -71,10 +72,10 @@ export default class VisualizerCourseVocabulary extends Component {
             sessions: [],
           },
         };
-        set.pushObject(existing);
+        set.push(existing);
       }
       existing.data += session.minutes;
-      existing.meta.sessions.pushObject(session.title);
+      existing.meta.sessions.push(session.title);
 
       return set;
     }, []);

--- a/addon/components/visualizer-course-vocabulary.js
+++ b/addon/components/visualizer-course-vocabulary.js
@@ -52,9 +52,8 @@ export default class VisualizerCourseVocabulary extends Component {
       });
     });
 
-    return terms.reduce((flattened, obj) => {
-      flattened.push(...obj.slice());
-      return flattened;
+    return terms.reduce((flattened, arr) => {
+      return [...flattened, ...arr];
     }, []);
   }
 

--- a/addon/components/visualizer-course-vocabulary.js
+++ b/addon/components/visualizer-course-vocabulary.js
@@ -53,7 +53,7 @@ export default class VisualizerCourseVocabulary extends Component {
     });
 
     return terms.reduce((flattened, obj) => {
-      return flattened.pushObjects(obj.slice());
+      return flattened.push(obj.slice());
     }, []);
   }
 

--- a/addon/components/visualizer-course-vocabulary.js
+++ b/addon/components/visualizer-course-vocabulary.js
@@ -8,6 +8,7 @@ import { action } from '@ember/object';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import AsyncProcess from 'ilios-common/classes/async-process';
+import { mapBy } from '../utils/array-helpers';
 
 export default class VisualizerCourseVocabulary extends Component {
   @service router;
@@ -78,7 +79,7 @@ export default class VisualizerCourseVocabulary extends Component {
       return set;
     }, []);
 
-    const totalMinutes = termData.mapBy('data').reduce((total, minutes) => total + minutes, 0);
+    const totalMinutes = mapBy(termData, 'data').reduce((total, minutes) => total + minutes, 0);
     const mappedTermsWithLabel = termData.map((obj) => {
       const percent = ((obj.data / totalMinutes) * 100).toFixed(1);
       obj.label = `${obj.meta.termTitle}: ${obj.data} ${this.intl.t('general.minutes')}`;

--- a/addon/components/visualizer-course-vocabulary.js
+++ b/addon/components/visualizer-course-vocabulary.js
@@ -8,7 +8,7 @@ import { action } from '@ember/object';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import AsyncProcess from 'ilios-common/classes/async-process';
-import { mapBy, uniqueValues } from '../utils/array-helpers';
+import { findBy, mapBy, uniqueValues } from '../utils/array-helpers';
 
 export default class VisualizerCourseVocabulary extends Component {
   @service router;
@@ -60,7 +60,7 @@ export default class VisualizerCourseVocabulary extends Component {
   get data() {
     const termData = this.dataObjects.reduce((set, { term, session }) => {
       const termTitle = term.get('title');
-      let existing = set.findBy('label', termTitle);
+      let existing = findBy(set, 'label', termTitle);
       if (!existing) {
         existing = {
           data: 0,

--- a/addon/components/visualizer-course-vocabulary.js
+++ b/addon/components/visualizer-course-vocabulary.js
@@ -28,7 +28,7 @@ export default class VisualizerCourseVocabulary extends Component {
     if (!sessions) {
       return [];
     }
-    const sessionsWithMinutes = await map(sessions.toArray(), async (session) => {
+    const sessionsWithMinutes = await map(sessions.slice(), async (session) => {
       const hours = await session.getTotalSumDuration();
       return {
         session,
@@ -37,7 +37,7 @@ export default class VisualizerCourseVocabulary extends Component {
     });
     const terms = await map(sessionsWithMinutes, async ({ session, minutes }) => {
       const sessionTerms = await session.get('terms');
-      const sessionTermsInThisVocabulary = await filter(sessionTerms.toArray(), async (term) => {
+      const sessionTermsInThisVocabulary = await filter(sessionTerms.slice(), async (term) => {
         const termVocab = await term.get('vocabulary');
         return termVocab.get('id') === this.args.vocabulary.get('id');
       });
@@ -53,7 +53,7 @@ export default class VisualizerCourseVocabulary extends Component {
     });
 
     return terms.reduce((flattened, obj) => {
-      return flattened.pushObjects(obj.toArray());
+      return flattened.pushObjects(obj.slice());
     }, []);
   }
 

--- a/addon/components/visualizer-course-vocabulary.js
+++ b/addon/components/visualizer-course-vocabulary.js
@@ -8,7 +8,7 @@ import { action } from '@ember/object';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import AsyncProcess from 'ilios-common/classes/async-process';
-import { mapBy } from '../utils/array-helpers';
+import { mapBy, uniqueValues } from '../utils/array-helpers';
 
 export default class VisualizerCourseVocabulary extends Component {
   @service router;
@@ -103,7 +103,7 @@ export default class VisualizerCourseVocabulary extends Component {
     const { label, meta } = obj;
 
     this.tooltipTitle = htmlSafe(label);
-    this.tooltipContent = meta.sessions.uniq().sort().join(', ');
+    this.tooltipContent = uniqueValues(meta.sessions).sort().join(', ');
   });
 
   @action

--- a/addon/components/week-glance-event.js
+++ b/addon/components/week-glance-event.js
@@ -1,11 +1,12 @@
 import Component from '@glimmer/component';
+import { filterBy } from '../utils/array-helpers';
 
 export default class WeekGlanceEvent extends Component {
   sortString(a, b) {
     return a.localeCompare(b);
   }
   get sessionLearningMaterials() {
-    return this.args.event.learningMaterials?.filterBy('sessionLearningMaterial') ?? [];
+    return filterBy(this.args.event.learningMaterials, 'sessionLearningMaterial') ?? [];
   }
 
   get preworkEvents() {
@@ -18,9 +19,10 @@ export default class WeekGlanceEvent extends Component {
         slug: ev.slug,
         learningMaterials: [],
       };
-      rhett.learningMaterials = this.getTypedLearningMaterialProxies(ev.learningMaterials)
-        .filterBy('sessionLearningMaterial')
-        .sort(this.sessionLearningMaterialSortingCalling);
+      rhett.learningMaterials = filterBy(
+        this.getTypedLearningMaterialProxies(ev.learningMaterials),
+        'sessionLearningMaterial'
+      ).sort(this.sessionLearningMaterialSortingCalling);
       return rhett;
     });
   }

--- a/addon/components/week-glance-event.js
+++ b/addon/components/week-glance-event.js
@@ -6,7 +6,7 @@ export default class WeekGlanceEvent extends Component {
     return a.localeCompare(b);
   }
   get sessionLearningMaterials() {
-    return filterBy(this.args.event.learningMaterials, 'sessionLearningMaterial') ?? [];
+    return filterBy(this.args.event.learningMaterials ?? [], 'sessionLearningMaterial');
   }
 
   get preworkEvents() {

--- a/addon/components/weekly-calendar.js
+++ b/addon/components/weekly-calendar.js
@@ -3,7 +3,7 @@ import { inject as service } from '@ember/service';
 import { restartableTask, timeout } from 'ember-concurrency';
 import { action, set } from '@ember/object';
 import moment from 'moment';
-import { sortByDate, sortByString } from '../utils/array-helpers';
+import { sortBy } from '../utils/array-helpers';
 
 export default class WeeklyCalendarComponent extends Component {
   @service intl;
@@ -56,7 +56,7 @@ export default class WeeklyCalendarComponent extends Component {
       return [];
     }
 
-    return sortByDate(sortByDate(sortByString(this.args.events, 'name'), 'endDate'), 'startDate');
+    return sortBy(this.args.events, ['name', 'endDate', 'startDate']);
   }
 
   get eventDays() {

--- a/addon/components/weekly-calendar.js
+++ b/addon/components/weekly-calendar.js
@@ -56,7 +56,7 @@ export default class WeeklyCalendarComponent extends Component {
       return [];
     }
 
-    return sortBy(this.args.events, ['name', 'endDate', 'startDate']);
+    return sortBy(this.args.events, ['startDate', 'endDate', 'name']);
   }
 
   get eventDays() {

--- a/addon/components/weekly-calendar.js
+++ b/addon/components/weekly-calendar.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import { restartableTask, timeout } from 'ember-concurrency';
 import { action, set } from '@ember/object';
 import moment from 'moment';
+import { sortByDate, sortByString } from '../utils/array-helpers';
 
 export default class WeeklyCalendarComponent extends Component {
   @service intl;
@@ -55,7 +56,7 @@ export default class WeeklyCalendarComponent extends Component {
       return [];
     }
 
-    return this.args.events.sortBy('startDate', 'endDate', 'name');
+    return sortByDate(sortByDate(sortByString(this.args.events, 'name'), 'endDate'), 'startDate');
   }
 
   get eventDays() {

--- a/addon/controllers/dashboard/calendar.js
+++ b/addon/controllers/dashboard/calendar.js
@@ -107,7 +107,7 @@ export default class DashboardCalendarController extends Controller {
     if (str) {
       const idArray = str.split('-');
       if (idArray.includes(id)) {
-        idArray.removeObject(id);
+        idArray.splice(idArray.indexOf(id), 1);
         this[what] = idArray.join('-');
       }
     }

--- a/addon/controllers/dashboard/calendar.js
+++ b/addon/controllers/dashboard/calendar.js
@@ -3,6 +3,7 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import moment from 'moment';
+import { findById } from '../../utils/array-helpers';
 
 export default class DashboardCalendarController extends Controller {
   @service currentUser;
@@ -37,8 +38,7 @@ export default class DashboardCalendarController extends Controller {
 
   get selectedSchool() {
     const { schools } = this.model;
-
-    return schools.findBy('id', this.school);
+    return findById(schools, this.school);
   }
 
   get selectedDate() {

--- a/addon/controllers/weeklyevents.js
+++ b/addon/controllers/weeklyevents.js
@@ -19,8 +19,7 @@ export default class WeeklyeventsController extends Controller {
 
   @action
   toggleOpenWeek(week, shouldOpen) {
-    const arr = this.expandedWeeks;
-    arr.removeObject(week);
+    const arr = this.expandedWeeks.filter((w) => w !== week);
     this.week = '';
     if (shouldOpen) {
       arr.push(week);

--- a/addon/controllers/weeklyevents.js
+++ b/addon/controllers/weeklyevents.js
@@ -23,7 +23,7 @@ export default class WeeklyeventsController extends Controller {
     arr.removeObject(week);
     this.week = '';
     if (shouldOpen) {
-      arr.pushObject(week);
+      arr.push(week);
       this.week = week;
     }
     arr.sort();

--- a/addon/helpers/sort-by-position.js
+++ b/addon/helpers/sort-by-position.js
@@ -6,5 +6,5 @@ export default helper(function sortByPosition([list]) {
   if (isBlank(list)) {
     return [];
   }
-  return list.toArray().sort(sortableByPosition);
+  return list.slice().sort(sortableByPosition);
 });

--- a/addon/models/cohort.js
+++ b/addon/models/cohort.js
@@ -50,7 +50,7 @@ export default class CohortModel extends Model {
 
   async _getRootLevelLearnerGroups(learnerGroups) {
     return (await learnerGroups)
-      .toArray()
+      .slice()
       .filter((learnerGroup) => learnerGroup.belongsTo('parent').value() === null);
   }
 

--- a/addon/models/competency.js
+++ b/addon/models/competency.js
@@ -73,6 +73,6 @@ export default class CompetencyModel extends Model {
 
   async _treeChildren() {
     const children = await this.children;
-    return children.toArray();
+    return children.slice();
   }
 }

--- a/addon/models/course-objective.js
+++ b/addon/models/course-objective.js
@@ -70,7 +70,7 @@ export default class CourseObjective extends Model {
    * if they belong to any program years in the given list.
    */
   async removeParentWithProgramYears(programYearsToRemove) {
-    const programYearObjectives = (await this.programYearObjectives).toArray();
+    const programYearObjectives = (await this.programYearObjectives).slice();
 
     await map(programYearObjectives, async (programYearObjective) => {
       const programYear = await programYearObjective.programYear;

--- a/addon/models/course-objective.js
+++ b/addon/models/course-objective.js
@@ -49,19 +49,19 @@ export default class CourseObjective extends Model {
 
   @use _allTermVocabularies = new ResolveFlatMapBy(() => [this.terms, 'vocabulary']);
   get associatedVocabularies() {
-    return sortBy(uniqueValues(this._allTermVocabularies), 'title');
+    return sortBy(uniqueValues(this._allTermVocabularies ?? []), 'title');
   }
 
   @use _programYearObjectives = new ResolveAsyncValue(() => [this.programYearObjectives]);
   @use allTermCompetencies = new ResolveAsyncValue(() => [
-    mapBy(this._programYearObjectives?.slice(), 'competency'),
+    mapBy(this._programYearObjectives?.slice() ?? [], 'competency'),
   ]);
 
   /**
    * All competencies associated with any program-year objectives linked to this course objective.
    */
   get treeCompetencies() {
-    return uniqueValues(this.allTermCompetencies);
+    return uniqueValues(this.allTermCompetencies ?? []);
   }
 
   /**

--- a/addon/models/course-objective.js
+++ b/addon/models/course-objective.js
@@ -3,6 +3,7 @@ import { map } from 'rsvp';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
+import { mapBy, sortByString } from '../utils/array-helpers';
 
 export default class CourseObjective extends Model {
   @attr('string')
@@ -49,11 +50,12 @@ export default class CourseObjective extends Model {
 
   @use _allTermVocabularies = new ResolveFlatMapBy(() => [this.terms, 'vocabulary']);
   get associatedVocabularies() {
-    return this._allTermVocabularies?.uniq().sortBy('title');
+    return sortByString(this._allTermVocabularies?.uniq(), 'title');
   }
 
+  @use _programYearObjectives = new ResolveAsyncValue(() => [this.programYearObjectives]);
   @use allTermCompetencies = new ResolveAsyncValue(() => [
-    this.programYearObjectives.mapBy('competency'),
+    mapBy(this._programYearObjectives?.slice(), 'competency'),
   ]);
 
   /**

--- a/addon/models/course-objective.js
+++ b/addon/models/course-objective.js
@@ -3,7 +3,7 @@ import { map } from 'rsvp';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
-import { mapBy, sortByString, uniqueById } from '../utils/array-helpers';
+import { mapBy, sortBy, uniqueById } from '../utils/array-helpers';
 
 export default class CourseObjective extends Model {
   @attr('string')
@@ -50,7 +50,7 @@ export default class CourseObjective extends Model {
 
   @use _allTermVocabularies = new ResolveFlatMapBy(() => [this.terms, 'vocabulary']);
   get associatedVocabularies() {
-    return sortByString(uniqueById(this._allTermVocabularies), 'title');
+    return sortBy(uniqueById(this._allTermVocabularies), 'title');
   }
 
   @use _programYearObjectives = new ResolveAsyncValue(() => [this.programYearObjectives]);

--- a/addon/models/course-objective.js
+++ b/addon/models/course-objective.js
@@ -3,7 +3,7 @@ import { map } from 'rsvp';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
-import { mapBy, sortByString } from '../utils/array-helpers';
+import { mapBy, sortByString, uniqueById } from '../utils/array-helpers';
 
 export default class CourseObjective extends Model {
   @attr('string')
@@ -50,7 +50,7 @@ export default class CourseObjective extends Model {
 
   @use _allTermVocabularies = new ResolveFlatMapBy(() => [this.terms, 'vocabulary']);
   get associatedVocabularies() {
-    return sortByString(this._allTermVocabularies?.uniq(), 'title');
+    return sortByString(uniqueById(this._allTermVocabularies), 'title');
   }
 
   @use _programYearObjectives = new ResolveAsyncValue(() => [this.programYearObjectives]);
@@ -62,7 +62,7 @@ export default class CourseObjective extends Model {
    * All competencies associated with any program-year objectives linked to this course objective.
    */
   get treeCompetencies() {
-    return this.allTermCompetencies?.uniq();
+    return uniqueById(this.allTermCompetencies);
   }
 
   /**

--- a/addon/models/course.js
+++ b/addon/models/course.js
@@ -197,7 +197,7 @@ export default class Course extends Model {
   get assignableVocabularies() {
     return this._schoolVocabularies
       ?.reduce((acc, curr) => {
-        return acc.pushObjects(curr.toArray());
+        return acc.pushObjects(curr.slice());
       }, [])
       .sortBy('school.title', 'title');
   }
@@ -207,7 +207,7 @@ export default class Course extends Model {
    * A list of course objectives, sorted by position (asc) and then id (desc).
    */
   get sortedCourseObjectives() {
-    return this._courseObjectives?.toArray().sort(sortableByPosition);
+    return this._courseObjectives?.slice().sort(sortableByPosition);
   }
 
   get hasMultipleCohorts() {

--- a/addon/models/course.js
+++ b/addon/models/course.js
@@ -6,7 +6,7 @@ import AsyncProcess from 'ilios-common/classes/async-process';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
 import { map } from 'rsvp';
 import moment from 'moment';
-import { filterBy, mapBy, sortBy, uniqueById } from '../utils/array-helpers';
+import { filterBy, mapBy, sortBy, uniqueValues } from '../utils/array-helpers';
 
 export default class Course extends Model {
   @attr('string')
@@ -117,7 +117,7 @@ export default class Course extends Model {
   ]);
 
   get competencies() {
-    return uniqueById(this.allTreeCompetencies)?.filter(Boolean);
+    return uniqueValues(this.allTreeCompetencies)?.filter(Boolean);
   }
 
   @use competencyDomains = new ResolveAsyncValue(() => [mapBy(this.competencies, 'domain')]);
@@ -132,7 +132,7 @@ export default class Course extends Model {
     if (!domains || !courseCompetencies) {
       return;
     }
-    const domainProxies = await map(uniqueById(domains), async (domain) => {
+    const domainProxies = await map(uniqueValues(domains), async (domain) => {
       let subCompetencies = (await domain.children).filter((competency) => {
         return courseCompetencies.includes(competency);
       });
@@ -189,7 +189,7 @@ export default class Course extends Model {
       return [];
     }
 
-    return uniqueById([...this._programSchools, this._resolvedSchool]);
+    return uniqueValues([...this._programSchools, this._resolvedSchool]);
   }
 
   @use _schoolVocabularies = new ResolveAsyncValue(() => [mapBy(this.schools, 'vocabularies')]);
@@ -222,7 +222,7 @@ export default class Course extends Model {
    * A list of all vocabularies that are associated via terms.
    */
   get associatedVocabularies() {
-    return sortBy(uniqueById(this._allTermVocabularies), 'title');
+    return sortBy(uniqueValues(this._allTermVocabularies), 'title');
   }
 
   get termCount() {

--- a/addon/models/course.js
+++ b/addon/models/course.js
@@ -117,7 +117,7 @@ export default class Course extends Model {
   ]);
 
   get competencies() {
-    return uniqueValues(this.allTreeCompetencies)?.filter(Boolean);
+    return uniqueValues(this.allTreeCompetencies ?? []).filter(Boolean);
   }
 
   @use competencyDomains = new ResolveAsyncValue(() => [mapBy(this.competencies, 'domain')]);
@@ -180,9 +180,9 @@ export default class Course extends Model {
     return issues;
   }
 
-  @use _programYears = new ResolveAsyncValue(() => [mapBy(this.cohorts, 'programYear')]);
-  @use _programs = new ResolveAsyncValue(() => [mapBy(this._programYears, 'program')]);
-  @use _programSchools = new ResolveAsyncValue(() => [mapBy(this._programs, 'school')]);
+  @use _programYears = new ResolveAsyncValue(() => [mapBy(this.cohorts ?? [], 'programYear')]);
+  @use _programs = new ResolveAsyncValue(() => [mapBy(this._programYears ?? [], 'program')]);
+  @use _programSchools = new ResolveAsyncValue(() => [mapBy(this._programs ?? [], 'school')]);
   @use _resolvedSchool = new ResolveAsyncValue(() => [this.school]);
   get schools() {
     if (!this._programSchools || !this._resolvedSchool) {
@@ -199,7 +199,7 @@ export default class Course extends Model {
       this._schoolVocabularies?.reduce((acc, curr) => {
         acc.push(...curr.slice());
         return acc;
-      }, []),
+      }, []) ?? [],
       ['school.title', 'title']
     );
     return rhett;
@@ -222,7 +222,7 @@ export default class Course extends Model {
    * A list of all vocabularies that are associated via terms.
    */
   get associatedVocabularies() {
-    return sortBy(uniqueValues(this._allTermVocabularies), 'title');
+    return sortBy(uniqueValues(this._allTermVocabularies ?? []), 'title');
   }
 
   get termCount() {

--- a/addon/models/course.js
+++ b/addon/models/course.js
@@ -6,7 +6,7 @@ import AsyncProcess from 'ilios-common/classes/async-process';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
 import { map } from 'rsvp';
 import moment from 'moment';
-import { mapBy, sortByString } from '../utils/array-helpers';
+import { mapBy, sortByString, uniqueById } from '../utils/array-helpers';
 
 export default class Course extends Model {
   @attr('string')
@@ -117,7 +117,7 @@ export default class Course extends Model {
   ]);
 
   get competencies() {
-    return this.allTreeCompetencies?.uniq().filter(Boolean);
+    return uniqueById(this.allTreeCompetencies).filter(Boolean);
   }
 
   @use competencyDomains = new ResolveAsyncValue(() => [mapBy(this.competencies, 'domain')]);
@@ -132,7 +132,7 @@ export default class Course extends Model {
     if (!domains || !courseCompetencies) {
       return;
     }
-    const domainProxies = await map(domains.uniq(), async (domain) => {
+    const domainProxies = await map(uniqueById(domains), async (domain) => {
       let subCompetencies = (await domain.children)
         .filter((competency) => {
           return courseCompetencies.includes(competency);
@@ -189,7 +189,7 @@ export default class Course extends Model {
       return [];
     }
 
-    return [...this._programSchools, this._resolvedSchool].uniq();
+    return uniqueById([...this._programSchools, this._resolvedSchool]);
   }
 
   @use _schoolVocabularies = new ResolveAsyncValue(() => [mapBy(this.schools, 'vocabularies')]);
@@ -219,7 +219,7 @@ export default class Course extends Model {
    * A list of all vocabularies that are associated via terms.
    */
   get associatedVocabularies() {
-    return sortByString(this._allTermVocabularies?.uniq(), 'title');
+    return sortByString(uniqueById(this._allTermVocabularies), 'title');
   }
 
   get termCount() {

--- a/addon/models/course.js
+++ b/addon/models/course.js
@@ -195,12 +195,14 @@ export default class Course extends Model {
   @use _schoolVocabularies = new ResolveAsyncValue(() => [mapBy(this.schools, 'vocabularies')]);
 
   get assignableVocabularies() {
-    return sortBy(
+    const rhett = sortBy(
       this._schoolVocabularies?.reduce((acc, curr) => {
-        return acc.push(...curr.slice());
+        acc.push(...curr.slice());
+        return acc;
       }, []),
       ['school.title', 'title']
     );
+    return rhett;
   }
 
   @use _courseObjectives = new ResolveAsyncValue(() => [this.courseObjectives]);

--- a/addon/models/course.js
+++ b/addon/models/course.js
@@ -6,6 +6,7 @@ import AsyncProcess from 'ilios-common/classes/async-process';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
 import { map } from 'rsvp';
 import moment from 'moment';
+import { mapBy, sortByString } from '../utils/array-helpers';
 
 export default class Course extends Model {
   @attr('string')
@@ -97,7 +98,7 @@ export default class Course extends Model {
   }
 
   @use publishedSessionOfferings = new ResolveAsyncValue(() => [
-    this.publishedSessions?.mapBy('offerings'),
+    mapBy(this.publishedSessions, 'offerings'),
   ]);
 
   get publishedOfferingCount() {
@@ -119,7 +120,7 @@ export default class Course extends Model {
     return this.allTreeCompetencies?.uniq().filter(Boolean);
   }
 
-  @use competencyDomains = new ResolveAsyncValue(() => [this.competencies?.mapBy('domain')]);
+  @use competencyDomains = new ResolveAsyncValue(() => [mapBy(this.competencies, 'domain')]);
 
   @use domainsWithSubcompetencies = new AsyncProcess(() => [
     this._getDomainProxies.bind(this),
@@ -145,7 +146,7 @@ export default class Course extends Model {
       };
     });
 
-    return domainProxies.sortBy('title');
+    return sortByString(domainProxies, 'title');
   }
 
   get requiredPublicationIssues() {
@@ -179,9 +180,9 @@ export default class Course extends Model {
     return issues;
   }
 
-  @use _programYears = new ResolveAsyncValue(() => [this.cohorts.mapBy('programYear')]);
-  @use _programs = new ResolveAsyncValue(() => [this._programYears?.mapBy('program')]);
-  @use _programSchools = new ResolveAsyncValue(() => [this._programs?.mapBy('school')]);
+  @use _programYears = new ResolveAsyncValue(() => [mapBy(this.cohorts, 'programYear')]);
+  @use _programs = new ResolveAsyncValue(() => [mapBy(this._programYears, 'program')]);
+  @use _programSchools = new ResolveAsyncValue(() => [mapBy(this._programs, 'school')]);
   @use _resolvedSchool = new ResolveAsyncValue(() => [this.school]);
   get schools() {
     if (!this._programSchools || !this._resolvedSchool) {
@@ -191,7 +192,7 @@ export default class Course extends Model {
     return [...this._programSchools, this._resolvedSchool].uniq();
   }
 
-  @use _schoolVocabularies = new ResolveAsyncValue(() => [this.schools?.mapBy('vocabularies')]);
+  @use _schoolVocabularies = new ResolveAsyncValue(() => [mapBy(this.schools, 'vocabularies')]);
 
   get assignableVocabularies() {
     return this._schoolVocabularies
@@ -218,7 +219,7 @@ export default class Course extends Model {
    * A list of all vocabularies that are associated via terms.
    */
   get associatedVocabularies() {
-    return this._allTermVocabularies?.uniq().sortBy('title');
+    return sortByString(this._allTermVocabularies?.uniq(), 'title');
   }
 
   get termCount() {

--- a/addon/models/course.js
+++ b/addon/models/course.js
@@ -6,7 +6,7 @@ import AsyncProcess from 'ilios-common/classes/async-process';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
 import { map } from 'rsvp';
 import moment from 'moment';
-import { mapBy, sortByString, uniqueById } from '../utils/array-helpers';
+import { filterBy, mapBy, sortByString, uniqueById } from '../utils/array-helpers';
 
 export default class Course extends Model {
   @attr('string')
@@ -94,7 +94,7 @@ export default class Course extends Model {
   terms;
 
   get publishedSessions() {
-    return this.sessions.filterBy('isPublished');
+    return filterBy(this.sessions, 'isPublished');
   }
 
   @use publishedSessionOfferings = new ResolveAsyncValue(() => [

--- a/addon/models/course.js
+++ b/addon/models/course.js
@@ -197,7 +197,7 @@ export default class Course extends Model {
   get assignableVocabularies() {
     return this._schoolVocabularies
       ?.reduce((acc, curr) => {
-        return acc.pushObjects(curr.slice());
+        return acc.push(curr.slice());
       }, [])
       .sortBy('school.title', 'title');
   }

--- a/addon/models/curriculum-inventory-report.js
+++ b/addon/models/curriculum-inventory-report.js
@@ -2,6 +2,7 @@ import Model, { hasMany, belongsTo, attr } from '@ember-data/model';
 import { use } from 'ember-could-get-used-to-this';
 import DeprecatedAsyncCP from 'ilios-common/classes/deprecated-async-cp';
 import { deprecate } from '@ember/debug';
+import { mapBy } from '../utils/array-helpers';
 
 export default class CurriculumInventoryReport extends Model {
   @attr('string')
@@ -79,7 +80,7 @@ export default class CurriculumInventoryReport extends Model {
   }
 
   async getLinkedCourses() {
-    const courses = await Promise.all((await this.sequenceBlocks).toArray().mapBy('course'));
+    const courses = await Promise.all(mapBy((await this.sequenceBlocks).slice(), 'course'));
     return courses.filter(Boolean);
   }
 

--- a/addon/models/curriculum-inventory-sequence-block.js
+++ b/addon/models/curriculum-inventory-sequence-block.js
@@ -109,15 +109,12 @@ export default class CurriculumInventorySequenceBlock extends Model {
    * If this sequence block is a top-level block within its owning report, then that array is empty.
    */
   async getAllParents() {
-    const rhett = [];
     const parent = await this.parent;
     if (!parent) {
       return [];
     }
-    rhett.push(parent);
-    const parentsAncestors = await parent.allParents;
-    rhett.push(parentsAncestors);
-    return rhett;
+    const parentsAncestors = (await parent.allParents).slice();
+    return [parent, ...parentsAncestors];
   }
 
   /**

--- a/addon/models/curriculum-inventory-sequence-block.js
+++ b/addon/models/curriculum-inventory-sequence-block.js
@@ -116,7 +116,7 @@ export default class CurriculumInventorySequenceBlock extends Model {
     }
     rhett.pushObject(parent);
     const parentsAncestors = await parent.allParents;
-    rhett.pushObjects(parentsAncestors);
+    rhett.push(parentsAncestors);
     return rhett;
   }
 

--- a/addon/models/curriculum-inventory-sequence-block.js
+++ b/addon/models/curriculum-inventory-sequence-block.js
@@ -114,7 +114,7 @@ export default class CurriculumInventorySequenceBlock extends Model {
     if (!parent) {
       return [];
     }
-    rhett.pushObject(parent);
+    rhett.push(parent);
     const parentsAncestors = await parent.allParents;
     rhett.push(parentsAncestors);
     return rhett;

--- a/addon/models/ilm-session.js
+++ b/addon/models/ilm-session.js
@@ -1,5 +1,5 @@
 import Model, { hasMany, belongsTo, attr } from '@ember-data/model';
-import { mapBy } from '../utils/array-helpers';
+import { mapBy, uniqueById } from '../utils/array-helpers';
 
 export default class IlmSession extends Model {
   @attr('number')
@@ -38,9 +38,9 @@ export default class IlmSession extends Model {
     const instructors = (await this.instructors).toArray();
     const instructorGroups = (await this.instructorGroups).toArray();
     const instructorsInInstructorGroups = await Promise.all(mapBy(instructorGroups, 'users'));
-    return [
+    return uniqueById([
       ...instructors,
-      ...instructorsInInstructorGroups.map((instructorGroup) => instructorGroup.toArray()).flat(),
-    ].uniq();
+      ...instructorsInInstructorGroups.map((instructorGroup) => instructorGroup.slice()).flat(),
+    ]);
   }
 }

--- a/addon/models/ilm-session.js
+++ b/addon/models/ilm-session.js
@@ -1,5 +1,5 @@
 import Model, { hasMany, belongsTo, attr } from '@ember-data/model';
-import { mapBy, uniqueById } from '../utils/array-helpers';
+import { mapBy, uniqueValues } from '../utils/array-helpers';
 
 export default class IlmSession extends Model {
   @attr('number')
@@ -38,7 +38,7 @@ export default class IlmSession extends Model {
     const instructors = (await this.instructors).slice();
     const instructorGroups = (await this.instructorGroups).slice();
     const instructorsInInstructorGroups = await Promise.all(mapBy(instructorGroups, 'users'));
-    return uniqueById([
+    return uniqueValues([
       ...instructors,
       ...instructorsInInstructorGroups.map((instructorGroup) => instructorGroup.slice()).flat(),
     ]);

--- a/addon/models/ilm-session.js
+++ b/addon/models/ilm-session.js
@@ -35,8 +35,8 @@ export default class IlmSession extends Model {
    * @returns {Promise<Array>}
    */
   async getAllInstructors() {
-    const instructors = (await this.instructors).toArray();
-    const instructorGroups = (await this.instructorGroups).toArray();
+    const instructors = (await this.instructors).slice();
+    const instructorGroups = (await this.instructorGroups).slice();
     const instructorsInInstructorGroups = await Promise.all(mapBy(instructorGroups, 'users'));
     return uniqueById([
       ...instructors,

--- a/addon/models/ilm-session.js
+++ b/addon/models/ilm-session.js
@@ -1,4 +1,5 @@
 import Model, { hasMany, belongsTo, attr } from '@ember-data/model';
+import { mapBy } from '../utils/array-helpers';
 
 export default class IlmSession extends Model {
   @attr('number')
@@ -36,7 +37,7 @@ export default class IlmSession extends Model {
   async getAllInstructors() {
     const instructors = (await this.instructors).toArray();
     const instructorGroups = (await this.instructorGroups).toArray();
-    const instructorsInInstructorGroups = await Promise.all(instructorGroups.mapBy('users'));
+    const instructorsInInstructorGroups = await Promise.all(mapBy(instructorGroups, 'users'));
     return [
       ...instructors,
       ...instructorsInInstructorGroups.map((instructorGroup) => instructorGroup.toArray()).flat(),

--- a/addon/models/instructor-group.js
+++ b/addon/models/instructor-group.js
@@ -1,6 +1,7 @@
 import Model, { hasMany, belongsTo, attr } from '@ember-data/model';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
+import { uniqueById } from '../utils/array-helpers';
 
 export default class InstructorGroupModel extends Model {
   @attr('string')
@@ -30,7 +31,7 @@ export default class InstructorGroupModel extends Model {
     if (!this.coursesFromIlmSessions || !this.coursesFromOfferings) {
       return [];
     }
-    return [...this.coursesFromIlmSessions, ...this.coursesFromOfferings].uniq();
+    return uniqueById([...this.coursesFromIlmSessions, ...this.coursesFromOfferings]);
   }
 
   /**
@@ -40,7 +41,7 @@ export default class InstructorGroupModel extends Model {
     if (!this._offeringSessions || !this._ilmSessionSessions) {
       return [];
     }
-    return [...this._offeringSessions, ...this._ilmSessionSessions].uniq();
+    return uniqueById([...this._offeringSessions, ...this._ilmSessionSessions]);
   }
 
   /**

--- a/addon/models/instructor-group.js
+++ b/addon/models/instructor-group.js
@@ -1,7 +1,7 @@
 import Model, { hasMany, belongsTo, attr } from '@ember-data/model';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
-import { uniqueById } from '../utils/array-helpers';
+import { uniqueValues } from '../utils/array-helpers';
 
 export default class InstructorGroupModel extends Model {
   @attr('string')
@@ -31,7 +31,7 @@ export default class InstructorGroupModel extends Model {
     if (!this.coursesFromIlmSessions || !this.coursesFromOfferings) {
       return [];
     }
-    return uniqueById([...this.coursesFromIlmSessions, ...this.coursesFromOfferings]);
+    return uniqueValues([...this.coursesFromIlmSessions, ...this.coursesFromOfferings]);
   }
 
   /**
@@ -41,7 +41,7 @@ export default class InstructorGroupModel extends Model {
     if (!this._offeringSessions || !this._ilmSessionSessions) {
       return [];
     }
-    return uniqueById([...this._offeringSessions, ...this._ilmSessionSessions]);
+    return uniqueValues([...this._offeringSessions, ...this._ilmSessionSessions]);
   }
 
   /**

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -7,7 +7,7 @@ import AsyncProcess from 'ilios-common/classes/async-process';
 import DeprecatedAsyncCP from 'ilios-common/classes/deprecated-async-cp';
 import DeprecatedResolveCP from 'ilios-common/classes/deprecated-resolve-cp';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
-import { filterBy, mapBy, uniqueById } from '../utils/array-helpers';
+import { filterBy, mapBy, uniqueValues } from '../utils/array-helpers';
 
 export default class LearnerGroup extends Model {
   @attr('string')
@@ -74,7 +74,7 @@ export default class LearnerGroup extends Model {
     if (!this._offeringSessions || !this._ilmSessionSessions) {
       return [];
     }
-    return uniqueById([...this._offeringSessions, ...this._ilmSessionSessions].filter(Boolean));
+    return uniqueValues([...this._offeringSessions, ...this._ilmSessionSessions].filter(Boolean));
   }
 
   @use _sessionCourses = new ResolveFlatMapBy(() => [this.sessions, 'course']);
@@ -83,7 +83,7 @@ export default class LearnerGroup extends Model {
    * A list of all courses associated with this learner group, via offerings/sessions or via ILMs.
    */
   get courses() {
-    return uniqueById(this._sessionCourses) ?? [];
+    return uniqueValues(this._sessionCourses) ?? [];
   }
 
   @use subgroupNumberingOffset = new DeprecatedAsyncCP(() => [
@@ -151,7 +151,7 @@ export default class LearnerGroup extends Model {
   async getAllDescendantUsers() {
     const users = await this.users;
     const descendantUsers = await this._getDescendantUsers();
-    return uniqueById([...users.slice(), ...descendantUsers]);
+    return uniqueValues([...users.slice(), ...descendantUsers]);
   }
 
   async _getDescendantUsers() {
@@ -264,7 +264,7 @@ export default class LearnerGroup extends Model {
       return [];
     }
 
-    return uniqueById([...this._instructors.slice(), ...this._instructorGroupUsers]);
+    return uniqueValues([...this._instructors.slice(), ...this._instructorGroupUsers]);
   }
 
   @use _cohort = new ResolveAsyncValue(() => [this.cohort]);
@@ -328,7 +328,7 @@ export default class LearnerGroup extends Model {
         modifiedGroups.push(group);
       }
     });
-    return uniqueById(modifiedGroups);
+    return uniqueValues(modifiedGroups);
   }
 
   async getAllParents() {
@@ -376,6 +376,6 @@ export default class LearnerGroup extends Model {
         modifiedGroups.push(groups[i]);
       }
     }
-    return uniqueById(modifiedGroups);
+    return uniqueValues(modifiedGroups);
   }
 }

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -83,7 +83,7 @@ export default class LearnerGroup extends Model {
    * A list of all courses associated with this learner group, via offerings/sessions or via ILMs.
    */
   get courses() {
-    return uniqueValues(this._sessionCourses) ?? [];
+    return uniqueValues(this._sessionCourses ?? []);
   }
 
   @use subgroupNumberingOffset = new DeprecatedAsyncCP(() => [

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -325,7 +325,7 @@ export default class LearnerGroup extends Model {
     [this, ...allDescendants].forEach((group) => {
       if (group.hasMany('users').ids().includes(userId)) {
         group.get('users').removeObject(user);
-        modifiedGroups.pushObject(group);
+        modifiedGroups.push(group);
       }
     });
     return uniqueById(modifiedGroups);
@@ -372,8 +372,8 @@ export default class LearnerGroup extends Model {
       const users = await groups[i].users;
       const ids = mapBy(users, 'id');
       if (!ids.includes(userId)) {
-        users.pushObject(user);
-        modifiedGroups.pushObject(groups[i]);
+        users.push(user);
+        modifiedGroups.push(groups[i]);
       }
     }
     return uniqueById(modifiedGroups);

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -7,6 +7,7 @@ import AsyncProcess from 'ilios-common/classes/async-process';
 import DeprecatedAsyncCP from 'ilios-common/classes/deprecated-async-cp';
 import DeprecatedResolveCP from 'ilios-common/classes/deprecated-resolve-cp';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
+import { mapBy } from '../utils/array-helpers';
 
 export default class LearnerGroup extends Model {
   @attr('string')
@@ -155,7 +156,7 @@ export default class LearnerGroup extends Model {
 
   async _getDescendantUsers() {
     const allDescendants = await this.getAllDescendants();
-    const descendantsUsers = await Promise.all(allDescendants.mapBy('users'));
+    const descendantsUsers = await Promise.all(mapBy(allDescendants, 'users'));
     return descendantsUsers.reduce((all, groups) => {
       all.pushObjects(groups.toArray());
 
@@ -218,8 +219,8 @@ export default class LearnerGroup extends Model {
     }
 
     return [
-      ...this.allDescendants.mapBy('title'),
-      ...this.allParents.mapBy('title'),
+      ...mapBy(this.allDescendants, 'title'),
+      ...mapBy(this.allParents, 'title'),
       this.title,
     ].join('');
   }
@@ -345,7 +346,7 @@ export default class LearnerGroup extends Model {
       return [];
     }
     const parents = await parent.getAllParents();
-    const titles = parents.mapBy('title');
+    const titles = mapBy(parents, 'title');
     return [...titles, parent.title];
   }
 
@@ -369,7 +370,7 @@ export default class LearnerGroup extends Model {
     const groups = [this, ...allParents];
     for (let i = 0; i < groups.length; i++) {
       const users = await groups[i].users;
-      const ids = users.mapBy('id');
+      const ids = mapBy(users, 'id');
       if (!ids.includes(userId)) {
         users.pushObject(user);
         modifiedGroups.pushObject(groups[i]);

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -158,7 +158,7 @@ export default class LearnerGroup extends Model {
     const allDescendants = await this.getAllDescendants();
     const descendantsUsers = await Promise.all(mapBy(allDescendants, 'users'));
     return descendantsUsers.reduce((all, groups) => {
-      all.pushObjects(groups.slice());
+      all.push(groups.slice());
 
       return all;
     }, []);

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -7,7 +7,7 @@ import AsyncProcess from 'ilios-common/classes/async-process';
 import DeprecatedAsyncCP from 'ilios-common/classes/deprecated-async-cp';
 import DeprecatedResolveCP from 'ilios-common/classes/deprecated-resolve-cp';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
-import { mapBy } from '../utils/array-helpers';
+import { mapBy, uniqueById } from '../utils/array-helpers';
 
 export default class LearnerGroup extends Model {
   @attr('string')
@@ -74,7 +74,7 @@ export default class LearnerGroup extends Model {
     if (!this._offeringSessions || !this._ilmSessionSessions) {
       return [];
     }
-    return [...this._offeringSessions, ...this._ilmSessionSessions].filter(Boolean).uniq();
+    return uniqueById([...this._offeringSessions, ...this._ilmSessionSessions].filter(Boolean));
   }
 
   @use _sessionCourses = new ResolveFlatMapBy(() => [this.sessions, 'course']);
@@ -83,7 +83,7 @@ export default class LearnerGroup extends Model {
    * A list of all courses associated with this learner group, via offerings/sessions or via ILMs.
    */
   get courses() {
-    return this._sessionCourses?.uniq() ?? [];
+    return uniqueById(this._sessionCourses) ?? [];
   }
 
   @use subgroupNumberingOffset = new DeprecatedAsyncCP(() => [
@@ -151,7 +151,7 @@ export default class LearnerGroup extends Model {
   async getAllDescendantUsers() {
     const users = await this.users;
     const descendantUsers = await this._getDescendantUsers();
-    return [...users.toArray(), ...descendantUsers].uniq();
+    return uniqueById([...users.toArray(), ...descendantUsers]);
   }
 
   async _getDescendantUsers() {
@@ -264,7 +264,7 @@ export default class LearnerGroup extends Model {
       return [];
     }
 
-    return [...this._instructors.toArray(), ...this._instructorGroupUsers].uniq();
+    return uniqueById([...this._instructors.toArray(), ...this._instructorGroupUsers]);
   }
 
   @use _cohort = new ResolveAsyncValue(() => [this.cohort]);
@@ -328,7 +328,7 @@ export default class LearnerGroup extends Model {
         modifiedGroups.pushObject(group);
       }
     });
-    return modifiedGroups.uniq();
+    return uniqueById(modifiedGroups);
   }
 
   async getAllParents() {
@@ -376,6 +376,6 @@ export default class LearnerGroup extends Model {
         modifiedGroups.pushObject(groups[i]);
       }
     }
-    return modifiedGroups.uniq();
+    return uniqueById(modifiedGroups);
   }
 }

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -158,9 +158,7 @@ export default class LearnerGroup extends Model {
     const allDescendants = await this.getAllDescendants();
     const descendantsUsers = await Promise.all(mapBy(allDescendants, 'users'));
     return descendantsUsers.reduce((all, groups) => {
-      all.push(groups.slice());
-
-      return all;
+      return [...all, ...groups.slice()];
     }, []);
   }
 

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -324,7 +324,7 @@ export default class LearnerGroup extends Model {
     const allDescendants = await this.getAllDescendants();
     [this, ...allDescendants].forEach((group) => {
       if (group.hasMany('users').ids().includes(userId)) {
-        group.get('users').removeObject(user);
+        group.users = group.users.filter(({ id }) => id !== user.id);
         modifiedGroups.push(group);
       }
     });

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -128,7 +128,7 @@ export default class LearnerGroup extends Model {
   }
 
   async getAllDescendants() {
-    const children = (await this.children).toArray();
+    const children = (await this.children).slice();
     const childDescendants = await map(children, (child) => {
       return child.getAllDescendants();
     });
@@ -151,14 +151,14 @@ export default class LearnerGroup extends Model {
   async getAllDescendantUsers() {
     const users = await this.users;
     const descendantUsers = await this._getDescendantUsers();
-    return uniqueById([...users.toArray(), ...descendantUsers]);
+    return uniqueById([...users.slice(), ...descendantUsers]);
   }
 
   async _getDescendantUsers() {
     const allDescendants = await this.getAllDescendants();
     const descendantsUsers = await Promise.all(mapBy(allDescendants, 'users'));
     return descendantsUsers.reduce((all, groups) => {
-      all.pushObjects(groups.toArray());
+      all.pushObjects(groups.slice());
 
       return all;
     }, []);
@@ -174,7 +174,7 @@ export default class LearnerGroup extends Model {
   ]);
 
   async getUsersOnlyAtThisLevel() {
-    const users = (await this.users).toArray();
+    const users = (await this.users).slice();
     const descendantsUsers = await this._getDescendantUsers();
 
     return users.filter((user) => !descendantsUsers.includes(user));
@@ -264,7 +264,7 @@ export default class LearnerGroup extends Model {
       return [];
     }
 
-    return uniqueById([...this._instructors.toArray(), ...this._instructorGroupUsers]);
+    return uniqueById([...this._instructors.slice(), ...this._instructorGroupUsers]);
   }
 
   @use _cohort = new ResolveAsyncValue(() => [this.cohort]);

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -7,7 +7,7 @@ import AsyncProcess from 'ilios-common/classes/async-process';
 import DeprecatedAsyncCP from 'ilios-common/classes/deprecated-async-cp';
 import DeprecatedResolveCP from 'ilios-common/classes/deprecated-resolve-cp';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
-import { mapBy, uniqueById } from '../utils/array-helpers';
+import { filterBy, mapBy, uniqueById } from '../utils/array-helpers';
 
 export default class LearnerGroup extends Model {
   @attr('string')
@@ -294,7 +294,7 @@ export default class LearnerGroup extends Model {
       return false;
     }
 
-    const subGroupsInNeedOfAccomodation = this.allDescendants?.filterBy('needsAccommodation');
+    const subGroupsInNeedOfAccomodation = filterBy(this.allDescendants, 'needsAccommodation');
 
     return subGroupsInNeedOfAccomodation?.length > 0;
   }

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -370,7 +370,7 @@ export default class LearnerGroup extends Model {
       const users = await groups[i].users;
       const ids = mapBy(users, 'id');
       if (!ids.includes(userId)) {
-        users.push(user);
+        users.pushObject(user);
         modifiedGroups.push(groups[i]);
       }
     }

--- a/addon/models/offering.js
+++ b/addon/models/offering.js
@@ -3,7 +3,7 @@ import { use } from 'ember-could-get-used-to-this';
 import moment from 'moment';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
-import { mapBy, sortBy, uniqueById } from '../utils/array-helpers';
+import { mapBy, sortBy, uniqueValues } from '../utils/array-helpers';
 
 export default class Offering extends Model {
   @attr('string')
@@ -109,7 +109,7 @@ export default class Offering extends Model {
       return [];
     }
     return sortBy(
-      uniqueById([...this._instructors.slice(), ...this._instructorsInGroups]),
+      uniqueValues([...this._instructors.slice(), ...this._instructorsInGroups]),
       'fullName'
     );
   }
@@ -118,7 +118,7 @@ export default class Offering extends Model {
     if (!this._learners || !this._learnersInGroups) {
       return [];
     }
-    return sortBy(uniqueById([...this._learners.slice(), ...this._learnersInGroups]), 'fullName');
+    return sortBy(uniqueValues([...this._learners.slice(), ...this._learnersInGroups]), 'fullName');
   }
 
   get durationHours() {
@@ -161,7 +161,7 @@ export default class Offering extends Model {
     const instructors = (await this.instructors).slice();
     const instructorGroups = (await this.instructorGroups).slice();
     const instructorsInInstructorGroups = await Promise.all(mapBy(instructorGroups, 'users'));
-    return uniqueById([
+    return uniqueValues([
       ...instructors,
       ...instructorsInInstructorGroups.map((instructorGroup) => instructorGroup.slice()).flat(),
     ]);

--- a/addon/models/offering.js
+++ b/addon/models/offering.js
@@ -3,7 +3,7 @@ import { use } from 'ember-could-get-used-to-this';
 import moment from 'moment';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
-import { mapBy, sortByString } from '../utils/array-helpers';
+import { mapBy, sortByString, uniqueById } from '../utils/array-helpers';
 
 export default class Offering extends Model {
   @attr('string')
@@ -109,7 +109,7 @@ export default class Offering extends Model {
       return [];
     }
     return sortByString(
-      [...this._instructors.toArray(), ...this._instructorsInGroups].uniq(),
+      uniqueById([...this._instructors.toArray(), ...this._instructorsInGroups]),
       'fullName'
     );
   }
@@ -118,7 +118,10 @@ export default class Offering extends Model {
     if (!this._learners || !this._learnersInGroups) {
       return [];
     }
-    return sortByString([...this._learners.slice(), ...this._learnersInGroups].uniq(), 'fullName');
+    return sortByString(
+      uniqueById([...this._learners.toArray(), ...this._learnersInGroups]),
+      'fullName'
+    );
   }
 
   get durationHours() {
@@ -161,9 +164,9 @@ export default class Offering extends Model {
     const instructors = (await this.instructors).toArray();
     const instructorGroups = (await this.instructorGroups).toArray();
     const instructorsInInstructorGroups = await Promise.all(mapBy(instructorGroups, 'users'));
-    return [
+    return uniqueById([
       ...instructors,
       ...instructorsInInstructorGroups.map((instructorGroup) => instructorGroup.toArray()).flat(),
-    ].uniq();
+    ]);
   }
 }

--- a/addon/models/offering.js
+++ b/addon/models/offering.js
@@ -3,7 +3,7 @@ import { use } from 'ember-could-get-used-to-this';
 import moment from 'moment';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
-import { mapBy, sortByString, uniqueById } from '../utils/array-helpers';
+import { mapBy, sortBy, uniqueById } from '../utils/array-helpers';
 
 export default class Offering extends Model {
   @attr('string')
@@ -108,7 +108,7 @@ export default class Offering extends Model {
     if (!this._instructors || !this._instructorsInGroups) {
       return [];
     }
-    return sortByString(
+    return sortBy(
       uniqueById([...this._instructors.slice(), ...this._instructorsInGroups]),
       'fullName'
     );
@@ -118,10 +118,7 @@ export default class Offering extends Model {
     if (!this._learners || !this._learnersInGroups) {
       return [];
     }
-    return sortByString(
-      uniqueById([...this._learners.slice(), ...this._learnersInGroups]),
-      'fullName'
-    );
+    return sortBy(uniqueById([...this._learners.slice(), ...this._learnersInGroups]), 'fullName');
   }
 
   get durationHours() {

--- a/addon/models/offering.js
+++ b/addon/models/offering.js
@@ -109,7 +109,7 @@ export default class Offering extends Model {
       return [];
     }
     return sortByString(
-      uniqueById([...this._instructors.toArray(), ...this._instructorsInGroups]),
+      uniqueById([...this._instructors.slice(), ...this._instructorsInGroups]),
       'fullName'
     );
   }
@@ -119,7 +119,7 @@ export default class Offering extends Model {
       return [];
     }
     return sortByString(
-      uniqueById([...this._learners.toArray(), ...this._learnersInGroups]),
+      uniqueById([...this._learners.slice(), ...this._learnersInGroups]),
       'fullName'
     );
   }
@@ -161,12 +161,12 @@ export default class Offering extends Model {
    * @returns {Promise<Array>}
    */
   async getAllInstructors() {
-    const instructors = (await this.instructors).toArray();
-    const instructorGroups = (await this.instructorGroups).toArray();
+    const instructors = (await this.instructors).slice();
+    const instructorGroups = (await this.instructorGroups).slice();
     const instructorsInInstructorGroups = await Promise.all(mapBy(instructorGroups, 'users'));
     return uniqueById([
       ...instructors,
-      ...instructorsInInstructorGroups.map((instructorGroup) => instructorGroup.toArray()).flat(),
+      ...instructorsInInstructorGroups.map((instructorGroup) => instructorGroup.slice()).flat(),
     ]);
   }
 }

--- a/addon/models/offering.js
+++ b/addon/models/offering.js
@@ -3,6 +3,7 @@ import { use } from 'ember-could-get-used-to-this';
 import moment from 'moment';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
+import { mapBy, sortByString } from '../utils/array-helpers';
 
 export default class Offering extends Model {
   @attr('string')
@@ -107,14 +108,17 @@ export default class Offering extends Model {
     if (!this._instructors || !this._instructorsInGroups) {
       return [];
     }
-    return [...this._instructors.toArray(), ...this._instructorsInGroups].uniq().sortBy('fullName');
+    return sortByString(
+      [...this._instructors.toArray(), ...this._instructorsInGroups].uniq(),
+      'fullName'
+    );
   }
 
   get allLearners() {
     if (!this._learners || !this._learnersInGroups) {
       return [];
     }
-    return [...this._learners.toArray(), ...this._learnersInGroups].uniq().sortBy('fullName');
+    return sortByString([...this._learners.slice(), ...this._learnersInGroups].uniq(), 'fullName');
   }
 
   get durationHours() {
@@ -156,7 +160,7 @@ export default class Offering extends Model {
   async getAllInstructors() {
     const instructors = (await this.instructors).toArray();
     const instructorGroups = (await this.instructorGroups).toArray();
-    const instructorsInInstructorGroups = await Promise.all(instructorGroups.mapBy('users'));
+    const instructorsInInstructorGroups = await Promise.all(mapBy(instructorGroups, 'users'));
     return [
       ...instructors,
       ...instructorsInInstructorGroups.map((instructorGroup) => instructorGroup.toArray()).flat(),

--- a/addon/models/program-year-objective.js
+++ b/addon/models/program-year-objective.js
@@ -46,7 +46,7 @@ export default class ProgramYearObjective extends Model {
 
   @use _allTermVocabularies = new ResolveFlatMapBy(() => [this.terms, 'vocabulary']);
   get associatedVocabularies() {
-    return sortBy(uniqueValues(this._allTermVocabularies), 'title');
+    return sortBy(uniqueValues(this._allTermVocabularies ?? []), 'title');
   }
 
   @use firstProgram = new DeprecatedResolveCP(() => [

--- a/addon/models/program-year-objective.js
+++ b/addon/models/program-year-objective.js
@@ -2,6 +2,7 @@ import Model, { hasMany, belongsTo, attr } from '@ember-data/model';
 import { use } from 'ember-could-get-used-to-this';
 import DeprecatedResolveCP from 'ilios-common/classes/deprecated-resolve-cp';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
+import { sortByString } from '../utils/array-helpers';
 
 export default class ProgramYearObjective extends Model {
   @attr('string')
@@ -45,7 +46,7 @@ export default class ProgramYearObjective extends Model {
 
   @use _allTermVocabularies = new ResolveFlatMapBy(() => [this.terms, 'vocabulary']);
   get associatedVocabularies() {
-    return this._allTermVocabularies?.uniq().sortBy('title');
+    return sortByString(this._allTermVocabularies?.uniq(), 'title');
   }
 
   @use firstProgram = new DeprecatedResolveCP(() => [

--- a/addon/models/program-year-objective.js
+++ b/addon/models/program-year-objective.js
@@ -2,7 +2,7 @@ import Model, { hasMany, belongsTo, attr } from '@ember-data/model';
 import { use } from 'ember-could-get-used-to-this';
 import DeprecatedResolveCP from 'ilios-common/classes/deprecated-resolve-cp';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
-import { sortByString, uniqueById } from '../utils/array-helpers';
+import { sortBy, uniqueById } from '../utils/array-helpers';
 
 export default class ProgramYearObjective extends Model {
   @attr('string')
@@ -46,7 +46,7 @@ export default class ProgramYearObjective extends Model {
 
   @use _allTermVocabularies = new ResolveFlatMapBy(() => [this.terms, 'vocabulary']);
   get associatedVocabularies() {
-    return sortByString(uniqueById(this._allTermVocabularies), 'title');
+    return sortBy(uniqueById(this._allTermVocabularies), 'title');
   }
 
   @use firstProgram = new DeprecatedResolveCP(() => [

--- a/addon/models/program-year-objective.js
+++ b/addon/models/program-year-objective.js
@@ -2,7 +2,7 @@ import Model, { hasMany, belongsTo, attr } from '@ember-data/model';
 import { use } from 'ember-could-get-used-to-this';
 import DeprecatedResolveCP from 'ilios-common/classes/deprecated-resolve-cp';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
-import { sortBy, uniqueById } from '../utils/array-helpers';
+import { sortBy, uniqueValues } from '../utils/array-helpers';
 
 export default class ProgramYearObjective extends Model {
   @attr('string')
@@ -46,7 +46,7 @@ export default class ProgramYearObjective extends Model {
 
   @use _allTermVocabularies = new ResolveFlatMapBy(() => [this.terms, 'vocabulary']);
   get associatedVocabularies() {
-    return sortBy(uniqueById(this._allTermVocabularies), 'title');
+    return sortBy(uniqueValues(this._allTermVocabularies), 'title');
   }
 
   @use firstProgram = new DeprecatedResolveCP(() => [

--- a/addon/models/program-year-objective.js
+++ b/addon/models/program-year-objective.js
@@ -2,7 +2,7 @@ import Model, { hasMany, belongsTo, attr } from '@ember-data/model';
 import { use } from 'ember-could-get-used-to-this';
 import DeprecatedResolveCP from 'ilios-common/classes/deprecated-resolve-cp';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
-import { sortByString } from '../utils/array-helpers';
+import { sortByString, uniqueById } from '../utils/array-helpers';
 
 export default class ProgramYearObjective extends Model {
   @attr('string')
@@ -46,7 +46,7 @@ export default class ProgramYearObjective extends Model {
 
   @use _allTermVocabularies = new ResolveFlatMapBy(() => [this.terms, 'vocabulary']);
   get associatedVocabularies() {
-    return sortByString(this._allTermVocabularies?.uniq(), 'title');
+    return sortByString(uniqueById(this._allTermVocabularies), 'title');
   }
 
   @use firstProgram = new DeprecatedResolveCP(() => [

--- a/addon/models/program-year.js
+++ b/addon/models/program-year.js
@@ -2,7 +2,7 @@ import Model, { hasMany, belongsTo, attr } from '@ember-data/model';
 import sortableByPosition from 'ilios-common/utils/sortable-by-position';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
-import { mapBy, sortBy, uniqueById } from '../utils/array-helpers';
+import { mapBy, sortBy, uniqueValues } from '../utils/array-helpers';
 
 export default class ProgramYear extends Model {
   @attr('string')
@@ -73,7 +73,7 @@ export default class ProgramYear extends Model {
    * A list of all vocabularies that are associated via terms.
    */
   get associatedVocabularies() {
-    return sortBy(uniqueById(this._allTermVocabularies), 'title');
+    return sortBy(uniqueValues(this._allTermVocabularies), 'title');
   }
 
   /**

--- a/addon/models/program-year.js
+++ b/addon/models/program-year.js
@@ -2,7 +2,7 @@ import Model, { hasMany, belongsTo, attr } from '@ember-data/model';
 import sortableByPosition from 'ilios-common/utils/sortable-by-position';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
-import { mapBy, sortByString } from '../utils/array-helpers';
+import { mapBy, sortByString, uniqueById } from '../utils/array-helpers';
 
 export default class ProgramYear extends Model {
   @attr('string')
@@ -73,7 +73,7 @@ export default class ProgramYear extends Model {
    * A list of all vocabularies that are associated via terms.
    */
   get associatedVocabularies() {
-    return sortByString(this._allTermVocabularies?.uniq(), 'title');
+    return sortByString(uniqueById(this._allTermVocabularies), 'title');
   }
 
   /**

--- a/addon/models/program-year.js
+++ b/addon/models/program-year.js
@@ -2,7 +2,7 @@ import Model, { hasMany, belongsTo, attr } from '@ember-data/model';
 import sortableByPosition from 'ilios-common/utils/sortable-by-position';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
-import { mapBy, sortByString, uniqueById } from '../utils/array-helpers';
+import { mapBy, sortBy, uniqueById } from '../utils/array-helpers';
 
 export default class ProgramYear extends Model {
   @attr('string')
@@ -41,7 +41,7 @@ export default class ProgramYear extends Model {
   @use _schoolVocabularies = new ResolveAsyncValue(() => [this._school?.vocabularies]);
 
   get assignableVocabularies() {
-    return sortByString(this._schoolVocabularies, 'title');
+    return sortBy(this._schoolVocabularies, 'title');
   }
 
   get classOfYear() {
@@ -73,7 +73,7 @@ export default class ProgramYear extends Model {
    * A list of all vocabularies that are associated via terms.
    */
   get associatedVocabularies() {
-    return sortByString(uniqueById(this._allTermVocabularies), 'title');
+    return sortBy(uniqueById(this._allTermVocabularies), 'title');
   }
 
   /**

--- a/addon/models/program-year.js
+++ b/addon/models/program-year.js
@@ -2,6 +2,7 @@ import Model, { hasMany, belongsTo, attr } from '@ember-data/model';
 import sortableByPosition from 'ilios-common/utils/sortable-by-position';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { mapBy, sortByString } from '../utils/array-helpers';
 
 export default class ProgramYear extends Model {
   @attr('string')
@@ -40,7 +41,7 @@ export default class ProgramYear extends Model {
   @use _schoolVocabularies = new ResolveAsyncValue(() => [this._school?.vocabularies]);
 
   get assignableVocabularies() {
-    return this._schoolVocabularies?.sortBy('title');
+    return sortByString(this._schoolVocabularies, 'title');
   }
 
   get classOfYear() {
@@ -66,13 +67,13 @@ export default class ProgramYear extends Model {
     return this._programYearObjectives?.toArray().sort(sortableByPosition);
   }
 
-  @use _allTermVocabularies = new ResolveAsyncValue(() => [this.terms.mapBy('vocabulary')]);
+  @use _allTermVocabularies = new ResolveAsyncValue(() => [mapBy(this.terms, 'vocabulary')]);
 
   /**
    * A list of all vocabularies that are associated via terms.
    */
   get associatedVocabularies() {
-    return this._allTermVocabularies?.uniq().sortBy('title');
+    return sortByString(this._allTermVocabularies?.uniq(), 'title');
   }
 
   /**

--- a/addon/models/program-year.js
+++ b/addon/models/program-year.js
@@ -64,7 +64,7 @@ export default class ProgramYear extends Model {
    * A list of program-year objectives, sorted by position.
    */
   get sortedProgramYearObjectives() {
-    return this._programYearObjectives?.toArray().sort(sortableByPosition);
+    return this._programYearObjectives?.slice().sort(sortableByPosition);
   }
 
   @use _allTermVocabularies = new ResolveAsyncValue(() => [mapBy(this.terms, 'vocabulary')]);

--- a/addon/models/program-year.js
+++ b/addon/models/program-year.js
@@ -41,7 +41,7 @@ export default class ProgramYear extends Model {
   @use _schoolVocabularies = new ResolveAsyncValue(() => [this._school?.vocabularies]);
 
   get assignableVocabularies() {
-    return sortBy(this._schoolVocabularies, 'title');
+    return sortBy(this._schoolVocabularies ?? [], 'title');
   }
 
   get classOfYear() {
@@ -73,7 +73,7 @@ export default class ProgramYear extends Model {
    * A list of all vocabularies that are associated via terms.
    */
   get associatedVocabularies() {
-    return sortBy(uniqueValues(this._allTermVocabularies), 'title');
+    return sortBy(uniqueValues(this._allTermVocabularies ?? []), 'title');
   }
 
   /**

--- a/addon/models/program.js
+++ b/addon/models/program.js
@@ -2,7 +2,7 @@ import Model, { hasMany, belongsTo, attr } from '@ember-data/model';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
-import { mapBy } from '../utils/array-helpers';
+import { mapBy, uniqueById } from '../utils/array-helpers';
 
 export default class Program extends Model {
   @attr('string')
@@ -49,6 +49,6 @@ export default class Program extends Model {
     if (!this._courses) {
       return [];
     }
-    return this._courses.uniq();
+    return uniqueById(this._courses);
   }
 }

--- a/addon/models/program.js
+++ b/addon/models/program.js
@@ -2,6 +2,7 @@ import Model, { hasMany, belongsTo, attr } from '@ember-data/model';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
+import { mapBy } from '../utils/array-helpers';
 
 export default class Program extends Model {
   @attr('string')
@@ -27,7 +28,7 @@ export default class Program extends Model {
     return !!this.hasMany('programYears').ids().length;
   }
 
-  @use _cohorts = new ResolveAsyncValue(() => [this.programYears?.mapBy('cohort')]);
+  @use _cohorts = new ResolveAsyncValue(() => [mapBy(this.programYears, 'cohort')]);
 
   /**
    * All cohorts associated with this program via its program years.

--- a/addon/models/program.js
+++ b/addon/models/program.js
@@ -37,7 +37,7 @@ export default class Program extends Model {
     if (!this._cohorts) {
       return [];
     }
-    return this._cohorts.toArray();
+    return this._cohorts.slice();
   }
 
   @use _courses = new ResolveFlatMapBy(() => [this._cohorts, 'courses']);

--- a/addon/models/program.js
+++ b/addon/models/program.js
@@ -2,7 +2,7 @@ import Model, { hasMany, belongsTo, attr } from '@ember-data/model';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
-import { mapBy, uniqueById } from '../utils/array-helpers';
+import { mapBy, uniqueValues } from '../utils/array-helpers';
 
 export default class Program extends Model {
   @attr('string')
@@ -49,6 +49,6 @@ export default class Program extends Model {
     if (!this._courses) {
       return [];
     }
-    return uniqueById(this._courses);
+    return uniqueValues(this._courses);
   }
 }

--- a/addon/models/school.js
+++ b/addon/models/school.js
@@ -1,6 +1,7 @@
 import Model, { hasMany, belongsTo, attr } from '@ember-data/model';
 import { isEmpty } from '@ember/utils';
 import { deprecate } from '@ember/debug';
+import { findBy } from '../utils/array-helpers';
 
 export default class School extends Model {
   @attr('string')
@@ -48,7 +49,7 @@ export default class School extends Model {
 
   async getConfigByName(name) {
     const configs = await this.configurations;
-    const config = configs.findBy('name', name);
+    const config = findBy(configs, 'name', name);
 
     return isEmpty(config) ? null : config;
   }

--- a/addon/models/school.js
+++ b/addon/models/school.js
@@ -85,7 +85,7 @@ export default class School extends Model {
       name,
     });
     const configurations = await this.configurations;
-    configurations.push(config);
+    configurations.pushObject(config);
 
     return config;
   }

--- a/addon/models/school.js
+++ b/addon/models/school.js
@@ -85,7 +85,7 @@ export default class School extends Model {
       name,
     });
     const configurations = await this.configurations;
-    configurations.pushObject(config);
+    configurations.push(config);
 
     return config;
   }

--- a/addon/models/session-objective.js
+++ b/addon/models/session-objective.js
@@ -1,6 +1,7 @@
 import Model, { hasMany, belongsTo, attr } from '@ember-data/model';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
+import { sortByString } from '../utils/array-helpers';
 
 export default class SessionObjectiveModel extends Model {
   @attr('string')
@@ -41,7 +42,7 @@ export default class SessionObjectiveModel extends Model {
 
   @use _allTermVocabularies = new ResolveFlatMapBy(() => [this.terms, 'vocabulary']);
   get associatedVocabularies() {
-    return this._allTermVocabularies?.uniq().sortBy('title');
+    return sortByString(this._allTermVocabularies?.uniq(), 'title');
   }
 
   /**

--- a/addon/models/session-objective.js
+++ b/addon/models/session-objective.js
@@ -1,7 +1,7 @@
 import Model, { hasMany, belongsTo, attr } from '@ember-data/model';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
-import { sortByString, uniqueById } from '../utils/array-helpers';
+import { sortBy, uniqueById } from '../utils/array-helpers';
 
 export default class SessionObjectiveModel extends Model {
   @attr('string')
@@ -42,7 +42,7 @@ export default class SessionObjectiveModel extends Model {
 
   @use _allTermVocabularies = new ResolveFlatMapBy(() => [this.terms, 'vocabulary']);
   get associatedVocabularies() {
-    return sortByString(uniqueById(this._allTermVocabularies), 'title');
+    return sortBy(uniqueById(this._allTermVocabularies), 'title');
   }
 
   /**

--- a/addon/models/session-objective.js
+++ b/addon/models/session-objective.js
@@ -42,7 +42,7 @@ export default class SessionObjectiveModel extends Model {
 
   @use _allTermVocabularies = new ResolveFlatMapBy(() => [this.terms, 'vocabulary']);
   get associatedVocabularies() {
-    return sortBy(uniqueValues(this._allTermVocabularies), 'title');
+    return sortBy(uniqueValues(this._allTermVocabularies ?? []), 'title');
   }
 
   /**

--- a/addon/models/session-objective.js
+++ b/addon/models/session-objective.js
@@ -1,7 +1,7 @@
 import Model, { hasMany, belongsTo, attr } from '@ember-data/model';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
-import { sortBy, uniqueById } from '../utils/array-helpers';
+import { sortBy, uniqueValues } from '../utils/array-helpers';
 
 export default class SessionObjectiveModel extends Model {
   @attr('string')
@@ -42,7 +42,7 @@ export default class SessionObjectiveModel extends Model {
 
   @use _allTermVocabularies = new ResolveFlatMapBy(() => [this.terms, 'vocabulary']);
   get associatedVocabularies() {
-    return sortBy(uniqueById(this._allTermVocabularies), 'title');
+    return sortBy(uniqueValues(this._allTermVocabularies), 'title');
   }
 
   /**

--- a/addon/models/session-objective.js
+++ b/addon/models/session-objective.js
@@ -1,7 +1,7 @@
 import Model, { hasMany, belongsTo, attr } from '@ember-data/model';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
-import { sortByString } from '../utils/array-helpers';
+import { sortByString, uniqueById } from '../utils/array-helpers';
 
 export default class SessionObjectiveModel extends Model {
   @attr('string')
@@ -42,7 +42,7 @@ export default class SessionObjectiveModel extends Model {
 
   @use _allTermVocabularies = new ResolveFlatMapBy(() => [this.terms, 'vocabulary']);
   get associatedVocabularies() {
-    return sortByString(this._allTermVocabularies?.uniq(), 'title');
+    return sortByString(uniqueById(this._allTermVocabularies), 'title');
   }
 
   /**

--- a/addon/models/session-type.js
+++ b/addon/models/session-type.js
@@ -45,6 +45,6 @@ export default class SessionType extends Model {
     if (!this._aamcMethods) {
       return undefined;
     }
-    return this._aamcMethods.get('firstObject');
+    return this._aamcMethods[0];
   }
 }

--- a/addon/models/session-type.js
+++ b/addon/models/session-type.js
@@ -45,6 +45,6 @@ export default class SessionType extends Model {
     if (!this._aamcMethods) {
       return undefined;
     }
-    return this._aamcMethods[0];
+    return this._aamcMethods.slice()[0];
   }
 }

--- a/addon/models/session.js
+++ b/addon/models/session.js
@@ -7,7 +7,7 @@ import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
 import AsyncProcess from 'ilios-common/classes/async-process';
-import { mapBy, sortByString, uniqueById } from '../utils/array-helpers';
+import { mapBy, sortBy, uniqueById } from '../utils/array-helpers';
 
 export default class SessionModel extends Model {
   @attr('string')
@@ -242,7 +242,7 @@ export default class SessionModel extends Model {
    * A list of all vocabularies that are associated via terms.
    */
   get associatedVocabularies() {
-    return sortByString(uniqueById(this._allTermVocabularies), 'title');
+    return sortBy(uniqueById(this._allTermVocabularies), 'title');
   }
 
   get termCount() {
@@ -253,7 +253,7 @@ export default class SessionModel extends Model {
     if (!this.offeringLearnerGroups) {
       return [];
     }
-    return sortByString(uniqueById(this.offeringLearnerGroups), 'title');
+    return sortBy(uniqueById(this.offeringLearnerGroups), 'title');
   }
   get associatedIlmLearnerGroups() {
     return this._ilmLearnerGroups?.slice() ?? [];
@@ -264,7 +264,7 @@ export default class SessionModel extends Model {
     if (!this.offeringLearnerGroups || !ilmLearnerGroups) {
       return [];
     }
-    return sortByString(
+    return sortBy(
       uniqueById([...this.offeringLearnerGroups, ...ilmLearnerGroups.slice()]),
       'title'
     );

--- a/addon/models/session.js
+++ b/addon/models/session.js
@@ -7,7 +7,7 @@ import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
 import AsyncProcess from 'ilios-common/classes/async-process';
-import { mapBy, sortByString } from '../utils/array-helpers';
+import { mapBy, sortByString, uniqueById } from '../utils/array-helpers';
 
 export default class SessionModel extends Model {
   @attr('string')
@@ -242,7 +242,7 @@ export default class SessionModel extends Model {
    * A list of all vocabularies that are associated via terms.
    */
   get associatedVocabularies() {
-    return sortByString(this._allTermVocabularies?.uniq(), 'title');
+    return sortByString(uniqueById(this._allTermVocabularies), 'title');
   }
 
   get termCount() {
@@ -253,7 +253,7 @@ export default class SessionModel extends Model {
     if (!this.offeringLearnerGroups) {
       return [];
     }
-    return sortByString(this.offeringLearnerGroups.uniq(), 'title');
+    return sortByString(uniqueById(this.offeringLearnerGroups), 'title');
   }
   get associatedIlmLearnerGroups() {
     return this._ilmLearnerGroups?.toArray() ?? [];
@@ -265,7 +265,7 @@ export default class SessionModel extends Model {
       return [];
     }
     return sortByString(
-      [...this.offeringLearnerGroups, ...ilmLearnerGroups.toArray()].uniq(),
+      uniqueById([...this.offeringLearnerGroups, ...ilmLearnerGroups.toArray()]),
       'title'
     );
   }
@@ -298,11 +298,11 @@ export default class SessionModel extends Model {
       return [];
     }
 
-    return [
+    return uniqueById([
       ...this._offeringInstructors,
       ...this._offeringInstructorGroupInstructors,
       ...this.ilmSessionInstructors,
-    ].uniq();
+    ]);
   }
 
   get hasPrerequisites() {
@@ -398,13 +398,13 @@ export default class SessionModel extends Model {
       })
     );
 
-    return allOfferingInstructors.flat().uniq();
+    return uniqueById(allOfferingInstructors.flat());
   }
 
   async getAllInstructors() {
     const allIlmSessionInstructors = await this.getAllIlmSessionInstructors();
     const allOfferingInstructors = await this.getAllOfferingInstructors();
-    return [...allOfferingInstructors, ...allIlmSessionInstructors].uniq();
+    return uniqueById([...allOfferingInstructors, ...allIlmSessionInstructors]);
   }
 
   async getTotalSumOfferingsDuration() {

--- a/addon/models/session.js
+++ b/addon/models/session.js
@@ -373,7 +373,9 @@ export default class SessionModel extends Model {
     const collectionOfCourseObjectives = await Promise.all(
       mapBy(sessionObjectives, 'courseObjectives')
     );
-    return collectionOfCourseObjectives.any((courseObjectives) => courseObjectives.length === 0);
+    return Boolean(
+      collectionOfCourseObjectives.find((courseObjectives) => courseObjectives.length === 0)
+    );
   }
 
   async getAllIlmSessionInstructors() {

--- a/addon/models/session.js
+++ b/addon/models/session.js
@@ -7,7 +7,7 @@ import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
 import AsyncProcess from 'ilios-common/classes/async-process';
-import { mapBy, sortBy, uniqueById } from '../utils/array-helpers';
+import { mapBy, sortBy, uniqueValues } from '../utils/array-helpers';
 
 export default class SessionModel extends Model {
   @attr('string')
@@ -242,7 +242,7 @@ export default class SessionModel extends Model {
    * A list of all vocabularies that are associated via terms.
    */
   get associatedVocabularies() {
-    return sortBy(uniqueById(this._allTermVocabularies), 'title');
+    return sortBy(uniqueValues(this._allTermVocabularies), 'title');
   }
 
   get termCount() {
@@ -253,7 +253,7 @@ export default class SessionModel extends Model {
     if (!this.offeringLearnerGroups) {
       return [];
     }
-    return sortBy(uniqueById(this.offeringLearnerGroups), 'title');
+    return sortBy(uniqueValues(this.offeringLearnerGroups), 'title');
   }
   get associatedIlmLearnerGroups() {
     return this._ilmLearnerGroups?.slice() ?? [];
@@ -265,7 +265,7 @@ export default class SessionModel extends Model {
       return [];
     }
     return sortBy(
-      uniqueById([...this.offeringLearnerGroups, ...ilmLearnerGroups.slice()]),
+      uniqueValues([...this.offeringLearnerGroups, ...ilmLearnerGroups.slice()]),
       'title'
     );
   }
@@ -295,7 +295,7 @@ export default class SessionModel extends Model {
       return [];
     }
 
-    return uniqueById([
+    return uniqueValues([
       ...this._offeringInstructors,
       ...this._offeringInstructorGroupInstructors,
       ...this.ilmSessionInstructors,
@@ -397,13 +397,13 @@ export default class SessionModel extends Model {
       })
     );
 
-    return uniqueById(allOfferingInstructors.flat());
+    return uniqueValues(allOfferingInstructors.flat());
   }
 
   async getAllInstructors() {
     const allIlmSessionInstructors = await this.getAllIlmSessionInstructors();
     const allOfferingInstructors = await this.getAllOfferingInstructors();
-    return uniqueById([...allOfferingInstructors, ...allIlmSessionInstructors]);
+    return uniqueValues([...allOfferingInstructors, ...allIlmSessionInstructors]);
   }
 
   async getTotalSumOfferingsDuration() {

--- a/addon/models/session.js
+++ b/addon/models/session.js
@@ -7,6 +7,7 @@ import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
 import AsyncProcess from 'ilios-common/classes/async-process';
+import { mapBy, sortByString } from '../utils/array-helpers';
 
 export default class SessionModel extends Model {
   @attr('string')
@@ -241,7 +242,7 @@ export default class SessionModel extends Model {
    * A list of all vocabularies that are associated via terms.
    */
   get associatedVocabularies() {
-    return this._allTermVocabularies?.uniq().sortBy('title');
+    return sortByString(this._allTermVocabularies?.uniq(), 'title');
   }
 
   get termCount() {
@@ -252,7 +253,7 @@ export default class SessionModel extends Model {
     if (!this.offeringLearnerGroups) {
       return [];
     }
-    return this.offeringLearnerGroups.uniq().sortBy('title');
+    return sortByString(this.offeringLearnerGroups.uniq(), 'title');
   }
   get associatedIlmLearnerGroups() {
     return this._ilmLearnerGroups?.toArray() ?? [];
@@ -263,7 +264,10 @@ export default class SessionModel extends Model {
     if (!this.offeringLearnerGroups || !ilmLearnerGroups) {
       return [];
     }
-    return [...this.offeringLearnerGroups, ...ilmLearnerGroups.toArray()].uniq().sortBy('title');
+    return sortByString(
+      [...this.offeringLearnerGroups, ...ilmLearnerGroups.toArray()].uniq(),
+      'title'
+    );
   }
 
   get sortedSessionObjectives() {
@@ -370,7 +374,7 @@ export default class SessionModel extends Model {
   async getShowUnlinkIcon() {
     const sessionObjectives = await this.sessionObjectives;
     const collectionOfCourseObjectives = await Promise.all(
-      sessionObjectives.mapBy('courseObjectives')
+      mapBy(sessionObjectives, 'courseObjectives')
     );
     return collectionOfCourseObjectives.any((courseObjectives) => courseObjectives.length === 0);
   }
@@ -430,7 +434,7 @@ export default class SessionModel extends Model {
     const offerings = await this.offerings;
     const offeringsWithUser = await filter(offerings.toArray(), async (offering) => {
       const instructors = await offering.getAllInstructors();
-      return instructors.mapBy('id').includes(user.id);
+      return mapBy(instructors, 'id').includes(user.id);
     });
     const offeringHours = offeringsWithUser
       .reduce((total, offering) => {
@@ -445,7 +449,7 @@ export default class SessionModel extends Model {
     let ilmMinutes = 0;
     if (ilmSession) {
       const instructors = await ilmSession.getAllInstructors();
-      if (instructors.mapBy('id').includes(user.id)) {
+      if (mapBy(instructors, 'id').includes(user.id)) {
         ilmMinutes = Math.round(parseFloat(ilmSession.hours) * 60);
       }
     }

--- a/addon/models/session.js
+++ b/addon/models/session.js
@@ -178,7 +178,7 @@ export default class SessionModel extends Model {
     if (!this.hasMany('offerings').ids().length || !this._offerings) {
       return 0;
     }
-    const sortedOfferings = this._offerings.toArray().sort(function (a, b) {
+    const sortedOfferings = this._offerings.slice().sort(function (a, b) {
       const diffA = moment(a.endDate).diff(moment(a.startDate), 'minutes');
       const diffB = moment(b.endDate).diff(moment(b.startDate), 'minutes');
       if (diffA > diffB) {
@@ -256,7 +256,7 @@ export default class SessionModel extends Model {
     return sortByString(uniqueById(this.offeringLearnerGroups), 'title');
   }
   get associatedIlmLearnerGroups() {
-    return this._ilmLearnerGroups?.toArray() ?? [];
+    return this._ilmLearnerGroups?.slice() ?? [];
   }
 
   get associatedLearnerGroups() {
@@ -265,13 +265,13 @@ export default class SessionModel extends Model {
       return [];
     }
     return sortByString(
-      uniqueById([...this.offeringLearnerGroups, ...ilmLearnerGroups.toArray()]),
+      uniqueById([...this.offeringLearnerGroups, ...ilmLearnerGroups.slice()]),
       'title'
     );
   }
 
   get sortedSessionObjectives() {
-    return this._sessionObjectives?.toArray().sort(sortableByPosition);
+    return this._sessionObjectives?.slice().sort(sortableByPosition);
   }
 
   get ilmSessionInstructors() {
@@ -283,10 +283,7 @@ export default class SessionModel extends Model {
       return [];
     }
 
-    return [
-      ...this._ilmSessionInstructors.toArray(),
-      ...this._ilmSessionInstructorGroupInstructors,
-    ];
+    return [...this._ilmSessionInstructors.slice(), ...this._ilmSessionInstructorGroupInstructors];
   }
 
   get allInstructors() {
@@ -388,13 +385,13 @@ export default class SessionModel extends Model {
   }
 
   async getAllOfferingInstructors() {
-    const offerings = (await this.offerings).toArray();
+    const offerings = (await this.offerings).slice();
     if (!offerings.length) {
       return [];
     }
     const allOfferingInstructors = await Promise.all(
       offerings.map(async (offering) => {
-        return (await offering.getAllInstructors()).toArray();
+        return (await offering.getAllInstructors()).slice();
       })
     );
 
@@ -432,7 +429,7 @@ export default class SessionModel extends Model {
 
   async getTotalSumOfferingsDurationByInstructor(user) {
     const offerings = await this.offerings;
-    const offeringsWithUser = await filter(offerings.toArray(), async (offering) => {
+    const offeringsWithUser = await filter(offerings.slice(), async (offering) => {
       const instructors = await offering.getAllInstructors();
       return mapBy(instructors, 'id').includes(user.id);
     });

--- a/addon/models/session.js
+++ b/addon/models/session.js
@@ -242,7 +242,7 @@ export default class SessionModel extends Model {
    * A list of all vocabularies that are associated via terms.
    */
   get associatedVocabularies() {
-    return sortBy(uniqueValues(this._allTermVocabularies), 'title');
+    return sortBy(uniqueValues(this._allTermVocabularies ?? []), 'title');
   }
 
   get termCount() {

--- a/addon/models/term.js
+++ b/addon/models/term.js
@@ -118,15 +118,15 @@ export default class Term extends Model {
   async getAllDescendants() {
     const descendants = [];
     const children = await this.children;
-    descendants.pushObjects(children.slice());
+    descendants.push(children.slice());
     const childrenDescendants = await Promise.all(
       children.slice().map(async (child) => {
         return child.getAllDescendants();
       })
     );
-    descendants.pushObjects(
+    descendants.push(
       childrenDescendants.reduce((array, set) => {
-        array.pushObjects(set);
+        array.push(set);
         return array;
       }, [])
     );

--- a/addon/models/term.js
+++ b/addon/models/term.js
@@ -116,21 +116,15 @@ export default class Term extends Model {
   }
 
   async getAllDescendants() {
-    const descendants = [];
-    const children = await this.children;
-    descendants.push(children.slice());
+    const children = (await this.children).slice();
     const childrenDescendants = await Promise.all(
-      children.slice().map(async (child) => {
-        return child.getAllDescendants();
-      })
+      children.map((child) => child.getAllDescendants())
     );
-    descendants.push(
-      childrenDescendants.reduce((array, set) => {
-        array.push(set);
-        return array;
-      }, [])
-    );
-    return descendants;
+    const flatChildrenDescendants = childrenDescendants.reduce((array, set) => {
+      return [...array, ...set];
+    }, []);
+
+    return [...children, ...flatChildrenDescendants];
   }
 
   /**

--- a/addon/models/term.js
+++ b/addon/models/term.js
@@ -118,9 +118,9 @@ export default class Term extends Model {
   async getAllDescendants() {
     const descendants = [];
     const children = await this.children;
-    descendants.pushObjects(children.toArray());
+    descendants.pushObjects(children.slice());
     const childrenDescendants = await Promise.all(
-      children.toArray().map(async (child) => {
+      children.slice().map(async (child) => {
         return child.getAllDescendants();
       })
     );

--- a/addon/models/term.js
+++ b/addon/models/term.js
@@ -1,6 +1,7 @@
 import Model, { hasMany, belongsTo, attr } from '@ember-data/model';
 import { use } from 'ember-could-get-used-to-this';
 import DeprecatedAsyncCP from 'ilios-common/classes/deprecated-async-cp';
+import { mapBy } from '../utils/array-helpers';
 
 export default class Term extends Model {
   @attr('string')
@@ -99,7 +100,7 @@ export default class Term extends Model {
       return [];
     }
     const parents = await parent.getAllParents();
-    const titles = parents.mapBy('title');
+    const titles = mapBy(parents, 'title');
     return [...titles, parent.title];
   }
 
@@ -137,7 +138,7 @@ export default class Term extends Model {
    */
   async getTitleWithDescendantTitles() {
     const allDescendants = await this.getAllDescendants();
-    const allDescendantTitles = allDescendants.mapBy('title');
+    const allDescendantTitles = mapBy(allDescendants, 'title');
     if (!allDescendantTitles.length) {
       return this.title;
     }

--- a/addon/models/user.js
+++ b/addon/models/user.js
@@ -2,7 +2,7 @@ import Model, { hasMany, belongsTo, attr } from '@ember-data/model';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
-import { mapBy } from '../utils/array-helpers';
+import { mapBy, uniqueById } from '../utils/array-helpers';
 
 export default class User extends Model {
   @attr('string')
@@ -296,7 +296,7 @@ export default class User extends Model {
     if (!this._instructedLearnerGroupOfferings || !this._instructedOfferings) {
       return [];
     }
-    return [...this._instructedLearnerGroupOfferings, ...this._instructedOfferings].uniq();
+    return uniqueById([...this._instructedLearnerGroupOfferings, ...this._instructedOfferings]);
   }
 
   @use _instructorIlmSessions = new ResolveAsyncValue(() => [this.instructorIlmSessions]);
@@ -326,13 +326,13 @@ export default class User extends Model {
     ) {
       return [];
     }
-    return [
-      ...this._instructorIlmSessionsSessions,
-      ...this._instructedOfferingSessions,
-      ...this._instructorGroupSessions,
-    ]
-      .uniq()
-      .filter(Boolean);
+    return uniqueById(
+      [
+        ...this._instructorIlmSessionsSessions,
+        ...this._instructedOfferingSessions,
+        ...this._instructorGroupSessions,
+      ].filter(Boolean)
+    );
   }
 
   @use allInstructedCourses = new ResolveFlatMapBy(() => [this.allInstructedSessions, 'course']);
@@ -353,7 +353,7 @@ export default class User extends Model {
     if (!this._learnerGroupOfferings || !this._offerings) {
       return [];
     }
-    return [...this._learnerGroupOfferings, ...this._offerings.toArray()].uniq();
+    return uniqueById([...this._learnerGroupOfferings, ...this._offerings.toArray()]);
   }
   @use _learnerOfferingSessions = new ResolveFlatMapBy(() => [this._learnerOfferings, 'session']);
 
@@ -365,13 +365,13 @@ export default class User extends Model {
     ) {
       return [];
     }
-    return [
-      ...this._learnerOfferingSessions,
-      ...this._learnerIlmSessionSessions,
-      ...this._learnerGroupIlmSessionsSessions,
-    ]
-      .uniq()
-      .filter(Boolean);
+    return uniqueById(
+      [
+        ...this._learnerOfferingSessions,
+        ...this._learnerIlmSessionSessions,
+        ...this._learnerGroupIlmSessionsSessions,
+      ].filter(Boolean)
+    );
   }
 
   @use _learnerCourses = new ResolveFlatMapBy(() => [this._learnerSessions, 'course']);
@@ -385,12 +385,12 @@ export default class User extends Model {
     ) {
       return [];
     }
-    return [
+    return uniqueById([
       ...this._learnerCourses,
       ...this.allInstructedCourses,
       ...this._directedCourses.toArray(),
       ...this._administeredCourses.toArray(),
-    ].uniq();
+    ]);
   }
 
   @use _primaryCohort = new ResolveAsyncValue(() => [this.primaryCohort]);

--- a/addon/models/user.js
+++ b/addon/models/user.js
@@ -2,7 +2,7 @@ import Model, { hasMany, belongsTo, attr } from '@ember-data/model';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
-import { mapBy, uniqueById } from '../utils/array-helpers';
+import { mapBy, uniqueValues } from '../utils/array-helpers';
 
 export default class User extends Model {
   @attr('string')
@@ -296,7 +296,7 @@ export default class User extends Model {
     if (!this._instructedLearnerGroupOfferings || !this._instructedOfferings) {
       return [];
     }
-    return uniqueById([...this._instructedLearnerGroupOfferings, ...this._instructedOfferings]);
+    return uniqueValues([...this._instructedLearnerGroupOfferings, ...this._instructedOfferings]);
   }
 
   @use _instructorIlmSessions = new ResolveAsyncValue(() => [this.instructorIlmSessions]);
@@ -326,7 +326,7 @@ export default class User extends Model {
     ) {
       return [];
     }
-    return uniqueById(
+    return uniqueValues(
       [
         ...this._instructorIlmSessionsSessions,
         ...this._instructedOfferingSessions,
@@ -353,7 +353,7 @@ export default class User extends Model {
     if (!this._learnerGroupOfferings || !this._offerings) {
       return [];
     }
-    return uniqueById([...this._learnerGroupOfferings, ...this._offerings.slice()]);
+    return uniqueValues([...this._learnerGroupOfferings, ...this._offerings.slice()]);
   }
   @use _learnerOfferingSessions = new ResolveFlatMapBy(() => [this._learnerOfferings, 'session']);
 
@@ -365,7 +365,7 @@ export default class User extends Model {
     ) {
       return [];
     }
-    return uniqueById(
+    return uniqueValues(
       [
         ...this._learnerOfferingSessions,
         ...this._learnerIlmSessionSessions,
@@ -385,7 +385,7 @@ export default class User extends Model {
     ) {
       return [];
     }
-    return uniqueById([
+    return uniqueValues([
       ...this._learnerCourses,
       ...this.allInstructedCourses,
       ...this._directedCourses.slice(),

--- a/addon/models/user.js
+++ b/addon/models/user.js
@@ -2,6 +2,7 @@ import Model, { hasMany, belongsTo, attr } from '@ember-data/model';
 import { use } from 'ember-could-get-used-to-this';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
+import { mapBy } from '../utils/array-helpers';
 
 export default class User extends Model {
   @attr('string')
@@ -181,7 +182,7 @@ export default class User extends Model {
   @use _roles = new ResolveAsyncValue(() => [this.roles, []]);
 
   get _roleTitles() {
-    return this._roles.mapBy('title');
+    return mapBy(this._roles, 'title');
   }
 
   get isStudent() {
@@ -416,7 +417,7 @@ export default class User extends Model {
     const relevantGroups = learnerGroups
       .toArray()
       .filter((group) => learnerGroupTree.includes(group));
-    const relevantGroupIds = relevantGroups.mapBy('id');
+    const relevantGroupIds = mapBy(relevantGroups, 'id');
     const lowestGroup = relevantGroups.find((group) => {
       const childIds = group.hasMany('children').ids();
       const childGroupsWhoAreUserGroupMembers = childIds.filter((id) =>

--- a/addon/models/user.js
+++ b/addon/models/user.js
@@ -309,7 +309,7 @@ export default class User extends Model {
     if (!this._instructorIlmSessions) {
       return [];
     }
-    return this._instructorIlmSessions.toArray();
+    return this._instructorIlmSessions.slice();
   }
 
   @use _instructedOfferingSessions = new ResolveFlatMapBy(() => [
@@ -353,7 +353,7 @@ export default class User extends Model {
     if (!this._learnerGroupOfferings || !this._offerings) {
       return [];
     }
-    return uniqueById([...this._learnerGroupOfferings, ...this._offerings.toArray()]);
+    return uniqueById([...this._learnerGroupOfferings, ...this._offerings.slice()]);
   }
   @use _learnerOfferingSessions = new ResolveFlatMapBy(() => [this._learnerOfferings, 'session']);
 
@@ -388,8 +388,8 @@ export default class User extends Model {
     return uniqueById([
       ...this._learnerCourses,
       ...this.allInstructedCourses,
-      ...this._directedCourses.toArray(),
-      ...this._administeredCourses.toArray(),
+      ...this._directedCourses.slice(),
+      ...this._administeredCourses.slice(),
     ]);
   }
 
@@ -399,7 +399,7 @@ export default class User extends Model {
     if (!this._cohorts || !this._primaryCohort) {
       return [];
     }
-    return this._cohorts.toArray().filter((cohort) => cohort !== this._primaryCohort);
+    return this._cohorts.slice().filter((cohort) => cohort !== this._primaryCohort);
   }
 
   /**
@@ -415,7 +415,7 @@ export default class User extends Model {
     const learnerGroups = await this.learnerGroups;
     //all the groups a user is in that are in our current learner groups tree
     const relevantGroups = learnerGroups
-      .toArray()
+      .slice()
       .filter((group) => learnerGroupTree.includes(group));
     const relevantGroupIds = mapBy(relevantGroups, 'id');
     const lowestGroup = relevantGroups.find((group) => {

--- a/addon/models/vocabulary.js
+++ b/addon/models/vocabulary.js
@@ -26,7 +26,7 @@ export default class Vocabulary extends Model {
 
   async getTopLevelTerms() {
     const terms = await this.terms;
-    return filter(terms.toArray(), async (term) => {
+    return filter(terms.slice(), async (term) => {
       return !(await term.parent);
     });
   }

--- a/addon/routes/course-materials.js
+++ b/addon/routes/course-materials.js
@@ -1,6 +1,7 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import { all } from 'rsvp';
+import { mapBy } from '../utils/array-helpers';
 
 export default class CourseMaterialsRoute extends Route {
   @service session;
@@ -25,11 +26,11 @@ export default class CourseMaterialsRoute extends Route {
 
   async loadCourseLearningMaterials(course) {
     const courseLearningMaterials = await course.learningMaterials;
-    return all(courseLearningMaterials.mapBy('learningMaterial'));
+    return all(mapBy(courseLearningMaterials, 'learningMaterial'));
   }
 
   async loadSessionLearningMaterials(course) {
     const sessions = await course.sessions;
-    return all([sessions.mapBy('learningMaterials'), sessions.mapBy('firstOfferingDate')]);
+    return all([mapBy(sessions, 'learningMaterials'), mapBy(sessions, 'firstOfferingDate')]);
   }
 }

--- a/addon/routes/course-visualizations.js
+++ b/addon/routes/course-visualizations.js
@@ -1,6 +1,7 @@
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { all } from 'rsvp';
+import { mapBy } from '../utils/array-helpers';
 
 export default class CourseVisualizationsRoute extends Route {
   @service store;
@@ -21,7 +22,7 @@ export default class CourseVisualizationsRoute extends Route {
     const course = model.get('id');
     const sessions = model.hasMany('sessions').ids();
     const existingSessionsInStore = this.store.peekAll('session');
-    const existingSessionIds = existingSessionsInStore.mapBy('id');
+    const existingSessionIds = mapBy(existingSessionsInStore, 'id');
     const unloadedSessions = sessions.filter((id) => !existingSessionIds.includes(id));
 
     //if we have already loaded all of these sessions we can just proceed normally

--- a/addon/routes/course-visualizations.js
+++ b/addon/routes/course-visualizations.js
@@ -38,19 +38,19 @@ export default class CourseVisualizationsRoute extends Route {
     ];
     const maximumSessionLoad = 100;
     if (sessions.length < maximumSessionLoad) {
-      promises.pushObject(this.store.query('session-objective', { filters: { sessions } }));
-      promises.pushObject(this.store.query('session-type', { filters: { sessions } }));
-      promises.pushObject(this.store.query('term', { filters: { sessions } }));
+      promises.push(this.store.query('session-objective', { filters: { sessions } }));
+      promises.push(this.store.query('session-type', { filters: { sessions } }));
+      promises.push(this.store.query('term', { filters: { sessions } }));
     } else {
       for (let i = 0; i < sessions.length; i += maximumSessionLoad) {
         const slice = sessions.slice(i, i + maximumSessionLoad);
-        promises.pushObject(
+        promises.push(
           this.store.query('session-objective', {
             filters: { sessions: slice },
           })
         );
-        promises.pushObject(this.store.query('session-type', { filters: { sessions: slice } }));
-        promises.pushObject(this.store.query('term', { filters: { sessions: slice } }));
+        promises.push(this.store.query('session-type', { filters: { sessions: slice } }));
+        promises.push(this.store.query('term', { filters: { sessions: slice } }));
       }
     }
 

--- a/addon/routes/course-visualize-instructor.js
+++ b/addon/routes/course-visualize-instructor.js
@@ -15,7 +15,7 @@ export default class CourseVisualizeInstructorRoute extends Route {
   }
 
   async afterModel({ course }) {
-    const sessions = (await course.sessions).toArray();
+    const sessions = (await course.sessions).slice();
     return await all([course.school, map(sessions, (s) => s.sessionType)]);
   }
 

--- a/addon/routes/course-visualize-instructors.js
+++ b/addon/routes/course-visualize-instructors.js
@@ -14,7 +14,7 @@ export default class CourseVisualizeInstructorsRoute extends Route {
   }
 
   async afterModel(course) {
-    const sessions = (await course.sessions).toArray();
+    const sessions = (await course.sessions).slice();
     return await all([
       map(sessions, (s) => s.offerings),
       map(sessions, (s) => s.totalSumDuration),

--- a/addon/routes/course-visualize-objectives.js
+++ b/addon/routes/course-visualize-objectives.js
@@ -14,7 +14,7 @@ export default class CourseVisualizeObjectivesRoute extends Route {
   }
 
   async afterModel(course) {
-    const sessions = (await course.sessions).toArray();
+    const sessions = (await course.sessions).slice();
     return await all([course.objectives, map(sessions, (s) => s.objectives)]);
   }
 

--- a/addon/routes/course-visualize-session-type.js
+++ b/addon/routes/course-visualize-session-type.js
@@ -16,7 +16,7 @@ export default class CourseVisualizeSessionTypeRoute extends Route {
   }
 
   async afterModel({ course }) {
-    const sessions = (await course.sessions).toArray();
+    const sessions = (await course.sessions).slice();
     return await all([
       map(sessions, (s) => s.sessionType),
       map(sessions, (s) => s.terms),

--- a/addon/routes/course-visualize-session-types.js
+++ b/addon/routes/course-visualize-session-types.js
@@ -14,8 +14,8 @@ export default class CourseVisualizeSessionTypesRoute extends Route {
   }
 
   async afterModel(course) {
-    const sessions = (await course.sessions).toArray();
-    return await map(sessions.toArray(), (s) => s.sessionType);
+    const sessions = (await course.sessions).slice();
+    return await map(sessions.slice(), (s) => s.sessionType);
   }
 
   beforeModel(transition) {

--- a/addon/routes/course-visualize-term.js
+++ b/addon/routes/course-visualize-term.js
@@ -16,7 +16,7 @@ export default class CourseVisualizeTermRoute extends Route {
   }
 
   async afterModel({ course, term }) {
-    const sessions = (await course.sessions).toArray();
+    const sessions = (await course.sessions).slice();
     return await all([
       term.vocabulary,
       map(sessions, (s) => s.sessionType),

--- a/addon/routes/course-visualize-vocabularies.js
+++ b/addon/routes/course-visualize-vocabularies.js
@@ -14,7 +14,7 @@ export default class CourseVisualizeVocabulariesRoute extends Route {
   }
 
   async afterModel(course) {
-    const sessions = (await course.sessions).toArray();
+    const sessions = (await course.sessions).slice();
     return await all([course.get('school'), map(sessions, (s) => s.terms)]);
   }
 

--- a/addon/routes/course-visualize-vocabulary.js
+++ b/addon/routes/course-visualize-vocabulary.js
@@ -17,7 +17,7 @@ export default class CourseVisualizeVocabularyRoute extends Route {
 
   async afterModel(model) {
     const { course, vocabulary } = model;
-    const sessions = (await course.sessions).toArray();
+    const sessions = (await course.sessions).slice();
     return await all([course.get('school'), vocabulary.terms, map(sessions, (s) => s.terms)]);
   }
 

--- a/addon/routes/session.js
+++ b/addon/routes/session.js
@@ -1,5 +1,6 @@
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
+import { findById } from '../utils/array-helpers';
 
 export default class SessionRoute extends Route {
   @service dataLoader;
@@ -9,7 +10,7 @@ export default class SessionRoute extends Route {
     const course = this.modelFor('course');
     await this.dataLoader.loadCourseSessions(course.id);
     const sessions = await course.sessions;
-    return sessions.findBy('id', params.session_id);
+    return findById(sessions, params.session_id);
   }
 
   beforeModel(transition) {

--- a/addon/services/current-user.js
+++ b/addon/services/current-user.js
@@ -3,6 +3,7 @@ import { get } from '@ember/object';
 import Service, { inject as service } from '@ember/service';
 import moment from 'moment';
 import jwtDecode from '../utils/jwt-decode';
+import { filterBy } from '../utils/array-helpers';
 
 export default class CurrentUserService extends Service {
   @service store;
@@ -202,7 +203,7 @@ export default class CurrentUserService extends Service {
     const user = await this.getModel();
 
     const courses = await user.get('allInstructedCourses');
-    const matches = courses.filterBy('id', course.get('id'));
+    const matches = filterBy(courses, 'id', course.id);
 
     return matches.length > 0;
   }
@@ -217,7 +218,7 @@ export default class CurrentUserService extends Service {
     const user = await this.getModel();
 
     const sessions = await user.get('allInstructedSessions');
-    const matches = sessions.filterBy('id', session.get('id'));
+    const matches = filterBy(sessions, 'id', session.id);
 
     return matches.length > 0;
   }

--- a/addon/services/current-user.js
+++ b/addon/services/current-user.js
@@ -255,49 +255,49 @@ export default class CurrentUserService extends Service {
   async getRolesInSchool(school, rolesToCheck = []) {
     const roles = [];
     if (rolesToCheck.includes('SCHOOL_DIRECTOR') && (await this.isDirectingSchool(school))) {
-      roles.pushObject('SCHOOL_DIRECTOR');
+      roles.push('SCHOOL_DIRECTOR');
     }
     if (
       rolesToCheck.includes('SCHOOL_ADMINISTRATOR') &&
       (await this.isAdministeringSchool(school))
     ) {
-      roles.pushObject('SCHOOL_ADMINISTRATOR');
+      roles.push('SCHOOL_ADMINISTRATOR');
     }
     if (
       rolesToCheck.includes('PROGRAM_DIRECTOR') &&
       (await this.isDirectingProgramInSchool(school))
     ) {
-      roles.pushObject('PROGRAM_DIRECTOR');
+      roles.push('PROGRAM_DIRECTOR');
     }
     if (
       rolesToCheck.includes('COURSE_DIRECTOR') &&
       (await this.isDirectingCourseInSchool(school))
     ) {
-      roles.pushObject('COURSE_DIRECTOR');
+      roles.push('COURSE_DIRECTOR');
     }
     if (
       rolesToCheck.includes('COURSE_ADMINISTRATOR') &&
       (await this.isAdministeringCourseInSchool(school))
     ) {
-      roles.pushObject('COURSE_ADMINISTRATOR');
+      roles.push('COURSE_ADMINISTRATOR');
     }
     if (
       rolesToCheck.includes('SESSION_ADMINISTRATOR') &&
       (await this.isAdministeringSessionInSchool(school))
     ) {
-      roles.pushObject('SESSION_ADMINISTRATOR');
+      roles.push('SESSION_ADMINISTRATOR');
     }
     if (
       rolesToCheck.includes('COURSE_INSTRUCTOR') &&
       (await this.isTeachingCourseInSchool(school))
     ) {
-      roles.pushObject('COURSE_INSTRUCTOR');
+      roles.push('COURSE_INSTRUCTOR');
     }
     if (
       rolesToCheck.includes('CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR') &&
       (await this.isAdministeringCurriculumInventoryReportInSchool(school))
     ) {
-      roles.pushObject('CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR');
+      roles.push('CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR');
     }
 
     return roles;
@@ -305,22 +305,22 @@ export default class CurrentUserService extends Service {
   async getRolesInCourse(course, rolesToCheck = []) {
     const roles = [];
     if (rolesToCheck.includes('COURSE_DIRECTOR') && (await this.isDirectingCourse(course))) {
-      roles.pushObject('COURSE_DIRECTOR');
+      roles.push('COURSE_DIRECTOR');
     }
     if (
       rolesToCheck.includes('COURSE_ADMINISTRATOR') &&
       (await this.isAdministeringCourse(course))
     ) {
-      roles.pushObject('COURSE_ADMINISTRATOR');
+      roles.push('COURSE_ADMINISTRATOR');
     }
     if (
       rolesToCheck.includes('SESSION_ADMINISTRATOR') &&
       (await this.isAdministeringSessionInCourse(course))
     ) {
-      roles.pushObject('SESSION_ADMINISTRATOR');
+      roles.push('SESSION_ADMINISTRATOR');
     }
     if (rolesToCheck.includes('COURSE_INSTRUCTOR') && (await this.isTeachingCourse(course))) {
-      roles.pushObject('COURSE_INSTRUCTOR');
+      roles.push('COURSE_INSTRUCTOR');
     }
 
     return roles;
@@ -331,10 +331,10 @@ export default class CurrentUserService extends Service {
       rolesToCheck.includes('SESSION_ADMINISTRATOR') &&
       (await this.isAdministeringSession(session))
     ) {
-      roles.pushObject('SESSION_ADMINISTRATOR');
+      roles.push('SESSION_ADMINISTRATOR');
     }
     if (rolesToCheck.includes('SESSION_INSTRUCTOR') && (await this.isTeachingSession(session))) {
-      roles.pushObject('SESSION_INSTRUCTOR');
+      roles.push('SESSION_INSTRUCTOR');
     }
 
     return roles;
@@ -342,13 +342,13 @@ export default class CurrentUserService extends Service {
   async getRolesInProgram(program, rolesToCheck = []) {
     const roles = [];
     if (rolesToCheck.includes('PROGRAM_DIRECTOR') && (await this.isDirectingProgram(program))) {
-      roles.pushObject('PROGRAM_DIRECTOR');
+      roles.push('PROGRAM_DIRECTOR');
     }
     if (
       rolesToCheck.includes('PROGRAM_YEAR_DIRECTOR') &&
       (await this.isDirectingProgramYearInProgram(program))
     ) {
-      roles.pushObject('PROGRAM_YEAR_DIRECTOR');
+      roles.push('PROGRAM_YEAR_DIRECTOR');
     }
 
     return roles;
@@ -359,7 +359,7 @@ export default class CurrentUserService extends Service {
       rolesToCheck.includes('PROGRAM_YEAR_DIRECTOR') &&
       (await this.isDirectingProgramYear(programYear))
     ) {
-      roles.pushObject('PROGRAM_YEAR_DIRECTOR');
+      roles.push('PROGRAM_YEAR_DIRECTOR');
     }
 
     return roles;
@@ -370,7 +370,7 @@ export default class CurrentUserService extends Service {
       rolesToCheck.includes('CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR') &&
       (await this.isAdministeringCurriculumInventoryReport(report))
     ) {
-      roles.pushObject('CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR');
+      roles.push('CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR');
     }
 
     return roles;

--- a/addon/services/permission-matrix.js
+++ b/addon/services/permission-matrix.js
@@ -1,4 +1,5 @@
 import Service, { inject as service } from '@ember/service';
+import { mapBy } from '../utils/array-helpers';
 
 export default class PermissionMatrixService extends Service {
   @service store;
@@ -13,7 +14,7 @@ export default class PermissionMatrixService extends Service {
   }
   async _fillMatrix() {
     const schools = await this.store.findAll('school');
-    const schoolIds = schools.mapBy('id');
+    const schoolIds = mapBy(schools, 'id');
     const matrix = {};
     schoolIds.forEach((id) => {
       matrix[id] = {

--- a/addon/services/school-events.js
+++ b/addon/services/school-events.js
@@ -1,6 +1,7 @@
 import EventsBase from '../classes/events-base';
 import { inject as service } from '@ember/service';
 import moment from 'moment';
+import { sortBy } from '../utils/array-helpers';
 
 export default class SchoolEvents extends EventsBase {
   @service store;
@@ -27,9 +28,10 @@ export default class SchoolEvents extends EventsBase {
 
     const data = await this.fetch.getJsonFromApiHost(url);
 
-    return data.events
-      .map((obj) => this.createEventFromData(obj, false))
-      .sortBy('startDate', 'name');
+    return sortBy(
+      data.events.map((obj) => this.createEventFromData(obj, false)),
+      ['startDate', 'name']
+    );
   }
 
   /**

--- a/addon/services/timezone.js
+++ b/addon/services/timezone.js
@@ -1,5 +1,6 @@
 import Service from '@ember/service';
 import moment from 'moment';
+import { uniqueValues } from '../utils/array-helpers';
 
 /**
  * Service wrapper around moment's timezone utilities.
@@ -55,7 +56,7 @@ export default class TimezoneService extends Service {
     });
     // ensure that the current timezone is always part of the list
     timezoneNames.push(currentTimezone);
-    timezoneNames = timezoneNames.uniq().sort();
+    timezoneNames = uniqueValues(timezoneNames).sort();
     return timezoneNames;
   }
 

--- a/addon/services/user-events.js
+++ b/addon/services/user-events.js
@@ -1,6 +1,7 @@
 import EventsBase from '../classes/events-base';
 import { inject as service } from '@ember/service';
 import moment from 'moment';
+import { sortBy } from '../utils/array-helpers';
 
 export default class UserEvents extends EventsBase {
   @service store;
@@ -31,9 +32,10 @@ export default class UserEvents extends EventsBase {
 
     const data = await this.fetch.getJsonFromApiHost(url);
 
-    return data.userEvents
-      .map((obj) => this.createEventFromData(obj, true))
-      .sortBy('startDate', 'name');
+    return sortBy(
+      data.userEvents.map((obj) => this.createEventFromData(obj, true)),
+      ['startDate', 'name']
+    );
   }
 
   /**

--- a/addon/utils/array-helpers.js
+++ b/addon/utils/array-helpers.js
@@ -1,0 +1,118 @@
+import { get } from '@ember/object';
+import { DateTime } from 'luxon';
+
+export function mapBy(arr, path) {
+  if (arr !== null && typeof arr === 'object') {
+    if ('slice' in arr) {
+      arr = arr.slice();
+    }
+  }
+  if (!Array.isArray(arr)) {
+    return arr;
+  }
+  return arr.map((item) => {
+    if (item === undefined) {
+      return undefined;
+    }
+    if (item === null) {
+      return null;
+    }
+
+    return get(item, path);
+  });
+}
+
+export function sortByString(arr, path) {
+  if (arr !== null && typeof arr === 'object') {
+    if ('slice' in arr) {
+      arr = arr.slice();
+    }
+  }
+
+  if (!Array.isArray(arr)) {
+    return arr;
+  }
+
+  return arr.sort((objA, objB) => {
+    const a = get(objA ?? {}, path);
+    const b = get(objB ?? {}, path);
+
+    if (a === b) {
+      return 0;
+    }
+
+    if (a === undefined || a === null) {
+      return 1;
+    }
+
+    if (b === undefined || b === null) {
+      return -1;
+    }
+
+    return a.localeCompare(b);
+  });
+}
+
+export function sortByDate(arr, path) {
+  if (arr !== null && typeof arr === 'object') {
+    if ('slice' in arr) {
+      arr = arr.slice();
+    }
+  }
+
+  if (!Array.isArray(arr)) {
+    return arr;
+  }
+
+  return arr.sort((objA, objB) => {
+    const a = get(objA ?? {}, path);
+    const b = get(objB ?? {}, path);
+
+    if (a === b) {
+      return 0;
+    }
+
+    if (a === undefined || a === null) {
+      return 1;
+    }
+
+    if (b === undefined || b === null) {
+      return -1;
+    }
+    const d1 = DateTime.fromJSDate(a);
+    const d2 = DateTime.fromJSDate(b);
+
+    return d1.toMillis() - d2.toMillis();
+  });
+}
+
+export function sortByNumber(arr, path) {
+  if (arr !== null && typeof arr === 'object') {
+    if ('slice' in arr) {
+      arr = arr.slice();
+    }
+  }
+
+  if (!Array.isArray(arr)) {
+    return arr;
+  }
+
+  return arr.sort((objA, objB) => {
+    const a = get(objA ?? {}, path);
+    const b = get(objB ?? {}, path);
+
+    if (a === b) {
+      return 0;
+    }
+
+    if (a === undefined || a === null) {
+      return 1;
+    }
+
+    if (b === undefined || b === null) {
+      return -1;
+    }
+
+    return a - b;
+  });
+}

--- a/addon/utils/array-helpers.js
+++ b/addon/utils/array-helpers.js
@@ -167,3 +167,29 @@ export function uniqueValues(arr) {
 
   return [...new Set(arr)];
 }
+
+export function findBy(arr, key, searchValue) {
+  if (arr !== null && typeof arr === 'object') {
+    if ('slice' in arr) {
+      arr = arr.slice();
+    }
+  }
+
+  if (!Array.isArray(arr)) {
+    return arr;
+  }
+
+  return arr.find((item) => {
+    if (item === undefined) {
+      return false;
+    }
+    if (item === null) {
+      return false;
+    }
+    return get(item, key) === searchValue;
+  });
+}
+
+export function findById(arr, id) {
+  return findBy(arr, 'id', id);
+}

--- a/addon/utils/array-helpers.js
+++ b/addon/utils/array-helpers.js
@@ -44,14 +44,6 @@ export function sortBy(arr, sortKeys) {
       const a = get(objA ?? {}, key);
       const b = get(objB ?? {}, key);
 
-      if (a === undefined || a === null) {
-        return 1;
-      }
-
-      if (b === undefined || b === null) {
-        return -1;
-      }
-
       // return 1 or -1 else continue to the next sortKey
       const compareValue = compare(a, b);
 

--- a/addon/utils/array-helpers.js
+++ b/addon/utils/array-helpers.js
@@ -193,3 +193,30 @@ export function findBy(arr, key, searchValue) {
 export function findById(arr, id) {
   return findBy(arr, 'id', id);
 }
+
+export function filterBy(arr, key, searchValue) {
+  if (arr !== null && typeof arr === 'object') {
+    if ('slice' in arr) {
+      arr = arr.slice();
+    }
+  }
+
+  if (!Array.isArray(arr)) {
+    return arr;
+  }
+
+  return arr.filter((item) => {
+    if (item === undefined) {
+      return false;
+    }
+    if (item === null) {
+      return false;
+    }
+    const value = get(item, key);
+    if (searchValue === undefined) {
+      return Boolean(value);
+    }
+
+    return searchValue === value;
+  });
+}

--- a/addon/utils/array-helpers.js
+++ b/addon/utils/array-helpers.js
@@ -71,16 +71,14 @@ export function uniqueBy(arr, key) {
   const seen = new Set();
   const rhett = [];
   arr.forEach((item) => {
+    let value;
     if (item === undefined) {
-      rhett.push(undefined);
-      return;
+      value = undefined;
+    } else if (item === null) {
+      value = null;
+    } else {
+      value = get(item, key);
     }
-    if (item === null) {
-      rhett.push(null);
-      return;
-    }
-
-    const value = get(item, key);
     if (seen.has(value)) {
       return;
     }

--- a/addon/utils/array-helpers.js
+++ b/addon/utils/array-helpers.js
@@ -7,9 +7,11 @@ export function mapBy(arr, path) {
       arr = arr.slice();
     }
   }
+  assert('value passed to mapBy is an array', Array.isArray(arr));
   if (!Array.isArray(arr)) {
-    return arr;
+    return [];
   }
+
   return arr.map((item) => {
     if (item === undefined) {
       return undefined;
@@ -29,9 +31,9 @@ export function sortBy(arr, sortKeys) {
       arr = arr.slice();
     }
   }
-
+  assert('value passed to sortBy is an array', Array.isArray(arr));
   if (!Array.isArray(arr)) {
-    return arr;
+    return [];
   }
 
   if (!Array.isArray(sortKeys)) {
@@ -61,9 +63,9 @@ export function uniqueBy(arr, key) {
       arr = arr.slice();
     }
   }
-
+  assert('value passed to uniqueBy is an array', Array.isArray(arr));
   if (!Array.isArray(arr)) {
-    return arr;
+    return [];
   }
 
   const seen = new Set();
@@ -98,9 +100,9 @@ export function uniqueValues(arr) {
       arr = arr.slice();
     }
   }
-
+  assert('value passed to uniqueValues is an array', Array.isArray(arr));
   if (!Array.isArray(arr)) {
-    return arr;
+    return [];
   }
 
   return [...new Set(arr)];
@@ -112,9 +114,9 @@ export function findBy(arr, key, searchValue) {
       arr = arr.slice();
     }
   }
-
+  assert('value passed to findBy is an array', Array.isArray(arr));
   if (!Array.isArray(arr)) {
-    return arr;
+    return [];
   }
 
   return arr.find((item) => {
@@ -138,9 +140,9 @@ export function filterBy(arr, key, searchValue) {
       arr = arr.slice();
     }
   }
-
+  assert('value passed to filterBy is an array', Array.isArray(arr));
   if (!Array.isArray(arr)) {
-    return arr;
+    return [];
   }
 
   return arr.filter((item) => {

--- a/addon/utils/array-helpers.js
+++ b/addon/utils/array-helpers.js
@@ -116,3 +116,54 @@ export function sortByNumber(arr, path) {
     return a - b;
   });
 }
+
+export function uniqueBy(arr, key) {
+  if (arr !== null && typeof arr === 'object') {
+    if ('slice' in arr) {
+      arr = arr.slice();
+    }
+  }
+
+  if (!Array.isArray(arr)) {
+    return arr;
+  }
+
+  const seen = new Set();
+  const rhett = [];
+  arr.forEach((item) => {
+    if (item === undefined) {
+      rhett.push(undefined);
+      return;
+    }
+    if (item === null) {
+      rhett.push(null);
+      return;
+    }
+
+    const value = get(item, key);
+    if (seen.has(value)) {
+      return;
+    }
+    seen.add(value);
+    rhett.push(item);
+  });
+  return rhett;
+}
+
+export function uniqueById(arr) {
+  return uniqueBy(arr, 'id');
+}
+
+export function uniqueValues(arr) {
+  if (arr !== null && typeof arr === 'object') {
+    if ('slice' in arr) {
+      arr = arr.slice();
+    }
+  }
+
+  if (!Array.isArray(arr)) {
+    return arr;
+  }
+
+  return [...new Set(arr)];
+}

--- a/addon/utils/offering-date-block.js
+++ b/addon/utils/offering-date-block.js
@@ -47,7 +47,7 @@ const OfferingDateBlock = OfferingBlock.extend({
     const offeringGroupArray = [];
     let key;
     for (key in offeringGroups) {
-      offeringGroupArray.pushObject(offeringGroups[key]);
+      offeringGroupArray.push(offeringGroups[key]);
     }
 
     return sortByNumber(offeringGroupArray, 'timeKey');

--- a/addon/utils/offering-date-block.js
+++ b/addon/utils/offering-date-block.js
@@ -1,6 +1,7 @@
 import EmberObject, { computed } from '@ember/object';
 import { sort } from '@ember/object/computed';
 import moment from 'moment';
+import { sortByNumber } from './array-helpers';
 
 const OfferingBlock = EmberObject.extend({
   offerings: null,
@@ -49,7 +50,7 @@ const OfferingDateBlock = OfferingBlock.extend({
       offeringGroupArray.pushObject(offeringGroups[key]);
     }
 
-    return offeringGroupArray.sortBy('timeKey');
+    return sortByNumber(offeringGroupArray, 'timeKey');
   }),
 });
 

--- a/addon/utils/offering-date-block.js
+++ b/addon/utils/offering-date-block.js
@@ -1,7 +1,7 @@
 import EmberObject, { computed } from '@ember/object';
 import { sort } from '@ember/object/computed';
 import moment from 'moment';
-import { sortByNumber } from './array-helpers';
+import { sortBy } from './array-helpers';
 
 const OfferingBlock = EmberObject.extend({
   offerings: null,
@@ -50,7 +50,7 @@ const OfferingDateBlock = OfferingBlock.extend({
       offeringGroupArray.push(offeringGroups[key]);
     }
 
-    return sortByNumber(offeringGroupArray, 'timeKey');
+    return sortBy(offeringGroupArray, 'timeKey');
   }),
 });
 

--- a/addon/utils/offering-date-block.js
+++ b/addon/utils/offering-date-block.js
@@ -57,7 +57,7 @@ const OfferingDateBlock = OfferingBlock.extend({
 const OfferingTimeBlock = OfferingBlock.extend({
   init() {
     this._super(...arguments);
-    this.set('sortOfferingsBy', ['learnerGroups.firstObject.title']);
+    this.set('sortOfferingsBy', ['learnerGroups[0].title']);
   },
   timeKey: null,
   isMultiDay: computed('startDate', 'endDate', function () {

--- a/addon/utils/preload-course.js
+++ b/addon/utils/preload-course.js
@@ -1,10 +1,12 @@
+import { mapBy } from './array-helpers';
+
 export default async function preloadCourse(store, courseModel) {
   const courses = [courseModel.get('id')];
   const course = courseModel.get('id');
   const school = courseModel.belongsTo('school').id();
   const sessions = courseModel.hasMany('sessions').ids();
   const existingSessionsInStore = store.peekAll('session');
-  const existingSessionIds = existingSessionsInStore.mapBy('id');
+  const existingSessionIds = mapBy(existingSessionsInStore, 'id');
   const unloadedSessions = sessions.filter((id) => !existingSessionIds.includes(id));
 
   //if we have already loaded all of these sessions we can just proceed normally

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,6 +94,7 @@
         "ember-cli-server-variables": "^3.0.0",
         "ember-cli-sri": "^2.1.1",
         "ember-cli-terser": "^4.0.2",
+        "ember-disable-prototype-extensions": "^1.1.3",
         "ember-export-application-global": "^2.0.1",
         "ember-load-initializers": "^2.1.2",
         "ember-page-title": "^7.0.0",
@@ -13969,6 +13970,15 @@
       },
       "engines": {
         "node": "10.* || >= 12"
+      }
+    },
+    "node_modules/ember-disable-prototype-extensions": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/ember-disable-prototype-extensions/-/ember-disable-prototype-extensions-1.1.3.tgz",
+      "integrity": "sha512-SB9NcZ27OtoUk+gfalsc3QU17+54OoqR668qHcuvHByk4KAhGxCKlkm9EBlKJcGr7yceOOAJqohTcCEBqfRw9g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10.0"
       }
     },
     "node_modules/ember-event-helpers": {
@@ -42706,6 +42716,12 @@
         "ember-cli-version-checker": "^5.1.1",
         "ember-compatibility-helpers": "^1.2.1"
       }
+    },
+    "ember-disable-prototype-extensions": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/ember-disable-prototype-extensions/-/ember-disable-prototype-extensions-1.1.3.tgz",
+      "integrity": "sha512-SB9NcZ27OtoUk+gfalsc3QU17+54OoqR668qHcuvHByk4KAhGxCKlkm9EBlKJcGr7yceOOAJqohTcCEBqfRw9g==",
+      "dev": true
     },
     "ember-event-helpers": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
     "ember-cli-server-variables": "^3.0.0",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",
+    "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.2",
     "ember-page-title": "^7.0.0",

--- a/tests/integration/components/dashboard/week-test.js
+++ b/tests/integration/components/dashboard/week-test.js
@@ -52,7 +52,7 @@ module('Integration | Component | dashboard/week', function (hooks) {
 
     this.userEventsMock = Service.extend({
       async getEvents() {
-        return events.toArray();
+        return events.slice();
       },
     });
     this.blankEventsMock = Service.extend({

--- a/tests/integration/components/leadership-manager-test.js
+++ b/tests/integration/components/leadership-manager-test.js
@@ -14,7 +14,7 @@ module('Integration | Component | leadership manager', function (hooks) {
   test('it renders with data', async function (assert) {
     assert.expect(7);
     this.server.createList('user', 2);
-    const users = await this.owner.lookup('service:store').findAll('user');
+    const users = (await this.owner.lookup('service:store').findAll('user')).slice();
     this.set('directors', [users[0]]);
     this.set('administrators', users);
     this.set('studentAdvisors', [users[1]]);
@@ -316,7 +316,7 @@ module('Integration | Component | leadership manager', function (hooks) {
     this.server.create('user', {
       enabled: false,
     });
-    const users = await this.owner.lookup('service:store').findAll('user');
+    const users = (await this.owner.lookup('service:store').findAll('user')).slice();
 
     this.set('directors', [users[0]]);
     this.set('administrators', users);

--- a/tests/integration/components/leadership-manager-test.js
+++ b/tests/integration/components/leadership-manager-test.js
@@ -15,7 +15,7 @@ module('Integration | Component | leadership manager', function (hooks) {
     assert.expect(7);
     this.server.createList('user', 2);
     const users = await this.owner.lookup('service:store').findAll('user');
-    this.set('directors', [users.firstObject]);
+    this.set('directors', [users[0]]);
     this.set('administrators', users);
     this.set('studentAdvisors', [users[1]]);
 
@@ -318,7 +318,7 @@ module('Integration | Component | leadership manager', function (hooks) {
     });
     const users = await this.owner.lookup('service:store').findAll('user');
 
-    this.set('directors', [users.firstObject]);
+    this.set('directors', [users[0]]);
     this.set('administrators', users);
 
     await render(hbs`<LeadershipManager

--- a/tests/integration/components/leadership-manager-test.js
+++ b/tests/integration/components/leadership-manager-test.js
@@ -17,7 +17,7 @@ module('Integration | Component | leadership manager', function (hooks) {
     const users = await this.owner.lookup('service:store').findAll('user');
     this.set('directors', [users.firstObject]);
     this.set('administrators', users);
-    this.set('studentAdvisors', [users.objectAt(1)]);
+    this.set('studentAdvisors', [users[1]]);
 
     await render(hbs`<LeadershipManager
       @showAdministrators={{true}}

--- a/tests/integration/components/selectable-terms-list-item-test.js
+++ b/tests/integration/components/selectable-terms-list-item-test.js
@@ -58,7 +58,7 @@ module('Integration | Component | selectable terms list item', function (hooks) 
     this.set('term', this.termModel);
     this.set('add', (term) => {
       assert.strictEqual(term, this.termModel);
-      this.selectedTerms.pushObject(term);
+      this.selectedTerms.push(term);
     });
 
     await render(hbs`<SelectableTermsListItem

--- a/tests/integration/components/selectable-terms-list-item-test.js
+++ b/tests/integration/components/selectable-terms-list-item-test.js
@@ -61,7 +61,7 @@ module('Integration | Component | selectable terms list item', function (hooks) 
     this.set('term', this.termModel);
     this.set('add', (term) => {
       assert.strictEqual(term, this.termModel);
-      this.selectedTerms.push(term);
+      this.set('selectedTerms', [...this.selectedTerms, term]);
     });
 
     await render(hbs`<SelectableTermsListItem

--- a/tests/integration/components/selectable-terms-list-item-test.js
+++ b/tests/integration/components/selectable-terms-list-item-test.js
@@ -36,7 +36,10 @@ module('Integration | Component | selectable terms list item', function (hooks) 
     this.set('term', this.termModel);
     this.set('remove', (term) => {
       assert.strictEqual(term, this.termModel);
-      this.selectedTerms.removeObject(term);
+      this.set(
+        'selectedTerms',
+        this.selectedTerms.filter((t) => t !== term)
+      );
     });
 
     await render(hbs`<SelectableTermsListItem

--- a/tests/integration/components/selectable-terms-list-test.js
+++ b/tests/integration/components/selectable-terms-list-test.js
@@ -139,7 +139,7 @@ module('Integration | Component | selectable terms list', function (hooks) {
     this.set('terms', resolve([this.termModel4, this.termModel5]));
     this.set('add', (term) => {
       assert.strictEqual(term, this.termModel4);
-      this.selectedTerms.pushObject(term);
+      this.selectedTerms.push(term);
     });
     this.set('remove', (term) => {
       assert.strictEqual(term, this.termModel4);

--- a/tests/integration/components/selectable-terms-list-test.js
+++ b/tests/integration/components/selectable-terms-list-test.js
@@ -56,12 +56,11 @@ module('Integration | Component | selectable terms list', function (hooks) {
 
     this.set('selectedTerms', []);
     this.set('vocabulary', this.vocabularyModel);
-    this.set('nothing', () => {});
     await render(hbs`<SelectableTermsList
       @selectedTerms={{this.selectedTerms}}
       @vocabulary={{this.vocabulary}}
-      @add={{action this.nothing}}
-      @remove={{action this.nothing}}
+      @add={{action (noop)}}
+      @remove={{action (noop)}}
     />`);
 
     assert.dom('li').exists({ count: 5 });
@@ -84,12 +83,11 @@ module('Integration | Component | selectable terms list', function (hooks) {
 
     this.set('selectedTerms', []);
     this.set('terms', resolve([this.termModel4, this.termModel5]));
-    this.set('nothing', () => {});
     await render(hbs`<SelectableTermsList
       @selectedTerms={{this.selectedTerms}}
       @terms={{await this.terms}}
-      @add={{action this.nothing}}
-      @remove={{action this.nothing}}
+      @add={{action (noop)}}
+      @remove={{action (noop)}}
     />`);
 
     assert.dom('li').exists({ count: 5 });
@@ -116,12 +114,11 @@ module('Integration | Component | selectable terms list', function (hooks) {
 
     this.set('selectedTerms', []);
     this.set('terms', resolve([this.termModel4, this.termModel5]));
-    this.set('nothing', () => {});
     await render(hbs`<SelectableTermsList
       @selectedTerms={{this.selectedTerms}}
       @terms={{await this.terms}}
-      @add={{action this.nothing}}
-      @remove={{action this.nothing}}
+      @add={{action (noop)}}
+      @remove={{action (noop)}}
     />`);
 
     assert.dom('li').exists({ count: 2 });
@@ -139,11 +136,14 @@ module('Integration | Component | selectable terms list', function (hooks) {
     this.set('terms', resolve([this.termModel4, this.termModel5]));
     this.set('add', (term) => {
       assert.strictEqual(term, this.termModel4);
-      this.selectedTerms.push(term);
+      this.set('selectedTerms', [...this.selectedTerms, term]);
     });
     this.set('remove', (term) => {
       assert.strictEqual(term, this.termModel4);
-      this.selectedTerms.removeObject(term);
+      this.set(
+        'selectedTerms',
+        this.selectedTerms.filter((t) => t !== term)
+      );
     });
     await render(hbs`<SelectableTermsList
       @selectedTerms={{this.selectedTerms}}
@@ -165,13 +165,12 @@ module('Integration | Component | selectable terms list', function (hooks) {
 
     this.set('selectedTerms', []);
     this.set('vocabulary', this.vocabularyModel);
-    this.set('nothing', () => {});
     this.set('termFilter', 'Gamma');
     await render(hbs`<SelectableTermsList
       @selectedTerms={{this.selectedTerms}}
       @vocabulary={{this.vocabulary}}
-      @add={{action this.nothing}}
-      @remove={{action this.nothing}}
+      @add={{action (noop)}}
+      @remove={{action (noop)}}
       @termFilter={{this.termFilter}}
     />`);
 
@@ -188,13 +187,12 @@ module('Integration | Component | selectable terms list', function (hooks) {
 
     this.set('selectedTerms', []);
     this.set('vocabulary', this.vocabularyModel);
-    this.set('nothing', () => {});
     this.set('termFilter', 'amma');
     await render(hbs`<SelectableTermsList
       @selectedTerms={{this.selectedTerms}}
       @vocabulary={{this.vocabulary}}
-      @add={{action this.nothing}}
-      @remove={{action this.nothing}}
+      @add={{action (noop)}}
+      @remove={{action (noop)}}
       @termFilter={{this.termFilter}}
     />`);
 

--- a/tests/integration/components/session-copy-test.js
+++ b/tests/integration/components/session-copy-test.js
@@ -6,6 +6,7 @@ import { render, click, find, fillIn } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import moment from 'moment';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { findById } from 'ilios-common/utils/array-helpers';
 
 module('Integration | Component | session copy', function (hooks) {
   setupRenderingTest(hooks);
@@ -137,7 +138,7 @@ module('Integration | Component | session copy', function (hooks) {
 
     const sessions = await this.owner.lookup('service:store').findAll('session');
     assert.strictEqual(sessions.length, 2);
-    const newSession = sessions.findBy('id', '2');
+    const newSession = findById(sessions, '2');
     assert.strictEqual(session.attireRequired, newSession.attireRequired);
     assert.strictEqual(session.equipmentRequired, newSession.equipmentRequired);
     assert.strictEqual(session.supplemental, newSession.supplemental);
@@ -150,7 +151,7 @@ module('Integration | Component | session copy', function (hooks) {
       .lookup('service:store')
       .findAll('session-learning-material');
     assert.strictEqual(sessionLearningMaterials.length, 2);
-    const newSessionLm = sessionLearningMaterials.findBy('id', '2');
+    const newSessionLm = findById(sessionLearningMaterials, '2');
     assert.strictEqual(sessionLearningMaterial.notes, newSessionLm.notes);
     assert.strictEqual(sessionLearningMaterial.required, newSessionLm.required);
     assert.strictEqual(sessionLearningMaterial.publicNotes, newSessionLm.publicNotes);
@@ -160,7 +161,7 @@ module('Integration | Component | session copy', function (hooks) {
 
     const sessionObjectives = await this.owner.lookup('service:store').findAll('session-objective');
     assert.strictEqual(sessionObjectives.length, 2);
-    const newSessionObjective = sessionObjectives.findBy('id', '2');
+    const newSessionObjective = findById(sessionObjectives, '2');
     assert.strictEqual(newSessionObjective.title, sessionObjective.title);
     assert.strictEqual(sessionObjective.position, newSessionObjective.position);
     assert.strictEqual(newSessionObjective.belongsTo('session').id(), newSession.id);
@@ -313,7 +314,7 @@ module('Integration | Component | session copy', function (hooks) {
 
     const sessions = await this.owner.lookup('service:store').findAll('session');
     assert.strictEqual(sessions.length, 2);
-    const newSession = sessions.findBy('id', '2');
+    const newSession = findById(sessions, '2');
     assert.strictEqual(newSession.belongsTo('course').id(), course3.id);
   });
 
@@ -362,7 +363,7 @@ module('Integration | Component | session copy', function (hooks) {
 
     const sessions = await this.owner.lookup('service:store').findAll('session');
     assert.strictEqual(sessions.length, 3);
-    const newSession = sessions.findBy('id', '3');
+    const newSession = findById(sessions, '3');
     assert.strictEqual(session.title, newSession.title);
 
     const newPostRequisite = await newSession.postrequisite;
@@ -419,7 +420,7 @@ module('Integration | Component | session copy', function (hooks) {
 
     const sessions = await this.owner.lookup('service:store').findAll('session');
     assert.strictEqual(sessions.length, 3);
-    const newSession = sessions.findBy('id', '3');
+    const newSession = findById(sessions, '3');
     assert.strictEqual(session.title, newSession.title);
 
     const newPostRequisite = await newSession.postrequisite;
@@ -475,7 +476,7 @@ module('Integration | Component | session copy', function (hooks) {
 
     const sessions = await this.owner.lookup('service:store').findAll('session');
     assert.strictEqual(sessions.length, 4);
-    const newSession = sessions.findBy('id', '4');
+    const newSession = findById(sessions, '4');
     assert.strictEqual(session.title, newSession.title);
 
     const newPostRequisites = await newSession.prerequisites;
@@ -537,7 +538,7 @@ module('Integration | Component | session copy', function (hooks) {
 
     const sessions = await this.owner.lookup('service:store').findAll('session');
     assert.strictEqual(sessions.length, 4);
-    const newSession = sessions.findBy('id', '4');
+    const newSession = findById(sessions, '4');
     assert.strictEqual(session.title, newSession.title);
 
     const newPostRequisites = await newSession.prerequisites;

--- a/tests/integration/components/taxonomy-manager-test.js
+++ b/tests/integration/components/taxonomy-manager-test.js
@@ -121,7 +121,10 @@ module('Integration | Component | taxonomy manager', function (hooks) {
     });
     this.set('remove', (term) => {
       assert.strictEqual(term, this.termModel2);
-      this.selectedTerms.removeObject(term);
+      this.set(
+        'selectedTerms',
+        this.selectedTerms.filter((t) => t !== term)
+      );
     });
 
     await render(hbs`<TaxonomyManager

--- a/tests/integration/components/taxonomy-manager-test.js
+++ b/tests/integration/components/taxonomy-manager-test.js
@@ -117,7 +117,7 @@ module('Integration | Component | taxonomy manager', function (hooks) {
     this.set('selectedTerms', [this.termModel1]);
     this.set('add', (term) => {
       assert.strictEqual(term, this.termModel2);
-      this.selectedTerms.pushObject(term);
+      this.selectedTerms.push(term);
     });
     this.set('remove', (term) => {
       assert.strictEqual(term, this.termModel2);

--- a/tests/integration/components/taxonomy-manager-test.js
+++ b/tests/integration/components/taxonomy-manager-test.js
@@ -117,7 +117,7 @@ module('Integration | Component | taxonomy manager', function (hooks) {
     this.set('selectedTerms', [this.termModel1]);
     this.set('add', (term) => {
       assert.strictEqual(term, this.termModel2);
-      this.selectedTerms.push(term);
+      this.set('selectedTerms', [...this.selectedTerms, term]);
     });
     this.set('remove', (term) => {
       assert.strictEqual(term, this.termModel2);

--- a/tests/integration/components/user-search-test.js
+++ b/tests/integration/components/user-search-test.js
@@ -82,7 +82,7 @@ module('Integration | Component | user search', function (hooks) {
     this.server.createList('instructor-group', 2);
     const instructorGroups = this.owner.lookup('service:store').findAll('instructor-group');
     this.set('action', (group) => {
-      assert.strictEqual(group, instructorGroups.toArray()[0]);
+      assert.strictEqual(group, instructorGroups.slice()[0]);
     });
     this.set('availableInstructorGroups', instructorGroups);
     await render(hbs`<UserSearch

--- a/tests/integration/components/week-glance-test.js
+++ b/tests/integration/components/week-glance-test.js
@@ -64,7 +64,7 @@ module('Integration | Component | week glance', function (hooks) {
 
     this.userEventsMock = Service.extend({
       async getEvents() {
-        return events.toArray();
+        return events.slice();
       },
     });
     this.blankEventsMock = Service.extend({

--- a/tests/integration/services/current-user-test.js
+++ b/tests/integration/services/current-user-test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { authenticateSession, invalidateSession } from 'ember-simple-auth/test-support';
+import { mapBy } from 'ilios-common/utils/array-helpers';
 
 module('Integration | Service | Current User', function (hooks) {
   setupTest(hooks);
@@ -133,7 +134,7 @@ module('Integration | Service | Current User', function (hooks) {
     });
     const subject = this.owner.lookup('service:current-user');
     const activeRelatedCourses = await subject.getActiveRelatedCoursesInThisYearAndLastYear();
-    assert.ok(activeRelatedCourses.mapBy('id').includes(courses[0].id));
-    assert.ok(activeRelatedCourses.mapBy('id').includes(courses[1].id));
+    assert.ok(mapBy(activeRelatedCourses, 'id').includes(courses[0].id));
+    assert.ok(mapBy(activeRelatedCourses, 'id').includes(courses[1].id));
   });
 });

--- a/tests/unit/models/cohort-test.js
+++ b/tests/unit/models/cohort-test.js
@@ -40,7 +40,7 @@ module('Unit | Model | Cohort', function (hooks) {
       parent: topGroup2,
     });
 
-    model.get('learnerGroups').push([group1, group2, group3, group4, topGroup1, topGroup2]);
+    model.get('learnerGroups').pushObjects([group1, group2, group3, group4, topGroup1, topGroup2]);
 
     const topLevelGroups = await model.get('rootLevelLearnerGroups');
 

--- a/tests/unit/models/cohort-test.js
+++ b/tests/unit/models/cohort-test.js
@@ -40,7 +40,7 @@ module('Unit | Model | Cohort', function (hooks) {
       parent: topGroup2,
     });
 
-    model.get('learnerGroups').pushObjects([group1, group2, group3, group4, topGroup1, topGroup2]);
+    model.get('learnerGroups').push([group1, group2, group3, group4, topGroup1, topGroup2]);
 
     const topLevelGroups = await model.get('rootLevelLearnerGroups');
 

--- a/tests/unit/models/cohort-test.js
+++ b/tests/unit/models/cohort-test.js
@@ -45,8 +45,8 @@ module('Unit | Model | Cohort', function (hooks) {
     const topLevelGroups = await model.get('rootLevelLearnerGroups');
 
     assert.strictEqual(topLevelGroups.length, 2);
-    assert.strictEqual(topLevelGroups.objectAt(0).get('title'), 'Top Group 1');
-    assert.strictEqual(topLevelGroups.objectAt(1).get('title'), 'Top Group 2');
+    assert.strictEqual(topLevelGroups[0].get('title'), 'Top Group 1');
+    assert.strictEqual(topLevelGroups[1].get('title'), 'Top Group 2');
   });
 
   test('competencies', async function (assert) {

--- a/tests/unit/models/course-objective-test.js
+++ b/tests/unit/models/course-objective-test.js
@@ -21,7 +21,7 @@ module('Unit | Model | course objective', function (hooks) {
     const term1 = store.createRecord('term', { vocabulary: vocab1 });
     const term2 = store.createRecord('term', { vocabulary: vocab1 });
     const term3 = store.createRecord('term', { vocabulary: vocab2 });
-    subject.get('terms').pushObjects([term1, term2, term3]);
+    subject.get('terms').push([term1, term2, term3]);
     const vocabularies = await waitForResource(subject, 'associatedVocabularies');
     assert.strictEqual(vocabularies.length, 2);
     assert.strictEqual(vocabularies[0], vocab2);
@@ -49,9 +49,7 @@ module('Unit | Model | course objective', function (hooks) {
     const programYearObjective2 = store.createRecord('program-year-objective', {
       competency: competency2,
     });
-    subject
-      .get('programYearObjectives')
-      .pushObjects([programYearObjective1, programYearObjective2]);
+    subject.get('programYearObjectives').push([programYearObjective1, programYearObjective2]);
     const treeCompetencies = await waitForResource(subject, 'treeCompetencies');
     assert.strictEqual(treeCompetencies.length, 2);
     assert.ok(treeCompetencies.includes(competency1));

--- a/tests/unit/models/course-objective-test.js
+++ b/tests/unit/models/course-objective-test.js
@@ -21,7 +21,7 @@ module('Unit | Model | course objective', function (hooks) {
     const term1 = store.createRecord('term', { vocabulary: vocab1 });
     const term2 = store.createRecord('term', { vocabulary: vocab1 });
     const term3 = store.createRecord('term', { vocabulary: vocab2 });
-    subject.get('terms').push([term1, term2, term3]);
+    subject.get('terms').pushObjects([term1, term2, term3]);
     const vocabularies = await waitForResource(subject, 'associatedVocabularies');
     assert.strictEqual(vocabularies.length, 2);
     assert.strictEqual(vocabularies[0], vocab2);
@@ -29,7 +29,7 @@ module('Unit | Model | course objective', function (hooks) {
 
     const vocab3 = store.createRecord('vocabulary', { title: 'New(ish)' });
     const term4 = store.createRecord('term', { vocabulary: vocab3 });
-    subject.get('terms').push(term4);
+    subject.get('terms').pushObject(term4);
     const vocabulariesAgain = await waitForResource(subject, 'associatedVocabularies');
     assert.strictEqual(vocabulariesAgain.length, 3);
     assert.strictEqual(vocabulariesAgain[0], vocab2);
@@ -49,7 +49,9 @@ module('Unit | Model | course objective', function (hooks) {
     const programYearObjective2 = store.createRecord('program-year-objective', {
       competency: competency2,
     });
-    subject.get('programYearObjectives').push([programYearObjective1, programYearObjective2]);
+    subject
+      .get('programYearObjectives')
+      .pushObjects([programYearObjective1, programYearObjective2]);
     const treeCompetencies = await waitForResource(subject, 'treeCompetencies');
     assert.strictEqual(treeCompetencies.length, 2);
     assert.ok(treeCompetencies.includes(competency1));

--- a/tests/unit/models/course-objective-test.js
+++ b/tests/unit/models/course-objective-test.js
@@ -29,7 +29,7 @@ module('Unit | Model | course objective', function (hooks) {
 
     const vocab3 = store.createRecord('vocabulary', { title: 'New(ish)' });
     const term4 = store.createRecord('term', { vocabulary: vocab3 });
-    subject.get('terms').pushObject(term4);
+    subject.get('terms').push(term4);
     const vocabulariesAgain = await waitForResource(subject, 'associatedVocabularies');
     assert.strictEqual(vocabulariesAgain.length, 3);
     assert.strictEqual(vocabulariesAgain[0], vocab2);

--- a/tests/unit/models/course-test.js
+++ b/tests/unit/models/course-test.js
@@ -107,7 +107,7 @@ module('Unit | Model | Course', function (hooks) {
 
     assert.strictEqual(await waitForResource(course, 'publishedOfferingCount'), 3);
     const offering5 = store.createRecord('offering');
-    session1.get('offerings').pushObject(offering5);
+    session1.get('offerings').push(offering5);
     session3.set('published', true);
 
     assert.strictEqual(await waitForResource(course, 'publishedOfferingCount'), 5);
@@ -255,7 +255,7 @@ module('Unit | Model | Course', function (hooks) {
     const program = store.createRecord('program', { school: school1 });
     const programYear = store.createRecord('programYear', { program });
     const cohort = store.createRecord('cohort', { programYear });
-    course.get('cohorts').pushObject(cohort);
+    course.get('cohorts').push(cohort);
     course.set('school', school2);
 
     const vocabularies = await waitForResource(course, 'assignableVocabularies');

--- a/tests/unit/models/course-test.js
+++ b/tests/unit/models/course-test.js
@@ -103,11 +103,11 @@ module('Unit | Model | Course', function (hooks) {
       published: false,
     });
 
-    course.get('sessions').push([session1, session2, session3]);
+    course.get('sessions').pushObjects([session1, session2, session3]);
 
     assert.strictEqual(await waitForResource(course, 'publishedOfferingCount'), 3);
     const offering5 = store.createRecord('offering');
-    session1.get('offerings').push(offering5);
+    session1.get('offerings').pushObject(offering5);
     session3.set('published', true);
 
     assert.strictEqual(await waitForResource(course, 'publishedOfferingCount'), 5);
@@ -219,7 +219,7 @@ module('Unit | Model | Course', function (hooks) {
     const cohort2 = store.createRecord('cohort', { programYear: programYear2 });
     const cohort3 = store.createRecord('cohort', { programYear: programYear3 });
 
-    course.get('cohorts').push([cohort1, cohort2, cohort3]);
+    course.get('cohorts').pushObjects([cohort1, cohort2, cohort3]);
     course.set('school', school1);
 
     const schools = await waitForResource(course, 'schools');
@@ -255,7 +255,7 @@ module('Unit | Model | Course', function (hooks) {
     const program = store.createRecord('program', { school: school1 });
     const programYear = store.createRecord('programYear', { program });
     const cohort = store.createRecord('cohort', { programYear });
-    course.get('cohorts').push(cohort);
+    course.get('cohorts').pushObject(cohort);
     course.set('school', school2);
 
     const vocabularies = await waitForResource(course, 'assignableVocabularies');
@@ -307,7 +307,7 @@ module('Unit | Model | Course', function (hooks) {
     const term2 = store.createRecord('term', { vocabulary: vocabulary1 });
     const term3 = store.createRecord('term', { vocabulary: vocabulary1 });
     const term4 = store.createRecord('term', { vocabulary: vocabulary2 });
-    course.terms.push([term1, term2, term3, term4]);
+    course.terms.pushObjects([term1, term2, term3, term4]);
 
     const vocabularies = await waitForResource(course, 'associatedVocabularies');
     assert.strictEqual(vocabularies.length, 2);

--- a/tests/unit/models/course-test.js
+++ b/tests/unit/models/course-test.js
@@ -103,7 +103,7 @@ module('Unit | Model | Course', function (hooks) {
       published: false,
     });
 
-    course.get('sessions').pushObjects([session1, session2, session3]);
+    course.get('sessions').push([session1, session2, session3]);
 
     assert.strictEqual(await waitForResource(course, 'publishedOfferingCount'), 3);
     const offering5 = store.createRecord('offering');
@@ -219,7 +219,7 @@ module('Unit | Model | Course', function (hooks) {
     const cohort2 = store.createRecord('cohort', { programYear: programYear2 });
     const cohort3 = store.createRecord('cohort', { programYear: programYear3 });
 
-    course.get('cohorts').pushObjects([cohort1, cohort2, cohort3]);
+    course.get('cohorts').push([cohort1, cohort2, cohort3]);
     course.set('school', school1);
 
     const schools = await waitForResource(course, 'schools');
@@ -307,7 +307,7 @@ module('Unit | Model | Course', function (hooks) {
     const term2 = store.createRecord('term', { vocabulary: vocabulary1 });
     const term3 = store.createRecord('term', { vocabulary: vocabulary1 });
     const term4 = store.createRecord('term', { vocabulary: vocabulary2 });
-    course.terms.pushObjects([term1, term2, term3, term4]);
+    course.terms.push([term1, term2, term3, term4]);
 
     const vocabularies = await waitForResource(course, 'associatedVocabularies');
     assert.strictEqual(vocabularies.length, 2);

--- a/tests/unit/models/curriculum-inventory-report-test.js
+++ b/tests/unit/models/curriculum-inventory-report-test.js
@@ -26,7 +26,7 @@ module('Unit | Model | CurriculumInventoryReport', function (hooks) {
       report: model,
       parent: block2,
     });
-    model.get('sequenceBlocks').pushObjects([block1, block2, block3]);
+    model.get('sequenceBlocks').push([block1, block2, block3]);
     const blocks = await model.topLevelSequenceBlocks;
     assert.strictEqual(blocks.length, 2);
     assert.ok(blocks.includes(block1));
@@ -60,7 +60,7 @@ module('Unit | Model | CurriculumInventoryReport', function (hooks) {
     const block3 = store.createRecord('curriculumInventorySequenceBlock', {
       report: model,
     });
-    model.get('sequenceBlocks').pushObjects([block1, block2, block3]);
+    model.get('sequenceBlocks').push([block1, block2, block3]);
     const linkedCourses = await model.linkedCourses;
     assert.ok(linkedCourses.includes(course1));
     assert.ok(linkedCourses.includes(course2));

--- a/tests/unit/models/curriculum-inventory-report-test.js
+++ b/tests/unit/models/curriculum-inventory-report-test.js
@@ -78,7 +78,7 @@ module('Unit | Model | CurriculumInventoryReport', function (hooks) {
     assert.expect(1);
     const model = this.owner.lookup('service:store').createRecord('curriculum-inventory-report');
     const store = this.owner.lookup('service:store');
-    model.get('sequenceBlocks').pushObject(
+    model.get('sequenceBlocks').push(
       store.createRecord('curriculumInventorySequenceBlock', {
         report: model,
       })
@@ -92,7 +92,7 @@ module('Unit | Model | CurriculumInventoryReport', function (hooks) {
     const model = this.owner.lookup('service:store').createRecord('curriculum-inventory-report');
     const store = this.owner.lookup('service:store');
     const course = store.createRecord('course');
-    model.get('sequenceBlocks').pushObject(
+    model.get('sequenceBlocks').push(
       store.createRecord('curriculumInventorySequenceBlock', {
         report: model,
         course,

--- a/tests/unit/models/curriculum-inventory-report-test.js
+++ b/tests/unit/models/curriculum-inventory-report-test.js
@@ -26,7 +26,7 @@ module('Unit | Model | CurriculumInventoryReport', function (hooks) {
       report: model,
       parent: block2,
     });
-    model.get('sequenceBlocks').push([block1, block2, block3]);
+    model.get('sequenceBlocks').pushObjects([block1, block2, block3]);
     const blocks = await model.topLevelSequenceBlocks;
     assert.strictEqual(blocks.length, 2);
     assert.ok(blocks.includes(block1));
@@ -60,7 +60,7 @@ module('Unit | Model | CurriculumInventoryReport', function (hooks) {
     const block3 = store.createRecord('curriculumInventorySequenceBlock', {
       report: model,
     });
-    model.get('sequenceBlocks').push([block1, block2, block3]);
+    model.get('sequenceBlocks').pushObjects([block1, block2, block3]);
     const linkedCourses = await model.linkedCourses;
     assert.ok(linkedCourses.includes(course1));
     assert.ok(linkedCourses.includes(course2));
@@ -78,7 +78,7 @@ module('Unit | Model | CurriculumInventoryReport', function (hooks) {
     assert.expect(1);
     const model = this.owner.lookup('service:store').createRecord('curriculum-inventory-report');
     const store = this.owner.lookup('service:store');
-    model.get('sequenceBlocks').push(
+    model.get('sequenceBlocks').pushObject(
       store.createRecord('curriculumInventorySequenceBlock', {
         report: model,
       })
@@ -92,7 +92,7 @@ module('Unit | Model | CurriculumInventoryReport', function (hooks) {
     const model = this.owner.lookup('service:store').createRecord('curriculum-inventory-report');
     const store = this.owner.lookup('service:store');
     const course = store.createRecord('course');
-    model.get('sequenceBlocks').push(
+    model.get('sequenceBlocks').pushObject(
       store.createRecord('curriculumInventorySequenceBlock', {
         report: model,
         course,

--- a/tests/unit/models/curriculum-inventory-sequence-block-test.js
+++ b/tests/unit/models/curriculum-inventory-sequence-block-test.js
@@ -17,7 +17,7 @@ module('Unit | Model | CurriculumInventorySequenceBlock ', function (hooks) {
     });
     parentBlock.set('parent', grandParent);
     model.set('parent', parentBlock);
-    const ancestors = await model.allParents;
+    const ancestors = (await model.allParents).slice();
     assert.strictEqual(ancestors.length, 2);
     assert.strictEqual(ancestors[0], parentBlock);
     assert.strictEqual(ancestors[1], grandParent);
@@ -27,7 +27,7 @@ module('Unit | Model | CurriculumInventorySequenceBlock ', function (hooks) {
     const model = this.owner
       .lookup('service:store')
       .createRecord('curriculum-inventory-sequence-block');
-    const ancestors = await model.allParents;
+    const ancestors = (await model.allParents).slice();
     assert.strictEqual(ancestors.length, 0);
   });
 });

--- a/tests/unit/models/instructor-group-test.js
+++ b/tests/unit/models/instructor-group-test.js
@@ -19,7 +19,7 @@ module('Unit | Model | InstructorGroup', function (hooks) {
 
     model
       .get('offerings')
-      .push([
+      .pushObjects([
         store.createRecord('offering', { session: session1 }),
         store.createRecord('offering', { session: session1 }),
         store.createRecord('offering', { session: session1 }),
@@ -29,7 +29,7 @@ module('Unit | Model | InstructorGroup', function (hooks) {
       ]);
     model
       .get('ilmSessions')
-      .push([
+      .pushObjects([
         store.createRecord('ilmSession', { session: session3 }),
         store.createRecord('ilmSession', { session: session4 }),
       ]);
@@ -50,7 +50,7 @@ module('Unit | Model | InstructorGroup', function (hooks) {
 
     model
       .get('offerings')
-      .push([
+      .pushObjects([
         store.createRecord('offering', { session: session1 }),
         store.createRecord('offering', { session: session1 }),
         store.createRecord('offering', { session: session1 }),
@@ -60,7 +60,7 @@ module('Unit | Model | InstructorGroup', function (hooks) {
       ]);
     model
       .get('ilmSessions')
-      .push([
+      .pushObjects([
         store.createRecord('ilmSession', { session: session3 }),
         store.createRecord('ilmSession', { session: session4 }),
       ]);
@@ -80,7 +80,7 @@ module('Unit | Model | InstructorGroup', function (hooks) {
     const user1 = store.createRecord('user', { id: 1, instructorGroups: [instructorGroup] });
     const user2 = store.createRecord('user', { id: 2, instructorGroups: [instructorGroup] });
 
-    instructorGroup.get('users').push([user1, user2]);
+    instructorGroup.get('users').pushObjects([user1, user2]);
     assert.strictEqual(await waitForResource(instructorGroup, 'usersCount'), 2);
   });
 });

--- a/tests/unit/models/instructor-group-test.js
+++ b/tests/unit/models/instructor-group-test.js
@@ -19,7 +19,7 @@ module('Unit | Model | InstructorGroup', function (hooks) {
 
     model
       .get('offerings')
-      .pushObjects([
+      .push([
         store.createRecord('offering', { session: session1 }),
         store.createRecord('offering', { session: session1 }),
         store.createRecord('offering', { session: session1 }),
@@ -29,7 +29,7 @@ module('Unit | Model | InstructorGroup', function (hooks) {
       ]);
     model
       .get('ilmSessions')
-      .pushObjects([
+      .push([
         store.createRecord('ilmSession', { session: session3 }),
         store.createRecord('ilmSession', { session: session4 }),
       ]);
@@ -50,7 +50,7 @@ module('Unit | Model | InstructorGroup', function (hooks) {
 
     model
       .get('offerings')
-      .pushObjects([
+      .push([
         store.createRecord('offering', { session: session1 }),
         store.createRecord('offering', { session: session1 }),
         store.createRecord('offering', { session: session1 }),
@@ -60,7 +60,7 @@ module('Unit | Model | InstructorGroup', function (hooks) {
       ]);
     model
       .get('ilmSessions')
-      .pushObjects([
+      .push([
         store.createRecord('ilmSession', { session: session3 }),
         store.createRecord('ilmSession', { session: session4 }),
       ]);
@@ -80,7 +80,7 @@ module('Unit | Model | InstructorGroup', function (hooks) {
     const user1 = store.createRecord('user', { id: 1, instructorGroups: [instructorGroup] });
     const user2 = store.createRecord('user', { id: 2, instructorGroups: [instructorGroup] });
 
-    instructorGroup.get('users').pushObjects([user1, user2]);
+    instructorGroup.get('users').push([user1, user2]);
     assert.strictEqual(await waitForResource(instructorGroup, 'usersCount'), 2);
   });
 });

--- a/tests/unit/models/learner-group-test.js
+++ b/tests/unit/models/learner-group-test.js
@@ -249,7 +249,7 @@ module('Unit | Model | LearnerGroup', function (hooks) {
     const user1 = store.createRecord('user');
     const user2 = store.createRecord('user');
     const user3 = store.createRecord('user');
-    learnerGroup.get('instructors').pushObject(user1, user2);
+    learnerGroup.get('instructors').push(user1, user2);
     const instructorGroup1 = store.createRecord('instructor-group', {
       users: [user2],
     });
@@ -266,11 +266,11 @@ module('Unit | Model | LearnerGroup', function (hooks) {
 
     const user4 = store.createRecord('user');
     const user5 = store.createRecord('user');
-    learnerGroup.get('instructors').pushObject(user4);
+    learnerGroup.get('instructors').push(user4);
     const instructorGroup3 = store.createRecord('instructor-group', {
       users: [user5],
     });
-    learnerGroup.get('instructorGroups').pushObject(instructorGroup3);
+    learnerGroup.get('instructorGroups').push(instructorGroup3);
 
     allInstructors = await waitForResource(learnerGroup, 'allInstructors');
     assert.strictEqual(allInstructors.length, 5);
@@ -480,7 +480,7 @@ module('Unit | Model | LearnerGroup', function (hooks) {
     const store = this.owner.lookup('service:store');
     const learnerGroup = store.createRecord('learner-group');
     const learner = store.createRecord('user', { id: 1 });
-    learnerGroup.get('users').pushObject(learner);
+    learnerGroup.get('users').push(learner);
     const hasLearners = await waitForResource(learnerGroup, 'hasLearnersInGroupOrSubgroups');
     assert.ok(hasLearners);
   });
@@ -493,7 +493,7 @@ module('Unit | Model | LearnerGroup', function (hooks) {
       id: 2,
       parent: learnerGroup,
     });
-    learnerGroup.get('children').pushObject(subgroup);
+    learnerGroup.get('children').push(subgroup);
     const hasLearners = await waitForResource(learnerGroup, 'hasLearnersInGroupOrSubgroups');
     assert.notOk(hasLearners);
   });
@@ -509,7 +509,7 @@ module('Unit | Model | LearnerGroup', function (hooks) {
       parent: learnerGroup,
     });
 
-    learnerGroup.get('children').pushObject(subgroup);
+    learnerGroup.get('children').push(subgroup);
     assert.ok(await waitForResource(learnerGroup, 'hasLearnersInGroupOrSubgroups'));
   });
 
@@ -524,9 +524,9 @@ module('Unit | Model | LearnerGroup', function (hooks) {
       users: [learner],
       parent: learnerGroup,
     });
-    learnerGroup.get('children').pushObject(subgroup);
+    learnerGroup.get('children').push(subgroup);
 
-    learnerGroup.get('users').pushObject(learner2);
+    learnerGroup.get('users').push(learner2);
     assert.ok(await waitForResource(learnerGroup, 'hasLearnersInGroupOrSubgroups'));
   });
 
@@ -550,7 +550,7 @@ module('Unit | Model | LearnerGroup', function (hooks) {
       users: [user4],
     });
     learnerGroup.get('users').push([user1, user2, user3, user4]);
-    learnerGroup.get('children').pushObject(subgroup);
+    learnerGroup.get('children').push(subgroup);
     const users = await waitForResource(learnerGroup, 'usersOnlyAtThisLevel');
     assert.strictEqual(users.length, 1);
     assert.ok(users.includes(user2));
@@ -576,7 +576,7 @@ module('Unit | Model | LearnerGroup', function (hooks) {
       users: [user4],
     });
     learnerGroup.get('users').push([user1, user2, user3, user4]);
-    learnerGroup.get('children').pushObject(subgroup);
+    learnerGroup.get('children').push(subgroup);
     const users = await learnerGroup.getUsersOnlyAtThisLevel();
     assert.strictEqual(users.length, 1);
     assert.ok(users.includes(user2));
@@ -732,8 +732,8 @@ module('Unit | Model | LearnerGroup', function (hooks) {
     const subGroup2 = store.createRecord('learner-group', {
       parent: learnerGroup,
     });
-    learnerGroup.get('children').pushObject(subGroup1);
-    learnerGroup.get('children').pushObject(subGroup2);
+    learnerGroup.get('children').push(subGroup1);
+    learnerGroup.get('children').push(subGroup2);
 
     const hasNeeds = await waitForResource(learnerGroup, 'hasSubgroupsInNeedOfAccommodation');
     assert.notOk(hasNeeds);
@@ -750,8 +750,8 @@ module('Unit | Model | LearnerGroup', function (hooks) {
       parent: learnerGroup,
       needsAccommodation: true,
     });
-    learnerGroup.get('children').pushObject(subGroup1);
-    learnerGroup.get('children').pushObject(subGroup2);
+    learnerGroup.get('children').push(subGroup1);
+    learnerGroup.get('children').push(subGroup2);
     const hasNeeds = await waitForResource(learnerGroup, 'hasSubgroupsInNeedOfAccommodation');
     assert.ok(hasNeeds);
   });
@@ -766,24 +766,24 @@ module('Unit | Model | LearnerGroup', function (hooks) {
     const subGroup2 = store.createRecord('learner-group', {
       parent: learnerGroup,
     });
-    learnerGroup.get('children').pushObject(subGroup1);
-    learnerGroup.get('children').pushObject(subGroup2);
+    learnerGroup.get('children').push(subGroup1);
+    learnerGroup.get('children').push(subGroup2);
     const subSubGroup1 = store.createRecord('learner-group', {
       parent: subGroup1,
     });
     const subSubGroup2 = store.createRecord('learner-group', {
       parent: subGroup1,
     });
-    subGroup1.get('children').pushObject(subSubGroup1);
-    subGroup1.get('children').pushObject(subSubGroup2);
+    subGroup1.get('children').push(subSubGroup1);
+    subGroup1.get('children').push(subSubGroup2);
     const subSubGroup3 = store.createRecord('learner-group', {
       parent: subGroup2,
     });
     const subSubGroup4 = store.createRecord('learner-group', {
       parent: subGroup2,
     });
-    subGroup2.get('children').pushObject(subSubGroup3);
-    subGroup2.get('children').pushObject(subSubGroup4);
+    subGroup2.get('children').push(subSubGroup3);
+    subGroup2.get('children').push(subSubGroup4);
     const hasNeeds = await waitForResource(learnerGroup, 'hasSubgroupsInNeedOfAccommodation');
     assert.notOk(hasNeeds);
   });
@@ -798,16 +798,16 @@ module('Unit | Model | LearnerGroup', function (hooks) {
     const subGroup2 = store.createRecord('learner-group', {
       parent: learnerGroup,
     });
-    learnerGroup.get('children').pushObject(subGroup1);
-    learnerGroup.get('children').pushObject(subGroup2);
+    learnerGroup.get('children').push(subGroup1);
+    learnerGroup.get('children').push(subGroup2);
     const subSubGroup1 = store.createRecord('learner-group', {
       parent: subGroup1,
     });
     const subSubGroup2 = store.createRecord('learner-group', {
       parent: subGroup1,
     });
-    subGroup1.get('children').pushObject(subSubGroup1);
-    subGroup1.get('children').pushObject(subSubGroup2);
+    subGroup1.get('children').push(subSubGroup1);
+    subGroup1.get('children').push(subSubGroup2);
     const subSubGroup3 = store.createRecord('learner-group', {
       parent: subGroup2,
     });
@@ -815,8 +815,8 @@ module('Unit | Model | LearnerGroup', function (hooks) {
       parent: subGroup2,
       needsAccommodation: true,
     });
-    subGroup2.get('children').pushObject(subSubGroup3);
-    subGroup2.get('children').pushObject(subSubGroup4);
+    subGroup2.get('children').push(subSubGroup3);
+    subGroup2.get('children').push(subSubGroup4);
     const hasNeeds = await waitForResource(learnerGroup, 'hasSubgroupsInNeedOfAccommodation');
     assert.ok(hasNeeds);
   });

--- a/tests/unit/models/learner-group-test.js
+++ b/tests/unit/models/learner-group-test.js
@@ -21,7 +21,7 @@ module('Unit | Model | LearnerGroup', function (hooks) {
     const session3 = store.createRecord('session', { course: course2 });
     model
       .get('offerings')
-      .pushObjects([
+      .push([
         store.createRecord('offering', { session: session1 }),
         store.createRecord('offering', { session: session1 }),
         store.createRecord('offering', { session: session1 }),
@@ -47,7 +47,7 @@ module('Unit | Model | LearnerGroup', function (hooks) {
 
     model
       .get('offerings')
-      .pushObjects([
+      .push([
         store.createRecord('offering', { session: session1 }),
         store.createRecord('offering', { session: session1 }),
         store.createRecord('offering', { session: session1 }),
@@ -57,7 +57,7 @@ module('Unit | Model | LearnerGroup', function (hooks) {
       ]);
     model
       .get('ilmSessions')
-      .pushObjects([
+      .push([
         store.createRecord('ilmSession', { session: session3 }),
         store.createRecord('ilmSession', { session: session4 }),
       ]);
@@ -94,8 +94,8 @@ module('Unit | Model | LearnerGroup', function (hooks) {
       users: [user5],
       children: [subSubGroup1],
     });
-    learnerGroup.get('users').pushObjects([user1, user2, user3, user4, user5]);
-    learnerGroup.get('children').pushObjects([subGroup1, subGroup2]);
+    learnerGroup.get('users').push([user1, user2, user3, user4, user5]);
+    learnerGroup.get('children').push([subGroup1, subGroup2]);
 
     const allDescendantUsers = await waitForResource(learnerGroup, 'allDescendantUsers');
     assert.strictEqual(allDescendantUsers.length, 5);
@@ -256,7 +256,7 @@ module('Unit | Model | LearnerGroup', function (hooks) {
     const instructorGroup2 = store.createRecord('instructor-group', {
       users: [user3],
     });
-    learnerGroup.get('instructorGroups').pushObjects([instructorGroup1, instructorGroup2]);
+    learnerGroup.get('instructorGroups').push([instructorGroup1, instructorGroup2]);
 
     allInstructors = await waitForResource(learnerGroup, 'allInstructors');
     assert.strictEqual(allInstructors.length, 3);
@@ -549,7 +549,7 @@ module('Unit | Model | LearnerGroup', function (hooks) {
       parent: subgroup,
       users: [user4],
     });
-    learnerGroup.get('users').pushObjects([user1, user2, user3, user4]);
+    learnerGroup.get('users').push([user1, user2, user3, user4]);
     learnerGroup.get('children').pushObject(subgroup);
     const users = await waitForResource(learnerGroup, 'usersOnlyAtThisLevel');
     assert.strictEqual(users.length, 1);
@@ -575,7 +575,7 @@ module('Unit | Model | LearnerGroup', function (hooks) {
       parent: subgroup,
       users: [user4],
     });
-    learnerGroup.get('users').pushObjects([user1, user2, user3, user4]);
+    learnerGroup.get('users').push([user1, user2, user3, user4]);
     learnerGroup.get('children').pushObject(subgroup);
     const users = await learnerGroup.getUsersOnlyAtThisLevel();
     assert.strictEqual(users.length, 1);
@@ -699,7 +699,7 @@ module('Unit | Model | LearnerGroup', function (hooks) {
     const user1 = store.createRecord('user', { id: 1, learnerGroups: [learnerGroup] });
     const user2 = store.createRecord('user', { id: 2, learnerGroups: [learnerGroup] });
 
-    learnerGroup.get('users').pushObjects([user1, user2]);
+    learnerGroup.get('users').push([user1, user2]);
     assert.strictEqual(await waitForResource(learnerGroup, 'usersCount'), 2);
   });
 
@@ -711,7 +711,7 @@ module('Unit | Model | LearnerGroup', function (hooks) {
     const group1 = store.createRecord('learner-group', { id: 1, parent: learnerGroup });
     const group2 = store.createRecord('learner-group', { id: 2, parent: learnerGroup });
 
-    learnerGroup.get('children').pushObjects([group1, group2]);
+    learnerGroup.get('children').push([group1, group2]);
     assert.strictEqual(learnerGroup.childrenCount, 2);
   });
 

--- a/tests/unit/models/learner-group-test.js
+++ b/tests/unit/models/learner-group-test.js
@@ -21,7 +21,7 @@ module('Unit | Model | LearnerGroup', function (hooks) {
     const session3 = store.createRecord('session', { course: course2 });
     model
       .get('offerings')
-      .push([
+      .pushObjects([
         store.createRecord('offering', { session: session1 }),
         store.createRecord('offering', { session: session1 }),
         store.createRecord('offering', { session: session1 }),
@@ -47,7 +47,7 @@ module('Unit | Model | LearnerGroup', function (hooks) {
 
     model
       .get('offerings')
-      .push([
+      .pushObjects([
         store.createRecord('offering', { session: session1 }),
         store.createRecord('offering', { session: session1 }),
         store.createRecord('offering', { session: session1 }),
@@ -57,7 +57,7 @@ module('Unit | Model | LearnerGroup', function (hooks) {
       ]);
     model
       .get('ilmSessions')
-      .push([
+      .pushObjects([
         store.createRecord('ilmSession', { session: session3 }),
         store.createRecord('ilmSession', { session: session4 }),
       ]);
@@ -94,8 +94,8 @@ module('Unit | Model | LearnerGroup', function (hooks) {
       users: [user5],
       children: [subSubGroup1],
     });
-    learnerGroup.get('users').push([user1, user2, user3, user4, user5]);
-    learnerGroup.get('children').push([subGroup1, subGroup2]);
+    learnerGroup.get('users').pushObjects([user1, user2, user3, user4, user5]);
+    learnerGroup.get('children').pushObjects([subGroup1, subGroup2]);
 
     const allDescendantUsers = await waitForResource(learnerGroup, 'allDescendantUsers');
     assert.strictEqual(allDescendantUsers.length, 5);
@@ -249,14 +249,14 @@ module('Unit | Model | LearnerGroup', function (hooks) {
     const user1 = store.createRecord('user');
     const user2 = store.createRecord('user');
     const user3 = store.createRecord('user');
-    learnerGroup.get('instructors').push(user1, user2);
+    learnerGroup.get('instructors').pushObject(user1, user2);
     const instructorGroup1 = store.createRecord('instructor-group', {
       users: [user2],
     });
     const instructorGroup2 = store.createRecord('instructor-group', {
       users: [user3],
     });
-    learnerGroup.get('instructorGroups').push([instructorGroup1, instructorGroup2]);
+    learnerGroup.get('instructorGroups').pushObjects([instructorGroup1, instructorGroup2]);
 
     allInstructors = await waitForResource(learnerGroup, 'allInstructors');
     assert.strictEqual(allInstructors.length, 3);
@@ -266,11 +266,11 @@ module('Unit | Model | LearnerGroup', function (hooks) {
 
     const user4 = store.createRecord('user');
     const user5 = store.createRecord('user');
-    learnerGroup.get('instructors').push(user4);
+    learnerGroup.get('instructors').pushObject(user4);
     const instructorGroup3 = store.createRecord('instructor-group', {
       users: [user5],
     });
-    learnerGroup.get('instructorGroups').push(instructorGroup3);
+    learnerGroup.get('instructorGroups').pushObject(instructorGroup3);
 
     allInstructors = await waitForResource(learnerGroup, 'allInstructors');
     assert.strictEqual(allInstructors.length, 5);
@@ -480,7 +480,7 @@ module('Unit | Model | LearnerGroup', function (hooks) {
     const store = this.owner.lookup('service:store');
     const learnerGroup = store.createRecord('learner-group');
     const learner = store.createRecord('user', { id: 1 });
-    learnerGroup.get('users').push(learner);
+    learnerGroup.get('users').pushObject(learner);
     const hasLearners = await waitForResource(learnerGroup, 'hasLearnersInGroupOrSubgroups');
     assert.ok(hasLearners);
   });
@@ -493,7 +493,7 @@ module('Unit | Model | LearnerGroup', function (hooks) {
       id: 2,
       parent: learnerGroup,
     });
-    learnerGroup.get('children').push(subgroup);
+    learnerGroup.get('children').pushObject(subgroup);
     const hasLearners = await waitForResource(learnerGroup, 'hasLearnersInGroupOrSubgroups');
     assert.notOk(hasLearners);
   });
@@ -509,7 +509,7 @@ module('Unit | Model | LearnerGroup', function (hooks) {
       parent: learnerGroup,
     });
 
-    learnerGroup.get('children').push(subgroup);
+    learnerGroup.get('children').pushObject(subgroup);
     assert.ok(await waitForResource(learnerGroup, 'hasLearnersInGroupOrSubgroups'));
   });
 
@@ -524,9 +524,9 @@ module('Unit | Model | LearnerGroup', function (hooks) {
       users: [learner],
       parent: learnerGroup,
     });
-    learnerGroup.get('children').push(subgroup);
+    learnerGroup.get('children').pushObject(subgroup);
 
-    learnerGroup.get('users').push(learner2);
+    learnerGroup.get('users').pushObject(learner2);
     assert.ok(await waitForResource(learnerGroup, 'hasLearnersInGroupOrSubgroups'));
   });
 
@@ -549,8 +549,8 @@ module('Unit | Model | LearnerGroup', function (hooks) {
       parent: subgroup,
       users: [user4],
     });
-    learnerGroup.get('users').push([user1, user2, user3, user4]);
-    learnerGroup.get('children').push(subgroup);
+    learnerGroup.get('users').pushObjects([user1, user2, user3, user4]);
+    learnerGroup.get('children').pushObject(subgroup);
     const users = await waitForResource(learnerGroup, 'usersOnlyAtThisLevel');
     assert.strictEqual(users.length, 1);
     assert.ok(users.includes(user2));
@@ -575,8 +575,8 @@ module('Unit | Model | LearnerGroup', function (hooks) {
       parent: subgroup,
       users: [user4],
     });
-    learnerGroup.get('users').push([user1, user2, user3, user4]);
-    learnerGroup.get('children').push(subgroup);
+    learnerGroup.get('users').pushObjects([user1, user2, user3, user4]);
+    learnerGroup.get('children').pushObject(subgroup);
     const users = await learnerGroup.getUsersOnlyAtThisLevel();
     assert.strictEqual(users.length, 1);
     assert.ok(users.includes(user2));
@@ -699,7 +699,7 @@ module('Unit | Model | LearnerGroup', function (hooks) {
     const user1 = store.createRecord('user', { id: 1, learnerGroups: [learnerGroup] });
     const user2 = store.createRecord('user', { id: 2, learnerGroups: [learnerGroup] });
 
-    learnerGroup.get('users').push([user1, user2]);
+    learnerGroup.get('users').pushObjects([user1, user2]);
     assert.strictEqual(await waitForResource(learnerGroup, 'usersCount'), 2);
   });
 
@@ -711,7 +711,7 @@ module('Unit | Model | LearnerGroup', function (hooks) {
     const group1 = store.createRecord('learner-group', { id: 1, parent: learnerGroup });
     const group2 = store.createRecord('learner-group', { id: 2, parent: learnerGroup });
 
-    learnerGroup.get('children').push([group1, group2]);
+    learnerGroup.get('children').pushObjects([group1, group2]);
     assert.strictEqual(learnerGroup.childrenCount, 2);
   });
 
@@ -732,8 +732,8 @@ module('Unit | Model | LearnerGroup', function (hooks) {
     const subGroup2 = store.createRecord('learner-group', {
       parent: learnerGroup,
     });
-    learnerGroup.get('children').push(subGroup1);
-    learnerGroup.get('children').push(subGroup2);
+    learnerGroup.get('children').pushObject(subGroup1);
+    learnerGroup.get('children').pushObject(subGroup2);
 
     const hasNeeds = await waitForResource(learnerGroup, 'hasSubgroupsInNeedOfAccommodation');
     assert.notOk(hasNeeds);
@@ -750,8 +750,8 @@ module('Unit | Model | LearnerGroup', function (hooks) {
       parent: learnerGroup,
       needsAccommodation: true,
     });
-    learnerGroup.get('children').push(subGroup1);
-    learnerGroup.get('children').push(subGroup2);
+    learnerGroup.get('children').pushObject(subGroup1);
+    learnerGroup.get('children').pushObject(subGroup2);
     const hasNeeds = await waitForResource(learnerGroup, 'hasSubgroupsInNeedOfAccommodation');
     assert.ok(hasNeeds);
   });
@@ -766,24 +766,24 @@ module('Unit | Model | LearnerGroup', function (hooks) {
     const subGroup2 = store.createRecord('learner-group', {
       parent: learnerGroup,
     });
-    learnerGroup.get('children').push(subGroup1);
-    learnerGroup.get('children').push(subGroup2);
+    learnerGroup.get('children').pushObject(subGroup1);
+    learnerGroup.get('children').pushObject(subGroup2);
     const subSubGroup1 = store.createRecord('learner-group', {
       parent: subGroup1,
     });
     const subSubGroup2 = store.createRecord('learner-group', {
       parent: subGroup1,
     });
-    subGroup1.get('children').push(subSubGroup1);
-    subGroup1.get('children').push(subSubGroup2);
+    subGroup1.get('children').pushObject(subSubGroup1);
+    subGroup1.get('children').pushObject(subSubGroup2);
     const subSubGroup3 = store.createRecord('learner-group', {
       parent: subGroup2,
     });
     const subSubGroup4 = store.createRecord('learner-group', {
       parent: subGroup2,
     });
-    subGroup2.get('children').push(subSubGroup3);
-    subGroup2.get('children').push(subSubGroup4);
+    subGroup2.get('children').pushObject(subSubGroup3);
+    subGroup2.get('children').pushObject(subSubGroup4);
     const hasNeeds = await waitForResource(learnerGroup, 'hasSubgroupsInNeedOfAccommodation');
     assert.notOk(hasNeeds);
   });
@@ -798,16 +798,16 @@ module('Unit | Model | LearnerGroup', function (hooks) {
     const subGroup2 = store.createRecord('learner-group', {
       parent: learnerGroup,
     });
-    learnerGroup.get('children').push(subGroup1);
-    learnerGroup.get('children').push(subGroup2);
+    learnerGroup.get('children').pushObject(subGroup1);
+    learnerGroup.get('children').pushObject(subGroup2);
     const subSubGroup1 = store.createRecord('learner-group', {
       parent: subGroup1,
     });
     const subSubGroup2 = store.createRecord('learner-group', {
       parent: subGroup1,
     });
-    subGroup1.get('children').push(subSubGroup1);
-    subGroup1.get('children').push(subSubGroup2);
+    subGroup1.get('children').pushObject(subSubGroup1);
+    subGroup1.get('children').pushObject(subSubGroup2);
     const subSubGroup3 = store.createRecord('learner-group', {
       parent: subGroup2,
     });
@@ -815,8 +815,8 @@ module('Unit | Model | LearnerGroup', function (hooks) {
       parent: subGroup2,
       needsAccommodation: true,
     });
-    subGroup2.get('children').push(subSubGroup3);
-    subGroup2.get('children').push(subSubGroup4);
+    subGroup2.get('children').pushObject(subSubGroup3);
+    subGroup2.get('children').pushObject(subSubGroup4);
     const hasNeeds = await waitForResource(learnerGroup, 'hasSubgroupsInNeedOfAccommodation');
     assert.ok(hasNeeds);
   });

--- a/tests/unit/models/learner-group-test.js
+++ b/tests/unit/models/learner-group-test.js
@@ -32,8 +32,8 @@ module('Unit | Model | LearnerGroup', function (hooks) {
 
     const courses = await waitForResource(model, 'courses');
     assert.strictEqual(courses.length, 2);
-    assert.strictEqual(courses.objectAt(0).title, 'course1');
-    assert.strictEqual(courses.objectAt(1).title, 'course2');
+    assert.strictEqual(courses[0].title, 'course1');
+    assert.strictEqual(courses[1].title, 'course2');
   });
 
   test('list sessions', async function (assert) {

--- a/tests/unit/models/offering-test.js
+++ b/tests/unit/models/offering-test.js
@@ -25,7 +25,7 @@ module('Unit | Model | Offering', function (hooks) {
     const instructorGroup2 = store.createRecord('instructor-group', {
       users: [user3],
     });
-    offering.get('instructorGroups').pushObjects([instructorGroup1, instructorGroup2]);
+    offering.get('instructorGroups').push([instructorGroup1, instructorGroup2]);
 
     allInstructors = await waitForResource(offering, 'allInstructors');
 
@@ -97,7 +97,7 @@ module('Unit | Model | Offering', function (hooks) {
     const learnerGroup2 = store.createRecord('learner-group', {
       users: [user3],
     });
-    offering.get('learnerGroups').pushObjects([learnerGroup1, learnerGroup2]);
+    offering.get('learnerGroups').push([learnerGroup1, learnerGroup2]);
 
     allLearners = await waitForResource(offering, 'allLearners');
 

--- a/tests/unit/models/offering-test.js
+++ b/tests/unit/models/offering-test.js
@@ -18,7 +18,7 @@ module('Unit | Model | Offering', function (hooks) {
     const user1 = store.createRecord('user', { displayName: 'Beta' });
     const user2 = store.createRecord('user', { displayName: 'Alpha' });
     const user3 = store.createRecord('user', { displayName: 'Omega' });
-    offering.get('instructors').pushObject(user1);
+    offering.get('instructors').push(user1);
     const instructorGroup1 = store.createRecord('instructor-group', {
       users: [user2],
     });
@@ -39,11 +39,11 @@ module('Unit | Model | Offering', function (hooks) {
       lastName: 'Lazy',
     });
     const user5 = store.createRecord('user', { displayName: 'Gamma' });
-    offering.get('instructors').pushObject(user4);
+    offering.get('instructors').push(user4);
     const instructorGroup3 = store.createRecord('instructor-group', {
       users: [user5],
     });
-    offering.get('instructorGroups').pushObject(instructorGroup3);
+    offering.get('instructorGroups').push(instructorGroup3);
 
     allInstructors = await waitForResource(offering, 'allInstructors');
 
@@ -90,7 +90,7 @@ module('Unit | Model | Offering', function (hooks) {
     const user1 = store.createRecord('user', { displayName: 'Beta' });
     const user2 = store.createRecord('user', { displayName: 'Alpha' });
     const user3 = store.createRecord('user', { displayName: 'Omega' });
-    offering.get('learners').pushObject(user1);
+    offering.get('learners').push(user1);
     const learnerGroup1 = store.createRecord('learner-group', {
       users: [user2],
     });
@@ -111,11 +111,11 @@ module('Unit | Model | Offering', function (hooks) {
       lastName: 'Lazy',
     });
     const user5 = store.createRecord('user', { displayName: 'Gamma' });
-    offering.get('learners').pushObject(user4);
+    offering.get('learners').push(user4);
     const learnerGroup3 = store.createRecord('learner-group', {
       users: [user5],
     });
-    offering.get('learnerGroups').pushObject(learnerGroup3);
+    offering.get('learnerGroups').push(learnerGroup3);
 
     allLearners = await waitForResource(offering, 'allLearners');
 

--- a/tests/unit/models/offering-test.js
+++ b/tests/unit/models/offering-test.js
@@ -18,14 +18,14 @@ module('Unit | Model | Offering', function (hooks) {
     const user1 = store.createRecord('user', { displayName: 'Beta' });
     const user2 = store.createRecord('user', { displayName: 'Alpha' });
     const user3 = store.createRecord('user', { displayName: 'Omega' });
-    offering.get('instructors').push(user1);
+    offering.get('instructors').pushObject(user1);
     const instructorGroup1 = store.createRecord('instructor-group', {
       users: [user2],
     });
     const instructorGroup2 = store.createRecord('instructor-group', {
       users: [user3],
     });
-    offering.get('instructorGroups').push([instructorGroup1, instructorGroup2]);
+    offering.get('instructorGroups').pushObjects([instructorGroup1, instructorGroup2]);
 
     allInstructors = await waitForResource(offering, 'allInstructors');
 
@@ -39,11 +39,11 @@ module('Unit | Model | Offering', function (hooks) {
       lastName: 'Lazy',
     });
     const user5 = store.createRecord('user', { displayName: 'Gamma' });
-    offering.get('instructors').push(user4);
+    offering.get('instructors').pushObject(user4);
     const instructorGroup3 = store.createRecord('instructor-group', {
       users: [user5],
     });
-    offering.get('instructorGroups').push(instructorGroup3);
+    offering.get('instructorGroups').pushObject(instructorGroup3);
 
     allInstructors = await waitForResource(offering, 'allInstructors');
 
@@ -90,14 +90,14 @@ module('Unit | Model | Offering', function (hooks) {
     const user1 = store.createRecord('user', { displayName: 'Beta' });
     const user2 = store.createRecord('user', { displayName: 'Alpha' });
     const user3 = store.createRecord('user', { displayName: 'Omega' });
-    offering.get('learners').push(user1);
+    offering.get('learners').pushObject(user1);
     const learnerGroup1 = store.createRecord('learner-group', {
       users: [user2],
     });
     const learnerGroup2 = store.createRecord('learner-group', {
       users: [user3],
     });
-    offering.get('learnerGroups').push([learnerGroup1, learnerGroup2]);
+    offering.get('learnerGroups').pushObjects([learnerGroup1, learnerGroup2]);
 
     allLearners = await waitForResource(offering, 'allLearners');
 
@@ -111,11 +111,11 @@ module('Unit | Model | Offering', function (hooks) {
       lastName: 'Lazy',
     });
     const user5 = store.createRecord('user', { displayName: 'Gamma' });
-    offering.get('learners').push(user4);
+    offering.get('learners').pushObject(user4);
     const learnerGroup3 = store.createRecord('learner-group', {
       users: [user5],
     });
-    offering.get('learnerGroups').push(learnerGroup3);
+    offering.get('learnerGroups').pushObject(learnerGroup3);
 
     allLearners = await waitForResource(offering, 'allLearners');
 

--- a/tests/unit/models/program-test.js
+++ b/tests/unit/models/program-test.js
@@ -16,7 +16,7 @@ module('Unit | Model | Program', function (hooks) {
       id: 1,
       program: model,
     });
-    model.curriculumInventoryReports.pushObject(report);
+    model.curriculumInventoryReports.push(report);
     assert.ok(model.hasCurriculumInventoryReports);
   });
 
@@ -24,7 +24,7 @@ module('Unit | Model | Program', function (hooks) {
     const model = this.store.createRecord('program', { id: 1 });
     assert.notOk(model.hasProgramYears);
     const programYear = this.store.createRecord('program-year', { id: 1, program: model });
-    model.programYears.pushObject(programYear);
+    model.programYears.push(programYear);
     assert.ok(model.hasProgramYears);
   });
 

--- a/tests/unit/models/program-test.js
+++ b/tests/unit/models/program-test.js
@@ -16,7 +16,7 @@ module('Unit | Model | Program', function (hooks) {
       id: 1,
       program: model,
     });
-    model.curriculumInventoryReports.push(report);
+    model.curriculumInventoryReports.pushObject(report);
     assert.ok(model.hasCurriculumInventoryReports);
   });
 
@@ -24,7 +24,7 @@ module('Unit | Model | Program', function (hooks) {
     const model = this.store.createRecord('program', { id: 1 });
     assert.notOk(model.hasProgramYears);
     const programYear = this.store.createRecord('program-year', { id: 1, program: model });
-    model.programYears.push(programYear);
+    model.programYears.pushObject(programYear);
     assert.ok(model.hasProgramYears);
   });
 
@@ -38,7 +38,7 @@ module('Unit | Model | Program', function (hooks) {
     const programYear2 = this.store.createRecord('program-year', {
       cohort: cohort2,
     });
-    model.programYears.push([programYear1, programYear2]);
+    model.programYears.pushObjects([programYear1, programYear2]);
     await waitForResource(model, '_cohorts');
     assert.strictEqual(model.cohorts.length, 2);
     assert.ok(model.cohorts.includes(cohort1));
@@ -62,7 +62,7 @@ module('Unit | Model | Program', function (hooks) {
     const programYear2 = this.store.createRecord('program-year', {
       cohort: cohort2,
     });
-    model.programYears.push([programYear1, programYear2]);
+    model.programYears.pushObjects([programYear1, programYear2]);
     await waitForResource(model, '_courses');
     assert.strictEqual(model.courses.length, 3);
     assert.ok(model.courses.includes(course1));

--- a/tests/unit/models/program-test.js
+++ b/tests/unit/models/program-test.js
@@ -38,7 +38,7 @@ module('Unit | Model | Program', function (hooks) {
     const programYear2 = this.store.createRecord('program-year', {
       cohort: cohort2,
     });
-    model.programYears.pushObjects([programYear1, programYear2]);
+    model.programYears.push([programYear1, programYear2]);
     await waitForResource(model, '_cohorts');
     assert.strictEqual(model.cohorts.length, 2);
     assert.ok(model.cohorts.includes(cohort1));
@@ -62,7 +62,7 @@ module('Unit | Model | Program', function (hooks) {
     const programYear2 = this.store.createRecord('program-year', {
       cohort: cohort2,
     });
-    model.programYears.pushObjects([programYear1, programYear2]);
+    model.programYears.push([programYear1, programYear2]);
     await waitForResource(model, '_courses');
     assert.strictEqual(model.courses.length, 3);
     assert.ok(model.courses.includes(course1));

--- a/tests/unit/models/program-year-objective-test.js
+++ b/tests/unit/models/program-year-objective-test.js
@@ -21,7 +21,7 @@ module('Unit | Model | program year objective', function (hooks) {
     const term1 = store.createRecord('term', { vocabulary: vocab1 });
     const term2 = store.createRecord('term', { vocabulary: vocab1 });
     const term3 = store.createRecord('term', { vocabulary: vocab2 });
-    subject.get('terms').push([term1, term2, term3]);
+    subject.get('terms').pushObjects([term1, term2, term3]);
     const vocabularies = await waitForResource(subject, 'associatedVocabularies');
     assert.strictEqual(vocabularies.length, 2);
     assert.strictEqual(vocabularies[0], vocab2);

--- a/tests/unit/models/program-year-objective-test.js
+++ b/tests/unit/models/program-year-objective-test.js
@@ -21,7 +21,7 @@ module('Unit | Model | program year objective', function (hooks) {
     const term1 = store.createRecord('term', { vocabulary: vocab1 });
     const term2 = store.createRecord('term', { vocabulary: vocab1 });
     const term3 = store.createRecord('term', { vocabulary: vocab2 });
-    subject.get('terms').pushObjects([term1, term2, term3]);
+    subject.get('terms').push([term1, term2, term3]);
     const vocabularies = await waitForResource(subject, 'associatedVocabularies');
     assert.strictEqual(vocabularies.length, 2);
     assert.strictEqual(vocabularies[0], vocab2);

--- a/tests/unit/models/program-year-test.js
+++ b/tests/unit/models/program-year-test.js
@@ -86,7 +86,7 @@ module('Unit | Model | ProgramYear', function (hooks) {
     const term2 = store.createRecord('term', { vocabulary: vocabulary1 });
     const term3 = store.createRecord('term', { vocabulary: vocabulary1 });
     const term4 = store.createRecord('term', { vocabulary: vocabulary2 });
-    programYear.terms.push([term1, term2, term3, term4]);
+    programYear.terms.pushObjects([term1, term2, term3, term4]);
 
     const vocabularies = await waitForResource(programYear, 'associatedVocabularies');
     assert.strictEqual(vocabularies.length, 2);

--- a/tests/unit/models/program-year-test.js
+++ b/tests/unit/models/program-year-test.js
@@ -86,7 +86,7 @@ module('Unit | Model | ProgramYear', function (hooks) {
     const term2 = store.createRecord('term', { vocabulary: vocabulary1 });
     const term3 = store.createRecord('term', { vocabulary: vocabulary1 });
     const term4 = store.createRecord('term', { vocabulary: vocabulary2 });
-    programYear.terms.pushObjects([term1, term2, term3, term4]);
+    programYear.terms.push([term1, term2, term3, term4]);
 
     const vocabularies = await waitForResource(programYear, 'associatedVocabularies');
     assert.strictEqual(vocabularies.length, 2);

--- a/tests/unit/models/session-objective-test.js
+++ b/tests/unit/models/session-objective-test.js
@@ -21,7 +21,7 @@ module('Unit | Model | session objective', function (hooks) {
     const term1 = store.createRecord('term', { vocabulary: vocab1 });
     const term2 = store.createRecord('term', { vocabulary: vocab1 });
     const term3 = store.createRecord('term', { vocabulary: vocab2 });
-    subject.get('terms').push([term1, term2, term3]);
+    subject.get('terms').pushObjects([term1, term2, term3]);
     const vocabularies = await waitForResource(subject, 'associatedVocabularies');
     assert.strictEqual(vocabularies.length, 2);
     assert.strictEqual(vocabularies[0], vocab2);

--- a/tests/unit/models/session-objective-test.js
+++ b/tests/unit/models/session-objective-test.js
@@ -21,7 +21,7 @@ module('Unit | Model | session objective', function (hooks) {
     const term1 = store.createRecord('term', { vocabulary: vocab1 });
     const term2 = store.createRecord('term', { vocabulary: vocab1 });
     const term3 = store.createRecord('term', { vocabulary: vocab2 });
-    subject.get('terms').pushObjects([term1, term2, term3]);
+    subject.get('terms').push([term1, term2, term3]);
     const vocabularies = await waitForResource(subject, 'associatedVocabularies');
     assert.strictEqual(vocabularies.length, 2);
     assert.strictEqual(vocabularies[0], vocab2);

--- a/tests/unit/models/session-test.js
+++ b/tests/unit/models/session-test.js
@@ -209,9 +209,9 @@ module('Unit | Model | Session', function (hooks) {
     const offering3 = store.createRecord('offering', {
       learnerGroups: [learnerGroup4],
     });
-    session.get('offerings').pushObject(offering3);
+    session.get('offerings').push(offering3);
     const learnerGroup5 = store.createRecord('learner-group');
-    offering1.get('learnerGroups').pushObject(learnerGroup5);
+    offering1.get('learnerGroups').push(learnerGroup5);
 
     assert.strictEqual(await waitForResource(session, 'learnerGroupCount'), 5);
   });

--- a/tests/unit/models/session-test.js
+++ b/tests/unit/models/session-test.js
@@ -67,7 +67,7 @@ module('Unit | Model | Session', function (hooks) {
       learnerGroups: [learnerGroup3],
     });
 
-    session.get('offerings').push([offering1, offering2]);
+    session.get('offerings').pushObjects([offering1, offering2]);
 
     const groups = await waitForResource(session, 'associatedOfferingLearnerGroups');
     assert.strictEqual(groups.length, 3);
@@ -95,7 +95,7 @@ module('Unit | Model | Session', function (hooks) {
     const offering3 = store.createRecord('offering', {
       learnerGroups: [learnerGroup4],
     });
-    session.get('offerings').push([offering1, offering2, offering3]);
+    session.get('offerings').pushObjects([offering1, offering2, offering3]);
 
     const groups = await waitForResource(session, 'associatedOfferingLearnerGroups');
     assert.strictEqual(groups.length, 5);
@@ -175,7 +175,7 @@ module('Unit | Model | Session', function (hooks) {
     });
 
     session.set('ilmSession', ilm);
-    session.get('offerings').push([offering1, offering2]);
+    session.get('offerings').pushObjects([offering1, offering2]);
 
     const groups = await waitForResource(session, 'associatedLearnerGroups');
     assert.strictEqual(groups.length, 5);
@@ -201,7 +201,7 @@ module('Unit | Model | Session', function (hooks) {
       learnerGroups: [learnerGroup3],
     });
 
-    session.get('offerings').push([offering1, offering2]);
+    session.get('offerings').pushObjects([offering1, offering2]);
 
     assert.strictEqual(await waitForResource(session, 'learnerGroupCount'), 3);
 
@@ -209,9 +209,9 @@ module('Unit | Model | Session', function (hooks) {
     const offering3 = store.createRecord('offering', {
       learnerGroups: [learnerGroup4],
     });
-    session.get('offerings').push(offering3);
+    session.get('offerings').pushObject(offering3);
     const learnerGroup5 = store.createRecord('learner-group');
-    offering1.get('learnerGroups').push(learnerGroup5);
+    offering1.get('learnerGroups').pushObject(learnerGroup5);
 
     assert.strictEqual(await waitForResource(session, 'learnerGroupCount'), 5);
   });
@@ -234,7 +234,7 @@ module('Unit | Model | Session', function (hooks) {
     const term1 = store.createRecord('term', { vocabulary: vocab1 });
     const term2 = store.createRecord('term', { vocabulary: vocab1 });
     const term3 = store.createRecord('term', { vocabulary: vocab2 });
-    subject.get('terms').push([term1, term2, term3]);
+    subject.get('terms').pushObjects([term1, term2, term3]);
     const vocabularies = await waitForResource(subject, 'associatedVocabularies');
     assert.strictEqual(vocabularies.length, 2);
     assert.strictEqual(vocabularies[0], vocab2);
@@ -248,7 +248,7 @@ module('Unit | Model | Session', function (hooks) {
     assert.strictEqual(subject.termCount, 0);
     const term1 = store.createRecord('term', { id: 1, sessions: [subject] });
     const term2 = store.createRecord('term', { id: 2, sessions: [subject] });
-    subject.get('terms').push([term1, term2]);
+    subject.get('terms').pushObjects([term1, term2]);
     assert.strictEqual(subject.termCount, 2);
   });
 
@@ -299,7 +299,7 @@ module('Unit | Model | Session', function (hooks) {
       startDate: moment('2017-01-01 09:30:00').toDate(),
       endDate: moment('2017-01-01 10:00:00').toDate(),
     });
-    subject.get('offerings').push([allDayOffering, halfAnHourOffering]);
+    subject.get('offerings').pushObjects([allDayOffering, halfAnHourOffering]);
     total = await waitForResource(subject, 'totalSumOfferingsDuration');
     assert.strictEqual(Number(total), 24.5);
   });
@@ -321,7 +321,7 @@ module('Unit | Model | Session', function (hooks) {
       endDate: moment('2017-01-01 10:00:00').toDate(),
       session: subject,
     });
-    subject.get('offerings').push([allDayOffering, halfAnHourOffering]);
+    subject.get('offerings').pushObjects([allDayOffering, halfAnHourOffering]);
     max = await waitForResource(subject, 'maxSingleOfferingDuration');
     assert.strictEqual(Number(max), 24.0);
   });
@@ -355,7 +355,7 @@ module('Unit | Model | Session', function (hooks) {
     const offering2 = store.createRecord('offering', {
       startDate: moment('2016-01-01').toDate(),
     });
-    subject.get('offerings').push([offering1, offering2]);
+    subject.get('offerings').pushObjects([offering1, offering2]);
     const firstDate = await waitForResource(subject, 'firstOfferingDate');
     assert.strictEqual(offering2.get('startDate'), firstDate);
   });
@@ -374,7 +374,9 @@ module('Unit | Model | Session', function (hooks) {
       startDate: moment('2015-01-01').toDate(),
     });
     const offeringWithNoStartDate = store.createRecord('offering');
-    subject.get('offerings').push([offering1, offering2, offering3, offeringWithNoStartDate]);
+    subject
+      .get('offerings')
+      .pushObjects([offering1, offering2, offering3, offeringWithNoStartDate]);
     const sortedDates = await waitForResource(subject, 'sortedOfferingsByDate');
     assert.strictEqual(sortedDates.length, 3);
     assert.strictEqual(sortedDates[0], offering3);
@@ -395,7 +397,7 @@ module('Unit | Model | Session', function (hooks) {
       startDate: moment('2017-01-01 09:30:00').toDate(),
       endDate: moment('2017-01-01 10:00:00').toDate(),
     });
-    subject.get('offerings').push([allDayOffering, halfAnHourOffering]);
+    subject.get('offerings').pushObjects([allDayOffering, halfAnHourOffering]);
     const ilmSession = store.createRecord('ilmSession', { hours: 2.1 });
     subject.set('ilmSession', ilmSession);
 
@@ -416,7 +418,7 @@ module('Unit | Model | Session', function (hooks) {
       startDate: moment('2017-01-01 09:30:00').toDate(),
       endDate: moment('2017-01-01 10:00:00').toDate(),
     });
-    subject.get('offerings').push([allDayOffering, halfAnHourOffering]);
+    subject.get('offerings').pushObjects([allDayOffering, halfAnHourOffering]);
 
     const max = await waitForResource(subject, 'maxDuration');
     assert.strictEqual(Number(max), 24.0);
@@ -447,7 +449,7 @@ module('Unit | Model | Session', function (hooks) {
       startDate: moment('2017-01-01 09:30:00').toDate(),
       endDate: moment('2017-01-01 10:00:00').toDate(),
     });
-    subject.get('offerings').push([allDayOffering, halfAnHourOffering]);
+    subject.get('offerings').pushObjects([allDayOffering, halfAnHourOffering]);
     const ilmSession = store.createRecord('ilmSession', { hours: 2.1 });
     subject.set('ilmSession', ilmSession);
 
@@ -468,7 +470,7 @@ module('Unit | Model | Session', function (hooks) {
       startDate: moment('2017-01-01 09:30:00').toDate(),
       endDate: moment('2017-01-01 10:00:00').toDate(),
     });
-    subject.get('offerings').push([allDayOffering, halfAnHourOffering]);
+    subject.get('offerings').pushObjects([allDayOffering, halfAnHourOffering]);
 
     const total = await waitForResource(subject, 'totalSumDuration');
     assert.strictEqual(Number(total), 24.5);
@@ -652,7 +654,7 @@ module('Unit | Model | Session', function (hooks) {
       startDate: moment('2017-01-01 09:30:00').toDate(),
       endDate: moment('2017-01-01 10:00:00').toDate(),
     });
-    subject.get('offerings').push([allDayOffering, halfAnHourOffering]);
+    subject.get('offerings').pushObjects([allDayOffering, halfAnHourOffering]);
     const ilmSession = store.createRecord('ilmSession', { hours: 2.1 });
     subject.set('ilmSession', ilmSession);
 
@@ -672,7 +674,7 @@ module('Unit | Model | Session', function (hooks) {
       startDate: moment('2017-01-01 09:30:00').toDate(),
       endDate: moment('2017-01-01 10:00:00').toDate(),
     });
-    subject.get('offerings').push([allDayOffering, halfAnHourOffering]);
+    subject.get('offerings').pushObjects([allDayOffering, halfAnHourOffering]);
 
     const total = await subject.getTotalSumDuration();
     assert.strictEqual(Number(total), 24.5);

--- a/tests/unit/models/session-test.js
+++ b/tests/unit/models/session-test.js
@@ -67,7 +67,7 @@ module('Unit | Model | Session', function (hooks) {
       learnerGroups: [learnerGroup3],
     });
 
-    session.get('offerings').pushObjects([offering1, offering2]);
+    session.get('offerings').push([offering1, offering2]);
 
     const groups = await waitForResource(session, 'associatedOfferingLearnerGroups');
     assert.strictEqual(groups.length, 3);
@@ -95,7 +95,7 @@ module('Unit | Model | Session', function (hooks) {
     const offering3 = store.createRecord('offering', {
       learnerGroups: [learnerGroup4],
     });
-    session.get('offerings').pushObjects([offering1, offering2, offering3]);
+    session.get('offerings').push([offering1, offering2, offering3]);
 
     const groups = await waitForResource(session, 'associatedOfferingLearnerGroups');
     assert.strictEqual(groups.length, 5);
@@ -175,7 +175,7 @@ module('Unit | Model | Session', function (hooks) {
     });
 
     session.set('ilmSession', ilm);
-    session.get('offerings').pushObjects([offering1, offering2]);
+    session.get('offerings').push([offering1, offering2]);
 
     const groups = await waitForResource(session, 'associatedLearnerGroups');
     assert.strictEqual(groups.length, 5);
@@ -201,7 +201,7 @@ module('Unit | Model | Session', function (hooks) {
       learnerGroups: [learnerGroup3],
     });
 
-    session.get('offerings').pushObjects([offering1, offering2]);
+    session.get('offerings').push([offering1, offering2]);
 
     assert.strictEqual(await waitForResource(session, 'learnerGroupCount'), 3);
 
@@ -234,7 +234,7 @@ module('Unit | Model | Session', function (hooks) {
     const term1 = store.createRecord('term', { vocabulary: vocab1 });
     const term2 = store.createRecord('term', { vocabulary: vocab1 });
     const term3 = store.createRecord('term', { vocabulary: vocab2 });
-    subject.get('terms').pushObjects([term1, term2, term3]);
+    subject.get('terms').push([term1, term2, term3]);
     const vocabularies = await waitForResource(subject, 'associatedVocabularies');
     assert.strictEqual(vocabularies.length, 2);
     assert.strictEqual(vocabularies[0], vocab2);
@@ -248,7 +248,7 @@ module('Unit | Model | Session', function (hooks) {
     assert.strictEqual(subject.termCount, 0);
     const term1 = store.createRecord('term', { id: 1, sessions: [subject] });
     const term2 = store.createRecord('term', { id: 2, sessions: [subject] });
-    subject.get('terms').pushObjects([term1, term2]);
+    subject.get('terms').push([term1, term2]);
     assert.strictEqual(subject.termCount, 2);
   });
 
@@ -299,7 +299,7 @@ module('Unit | Model | Session', function (hooks) {
       startDate: moment('2017-01-01 09:30:00').toDate(),
       endDate: moment('2017-01-01 10:00:00').toDate(),
     });
-    subject.get('offerings').pushObjects([allDayOffering, halfAnHourOffering]);
+    subject.get('offerings').push([allDayOffering, halfAnHourOffering]);
     total = await waitForResource(subject, 'totalSumOfferingsDuration');
     assert.strictEqual(Number(total), 24.5);
   });
@@ -321,7 +321,7 @@ module('Unit | Model | Session', function (hooks) {
       endDate: moment('2017-01-01 10:00:00').toDate(),
       session: subject,
     });
-    subject.get('offerings').pushObjects([allDayOffering, halfAnHourOffering]);
+    subject.get('offerings').push([allDayOffering, halfAnHourOffering]);
     max = await waitForResource(subject, 'maxSingleOfferingDuration');
     assert.strictEqual(Number(max), 24.0);
   });
@@ -355,7 +355,7 @@ module('Unit | Model | Session', function (hooks) {
     const offering2 = store.createRecord('offering', {
       startDate: moment('2016-01-01').toDate(),
     });
-    subject.get('offerings').pushObjects([offering1, offering2]);
+    subject.get('offerings').push([offering1, offering2]);
     const firstDate = await waitForResource(subject, 'firstOfferingDate');
     assert.strictEqual(offering2.get('startDate'), firstDate);
   });
@@ -374,9 +374,7 @@ module('Unit | Model | Session', function (hooks) {
       startDate: moment('2015-01-01').toDate(),
     });
     const offeringWithNoStartDate = store.createRecord('offering');
-    subject
-      .get('offerings')
-      .pushObjects([offering1, offering2, offering3, offeringWithNoStartDate]);
+    subject.get('offerings').push([offering1, offering2, offering3, offeringWithNoStartDate]);
     const sortedDates = await waitForResource(subject, 'sortedOfferingsByDate');
     assert.strictEqual(sortedDates.length, 3);
     assert.strictEqual(sortedDates[0], offering3);
@@ -397,7 +395,7 @@ module('Unit | Model | Session', function (hooks) {
       startDate: moment('2017-01-01 09:30:00').toDate(),
       endDate: moment('2017-01-01 10:00:00').toDate(),
     });
-    subject.get('offerings').pushObjects([allDayOffering, halfAnHourOffering]);
+    subject.get('offerings').push([allDayOffering, halfAnHourOffering]);
     const ilmSession = store.createRecord('ilmSession', { hours: 2.1 });
     subject.set('ilmSession', ilmSession);
 
@@ -418,7 +416,7 @@ module('Unit | Model | Session', function (hooks) {
       startDate: moment('2017-01-01 09:30:00').toDate(),
       endDate: moment('2017-01-01 10:00:00').toDate(),
     });
-    subject.get('offerings').pushObjects([allDayOffering, halfAnHourOffering]);
+    subject.get('offerings').push([allDayOffering, halfAnHourOffering]);
 
     const max = await waitForResource(subject, 'maxDuration');
     assert.strictEqual(Number(max), 24.0);
@@ -449,7 +447,7 @@ module('Unit | Model | Session', function (hooks) {
       startDate: moment('2017-01-01 09:30:00').toDate(),
       endDate: moment('2017-01-01 10:00:00').toDate(),
     });
-    subject.get('offerings').pushObjects([allDayOffering, halfAnHourOffering]);
+    subject.get('offerings').push([allDayOffering, halfAnHourOffering]);
     const ilmSession = store.createRecord('ilmSession', { hours: 2.1 });
     subject.set('ilmSession', ilmSession);
 
@@ -470,7 +468,7 @@ module('Unit | Model | Session', function (hooks) {
       startDate: moment('2017-01-01 09:30:00').toDate(),
       endDate: moment('2017-01-01 10:00:00').toDate(),
     });
-    subject.get('offerings').pushObjects([allDayOffering, halfAnHourOffering]);
+    subject.get('offerings').push([allDayOffering, halfAnHourOffering]);
 
     const total = await waitForResource(subject, 'totalSumDuration');
     assert.strictEqual(Number(total), 24.5);
@@ -654,7 +652,7 @@ module('Unit | Model | Session', function (hooks) {
       startDate: moment('2017-01-01 09:30:00').toDate(),
       endDate: moment('2017-01-01 10:00:00').toDate(),
     });
-    subject.get('offerings').pushObjects([allDayOffering, halfAnHourOffering]);
+    subject.get('offerings').push([allDayOffering, halfAnHourOffering]);
     const ilmSession = store.createRecord('ilmSession', { hours: 2.1 });
     subject.set('ilmSession', ilmSession);
 
@@ -674,7 +672,7 @@ module('Unit | Model | Session', function (hooks) {
       startDate: moment('2017-01-01 09:30:00').toDate(),
       endDate: moment('2017-01-01 10:00:00').toDate(),
     });
-    subject.get('offerings').pushObjects([allDayOffering, halfAnHourOffering]);
+    subject.get('offerings').push([allDayOffering, halfAnHourOffering]);
 
     const total = await subject.getTotalSumDuration();
     assert.strictEqual(Number(total), 24.5);

--- a/tests/unit/models/term-test.js
+++ b/tests/unit/models/term-test.js
@@ -21,7 +21,7 @@ module('Unit | Model | term', function (hooks) {
     const model = this.store.createRecord('term');
     assert.notOk(model.get('hasChildren'));
     const child = this.store.createRecord('term', { id: 1, parent: model });
-    model.get('children').pushObject(child);
+    model.get('children').push(child);
     assert.ok(model.get('hasChildren'));
   });
 
@@ -129,7 +129,7 @@ module('Unit | Model | term', function (hooks) {
     const model = this.store.createRecord('term');
     assert.strictEqual(model.get('childCount'), 0);
     const child = this.store.createRecord('term', { id: 1, parent: model });
-    model.get('children').pushObject(child);
+    model.get('children').push(child);
     assert.ok(model.get('childCount'), 1);
   });
 });

--- a/tests/unit/models/term-test.js
+++ b/tests/unit/models/term-test.js
@@ -21,7 +21,7 @@ module('Unit | Model | term', function (hooks) {
     const model = this.store.createRecord('term');
     assert.notOk(model.get('hasChildren'));
     const child = this.store.createRecord('term', { id: 1, parent: model });
-    model.get('children').push(child);
+    model.get('children').pushObject(child);
     assert.ok(model.get('hasChildren'));
   });
 
@@ -129,7 +129,7 @@ module('Unit | Model | term', function (hooks) {
     const model = this.store.createRecord('term');
     assert.strictEqual(model.get('childCount'), 0);
     const child = this.store.createRecord('term', { id: 1, parent: model });
-    model.get('children').push(child);
+    model.get('children').pushObject(child);
     assert.ok(model.get('childCount'), 1);
   });
 });

--- a/tests/unit/models/user-test.js
+++ b/tests/unit/models/user-test.js
@@ -142,13 +142,13 @@ module('Unit | Model | User', function (hooks) {
     const model = this.owner.lookup('service:store').createRecord('user');
     const store = this.owner.lookup('service:store');
     const courses = [];
-    courses.push(
+    courses.pushObject(
       store.createRecord('course', {
         directors: [model],
         id: 1,
       })
     );
-    courses.push(
+    courses.pushObject(
       store.createRecord('course', {
         directors: [model],
         id: 2,
@@ -166,13 +166,13 @@ module('Unit | Model | User', function (hooks) {
     const model = this.owner.lookup('service:store').createRecord('user');
     const store = this.owner.lookup('service:store');
     const courses = [];
-    courses.push(
+    courses.pushObject(
       store.createRecord('course', {
         administrators: [model],
         id: 1,
       })
     );
-    courses.push(
+    courses.pushObject(
       store.createRecord('course', {
         administrators: [model],
         id: 2,
@@ -455,7 +455,7 @@ module('Unit | Model | User', function (hooks) {
     const notAStudentRoleEither = store.createRecord('user-role', {
       title: 'Alien Overlord',
     });
-    model.get('roles').push([notAStudentRole, notAStudentRoleEither]);
+    model.get('roles').pushObjects([notAStudentRole, notAStudentRoleEither]);
     const isStudent = await waitForResource(model, 'isStudent');
     assert.notOk(isStudent);
   });
@@ -468,7 +468,7 @@ module('Unit | Model | User', function (hooks) {
       title: 'Non-student',
     });
     const studentRole = store.createRecord('user-role', { title: 'Student' });
-    model.get('roles').push([notAStudentRole, studentRole]);
+    model.get('roles').pushObjects([notAStudentRole, studentRole]);
     const isStudent = await waitForResource(model, 'isStudent');
     assert.ok(isStudent);
   });
@@ -656,7 +656,7 @@ module('Unit | Model | User', function (hooks) {
       parent: learnerGroup2,
     });
     const tree = [learnerGroup, learnerGroup2, learnerGroup3];
-    model.get('learnerGroups').push(learnerGroup);
+    model.get('learnerGroups').pushObject(learnerGroup);
 
     const lowestGroup = await model.getLowestMemberGroupInALearnerGroupTree(tree);
 
@@ -682,7 +682,7 @@ module('Unit | Model | User', function (hooks) {
       parent: learnerGroup2,
     });
     const tree = [learnerGroup, learnerGroup2, learnerGroup3];
-    model.get('learnerGroups').push([learnerGroup, learnerGroup2]);
+    model.get('learnerGroups').pushObjects([learnerGroup, learnerGroup2]);
 
     const lowestGroup = await model.getLowestMemberGroupInALearnerGroupTree(tree);
 
@@ -709,7 +709,7 @@ module('Unit | Model | User', function (hooks) {
       users: [model],
     });
     const tree = [learnerGroup, learnerGroup2, learnerGroup3];
-    model.get('learnerGroups').push([learnerGroup, learnerGroup2, learnerGroup3]);
+    model.get('learnerGroups').pushObjects([learnerGroup, learnerGroup2, learnerGroup3]);
 
     const lowestGroup = await model.getLowestMemberGroupInALearnerGroupTree(tree);
 
@@ -750,7 +750,7 @@ module('Unit | Model | User', function (hooks) {
       users: [model],
     });
     model.set('primaryCohort', primaryCohort);
-    model.get('cohorts').push([primaryCohort, secondaryCohort, anotherCohort]);
+    model.get('cohorts').pushObjects([primaryCohort, secondaryCohort, anotherCohort]);
 
     const cohorts = await waitForResource(model, 'secondaryCohorts');
     assert.strictEqual(cohorts.length, 2);

--- a/tests/unit/models/user-test.js
+++ b/tests/unit/models/user-test.js
@@ -455,7 +455,7 @@ module('Unit | Model | User', function (hooks) {
     const notAStudentRoleEither = store.createRecord('user-role', {
       title: 'Alien Overlord',
     });
-    model.get('roles').pushObjects([notAStudentRole, notAStudentRoleEither]);
+    model.get('roles').push([notAStudentRole, notAStudentRoleEither]);
     const isStudent = await waitForResource(model, 'isStudent');
     assert.notOk(isStudent);
   });
@@ -468,7 +468,7 @@ module('Unit | Model | User', function (hooks) {
       title: 'Non-student',
     });
     const studentRole = store.createRecord('user-role', { title: 'Student' });
-    model.get('roles').pushObjects([notAStudentRole, studentRole]);
+    model.get('roles').push([notAStudentRole, studentRole]);
     const isStudent = await waitForResource(model, 'isStudent');
     assert.ok(isStudent);
   });
@@ -682,7 +682,7 @@ module('Unit | Model | User', function (hooks) {
       parent: learnerGroup2,
     });
     const tree = [learnerGroup, learnerGroup2, learnerGroup3];
-    model.get('learnerGroups').pushObjects([learnerGroup, learnerGroup2]);
+    model.get('learnerGroups').push([learnerGroup, learnerGroup2]);
 
     const lowestGroup = await model.getLowestMemberGroupInALearnerGroupTree(tree);
 
@@ -709,7 +709,7 @@ module('Unit | Model | User', function (hooks) {
       users: [model],
     });
     const tree = [learnerGroup, learnerGroup2, learnerGroup3];
-    model.get('learnerGroups').pushObjects([learnerGroup, learnerGroup2, learnerGroup3]);
+    model.get('learnerGroups').push([learnerGroup, learnerGroup2, learnerGroup3]);
 
     const lowestGroup = await model.getLowestMemberGroupInALearnerGroupTree(tree);
 
@@ -750,7 +750,7 @@ module('Unit | Model | User', function (hooks) {
       users: [model],
     });
     model.set('primaryCohort', primaryCohort);
-    model.get('cohorts').pushObjects([primaryCohort, secondaryCohort, anotherCohort]);
+    model.get('cohorts').push([primaryCohort, secondaryCohort, anotherCohort]);
 
     const cohorts = await waitForResource(model, 'secondaryCohorts');
     assert.strictEqual(cohorts.length, 2);

--- a/tests/unit/models/user-test.js
+++ b/tests/unit/models/user-test.js
@@ -142,13 +142,13 @@ module('Unit | Model | User', function (hooks) {
     const model = this.owner.lookup('service:store').createRecord('user');
     const store = this.owner.lookup('service:store');
     const courses = [];
-    courses.pushObject(
+    courses.push(
       store.createRecord('course', {
         directors: [model],
         id: 1,
       })
     );
-    courses.pushObject(
+    courses.push(
       store.createRecord('course', {
         directors: [model],
         id: 2,
@@ -166,13 +166,13 @@ module('Unit | Model | User', function (hooks) {
     const model = this.owner.lookup('service:store').createRecord('user');
     const store = this.owner.lookup('service:store');
     const courses = [];
-    courses.pushObject(
+    courses.push(
       store.createRecord('course', {
         administrators: [model],
         id: 1,
       })
     );
-    courses.pushObject(
+    courses.push(
       store.createRecord('course', {
         administrators: [model],
         id: 2,

--- a/tests/unit/models/user-test.js
+++ b/tests/unit/models/user-test.js
@@ -142,13 +142,13 @@ module('Unit | Model | User', function (hooks) {
     const model = this.owner.lookup('service:store').createRecord('user');
     const store = this.owner.lookup('service:store');
     const courses = [];
-    courses.pushObject(
+    courses.push(
       store.createRecord('course', {
         directors: [model],
         id: 1,
       })
     );
-    courses.pushObject(
+    courses.push(
       store.createRecord('course', {
         directors: [model],
         id: 2,
@@ -166,13 +166,13 @@ module('Unit | Model | User', function (hooks) {
     const model = this.owner.lookup('service:store').createRecord('user');
     const store = this.owner.lookup('service:store');
     const courses = [];
-    courses.pushObject(
+    courses.push(
       store.createRecord('course', {
         administrators: [model],
         id: 1,
       })
     );
-    courses.pushObject(
+    courses.push(
       store.createRecord('course', {
         administrators: [model],
         id: 2,
@@ -656,7 +656,7 @@ module('Unit | Model | User', function (hooks) {
       parent: learnerGroup2,
     });
     const tree = [learnerGroup, learnerGroup2, learnerGroup3];
-    model.get('learnerGroups').pushObject(learnerGroup);
+    model.get('learnerGroups').push(learnerGroup);
 
     const lowestGroup = await model.getLowestMemberGroupInALearnerGroupTree(tree);
 

--- a/tests/unit/models/vocabulary-test.js
+++ b/tests/unit/models/vocabulary-test.js
@@ -21,7 +21,7 @@ module('Unit | Model | vocabulary', function (hooks) {
     const term1 = store.createRecord('term', { id: 1 });
     const term2 = store.createRecord('term', { id: 2 });
     const term3 = store.createRecord('term', { id: 3, parent: term2 });
-    model.get('terms').pushObjects([term1, term2, term3]);
+    model.get('terms').push([term1, term2, term3]);
     const topLevelTerms = await model.getTopLevelTerms();
     assert.strictEqual(topLevelTerms.length, 2);
     assert.ok(topLevelTerms.includes(term1));

--- a/tests/unit/models/vocabulary-test.js
+++ b/tests/unit/models/vocabulary-test.js
@@ -21,7 +21,7 @@ module('Unit | Model | vocabulary', function (hooks) {
     const term1 = store.createRecord('term', { id: 1 });
     const term2 = store.createRecord('term', { id: 2 });
     const term3 = store.createRecord('term', { id: 3, parent: term2 });
-    model.get('terms').push([term1, term2, term3]);
+    model.get('terms').pushObjects([term1, term2, term3]);
     const topLevelTerms = await model.getTopLevelTerms();
     assert.strictEqual(topLevelTerms.length, 2);
     assert.ok(topLevelTerms.includes(term1));

--- a/tests/unit/utils/array-helpers-test.js
+++ b/tests/unit/utils/array-helpers-test.js
@@ -101,9 +101,9 @@ module('Unit | Utility | array-helpers', function () {
     const arr = getDogs();
     arr[1] = {};
     const result = sortBy(arr, 'name');
-    assert.strictEqual(result[0].name, 'jackson');
-    assert.strictEqual(result[1].name, 'jayden');
-    assert.deepEqual(result[2], {});
+    assert.deepEqual(result[0], {});
+    assert.strictEqual(result[1].name, 'jackson');
+    assert.strictEqual(result[2].name, 'jayden');
   });
   test('sortBy string when item is undefined', function (assert) {
     const arr = getDogs();
@@ -117,9 +117,9 @@ module('Unit | Utility | array-helpers', function () {
     const arr = getDogs();
     arr[1] = null;
     const result = sortBy(arr, 'name');
-    assert.strictEqual(result[0].name, 'jackson');
-    assert.strictEqual(result[1].name, 'jayden');
-    assert.strictEqual(result[2], null);
+    assert.strictEqual(result[0], null);
+    assert.strictEqual(result[1].name, 'jackson');
+    assert.strictEqual(result[2].name, 'jayden');
   });
 
   test('sortBy string multiple', function (assert) {
@@ -132,9 +132,9 @@ module('Unit | Utility | array-helpers', function () {
     const arr = getDogs();
     arr[0] = {};
     const result = sortBy(arr, ['breed', 'name']);
-    assert.strictEqual(result[0].name, 'jackson');
-    assert.strictEqual(result[1].name, 'jasper');
-    assert.deepEqual(result[2], {});
+    assert.deepEqual(result[0], {});
+    assert.strictEqual(result[1].name, 'jackson');
+    assert.strictEqual(result[2].name, 'jasper');
   });
   test('sortBy string multiple when item is undefined', function (assert) {
     const arr = getDogs();
@@ -148,9 +148,9 @@ module('Unit | Utility | array-helpers', function () {
     const arr = getDogs();
     arr[0] = null;
     const result = sortBy(arr, ['breed', 'name']);
-    assert.strictEqual(result[0].name, 'jackson');
-    assert.strictEqual(result[1].name, 'jasper');
-    assert.strictEqual(result[2], null);
+    assert.strictEqual(result[0], null);
+    assert.strictEqual(result[1].name, 'jackson');
+    assert.strictEqual(result[2].name, 'jasper');
   });
 
   test('sortBy Date', function (assert) {
@@ -163,9 +163,9 @@ module('Unit | Utility | array-helpers', function () {
     const arr = getDogs();
     arr[1] = {};
     const result = sortBy(arr, 'dob');
-    assert.strictEqual(result[0].name, 'jackson');
-    assert.strictEqual(result[1].name, 'jayden');
-    assert.deepEqual(result[2], {});
+    assert.deepEqual(result[0], {});
+    assert.strictEqual(result[1].name, 'jackson');
+    assert.strictEqual(result[2].name, 'jayden');
   });
   test('sortBy Date when item is undefined', function (assert) {
     const arr = getDogs();
@@ -179,9 +179,9 @@ module('Unit | Utility | array-helpers', function () {
     const arr = getDogs();
     arr[1] = null;
     const result = sortBy(arr, 'dob');
-    assert.strictEqual(result[0].name, 'jackson');
-    assert.strictEqual(result[1].name, 'jayden');
-    assert.strictEqual(result[2], null);
+    assert.strictEqual(result[0], null);
+    assert.strictEqual(result[1].name, 'jackson');
+    assert.strictEqual(result[2].name, 'jayden');
   });
 
   test('sortBy number', function (assert) {
@@ -194,9 +194,9 @@ module('Unit | Utility | array-helpers', function () {
     const arr = getDogs();
     arr[1] = {};
     const result = sortBy(arr, 'goodnessRanking');
-    assert.strictEqual(result[0].name, 'jayden');
-    assert.strictEqual(result[1].name, 'jackson');
-    assert.deepEqual(result[2], {});
+    assert.deepEqual(result[0], {});
+    assert.strictEqual(result[1].name, 'jayden');
+    assert.strictEqual(result[2].name, 'jackson');
   });
   test('sortBy number when item is undefined', function (assert) {
     const arr = getDogs();
@@ -210,9 +210,9 @@ module('Unit | Utility | array-helpers', function () {
     const arr = getDogs();
     arr[1] = null;
     const result = sortBy(arr, 'goodnessRanking');
-    assert.strictEqual(result[0].name, 'jayden');
-    assert.strictEqual(result[1].name, 'jackson');
-    assert.strictEqual(result[2], null);
+    assert.strictEqual(result[0], null);
+    assert.strictEqual(result[1].name, 'jayden');
+    assert.strictEqual(result[2].name, 'jackson');
   });
 
   test('uniqueBy', function (assert) {

--- a/tests/unit/utils/array-helpers-test.js
+++ b/tests/unit/utils/array-helpers-test.js
@@ -3,9 +3,7 @@ import {
   findById,
   filterBy,
   mapBy,
-  sortByDate,
-  sortByString,
-  sortByNumber,
+  sortBy,
   uniqueBy,
   uniqueById,
   uniqueValues,
@@ -41,9 +39,8 @@ function getDogs() {
 module('Unit | Utility | array-helpers', function () {
   test('when array is false', function (assert) {
     assert.false(mapBy(false, 'name'));
-    assert.false(sortByDate(false, 'dob'));
-    assert.false(sortByString(false, 'name'));
-    assert.false(sortByNumber(false, 'goodnessRanking'));
+    assert.false(sortBy(false, 'dob'));
+    assert.false(sortBy(false, ['name', 'goodnessRanking']));
     assert.false(uniqueBy(false, 'name'));
     assert.false(uniqueById(false));
     assert.false(uniqueValues(false));
@@ -53,9 +50,8 @@ module('Unit | Utility | array-helpers', function () {
   });
   test('when array is null', function (assert) {
     assert.strictEqual(mapBy(null, 'name'), null);
-    assert.strictEqual(sortByDate(null, 'dob'), null);
-    assert.strictEqual(sortByString(null, 'name'), null);
-    assert.strictEqual(sortByNumber(null, 'goodnessRanking'), null);
+    assert.strictEqual(sortBy(null, 'name'), null);
+    assert.strictEqual(sortBy(null, ['name', 'goodnessRanking']), null);
     assert.strictEqual(uniqueBy(null, 'name'), null);
     assert.strictEqual(uniqueById(null), null);
     assert.strictEqual(uniqueValues(null), null);
@@ -65,9 +61,8 @@ module('Unit | Utility | array-helpers', function () {
   });
   test('when array is undefined', function (assert) {
     assert.strictEqual(mapBy(undefined, 'name'), undefined);
-    assert.strictEqual(sortByDate(undefined, 'dob'), undefined);
-    assert.strictEqual(sortByString(undefined, 'name'), undefined);
-    assert.strictEqual(sortByNumber(undefined, 'goodnessRanking'), undefined);
+    assert.strictEqual(sortBy(undefined, 'name'), undefined);
+    assert.strictEqual(sortBy(undefined, ['name', 'goodnessRanking']), undefined);
     assert.strictEqual(uniqueBy(undefined, 'name'), undefined);
     assert.strictEqual(uniqueById(undefined), undefined);
     assert.strictEqual(uniqueValues(undefined), undefined);
@@ -96,94 +91,125 @@ module('Unit | Utility | array-helpers', function () {
     assert.deepEqual(mapBy(arr, 'name'), ['jayden', null, 'jackson']);
   });
 
-  test('sortByString', function (assert) {
-    const result = sortByString(getDogs(), 'name');
+  test('sortBy string', function (assert) {
+    const result = sortBy(getDogs(), 'name');
     assert.strictEqual(result[0].name, 'jackson');
     assert.strictEqual(result[1].name, 'jasper');
     assert.strictEqual(result[2].name, 'jayden');
   });
-  test('sortByString when key does not exist', function (assert) {
+  test('sortBy string when key does not exist', function (assert) {
     const arr = getDogs();
     arr[1] = {};
-    const result = sortByString(arr, 'name');
+    const result = sortBy(arr, 'name');
     assert.strictEqual(result[0].name, 'jackson');
     assert.strictEqual(result[1].name, 'jayden');
     assert.deepEqual(result[2], {});
   });
-  test('sortByString when item is undefined', function (assert) {
+  test('sortBy string when item is undefined', function (assert) {
     const arr = getDogs();
     arr[1] = undefined;
-    const result = sortByString(arr, 'name');
+    const result = sortBy(arr, 'name');
     assert.strictEqual(result[0].name, 'jackson');
     assert.strictEqual(result[1].name, 'jayden');
     assert.strictEqual(result[2], undefined);
   });
-  test('sortByString when item is null', function (assert) {
+  test('sortBy string when item is null', function (assert) {
     const arr = getDogs();
     arr[1] = null;
-    const result = sortByString(arr, 'name');
+    const result = sortBy(arr, 'name');
     assert.strictEqual(result[0].name, 'jackson');
     assert.strictEqual(result[1].name, 'jayden');
     assert.strictEqual(result[2], null);
   });
 
-  test('sortByDate', function (assert) {
-    const result = sortByDate(getDogs(), 'dob');
+  test('sortBy string multiple', function (assert) {
+    const result = sortBy(getDogs(), ['breed', 'name']);
+    assert.strictEqual(result[0].name, 'jackson');
+    assert.strictEqual(result[1].name, 'jayden');
+    assert.strictEqual(result[2].name, 'jasper');
+  });
+  test('sortBy string multiple when key does not exist', function (assert) {
+    const arr = getDogs();
+    arr[0] = {};
+    const result = sortBy(arr, ['breed', 'name']);
+    assert.strictEqual(result[0].name, 'jackson');
+    assert.strictEqual(result[1].name, 'jasper');
+    assert.deepEqual(result[2], {});
+  });
+  test('sortBy string multiple when item is undefined', function (assert) {
+    const arr = getDogs();
+    arr[0] = undefined;
+    const result = sortBy(arr, ['breed', 'name']);
+    assert.strictEqual(result[0].name, 'jackson');
+    assert.strictEqual(result[1].name, 'jasper');
+    assert.strictEqual(result[2], undefined);
+  });
+  test('sortBy string multiple when item is null', function (assert) {
+    const arr = getDogs();
+    arr[0] = null;
+    const result = sortBy(arr, ['breed', 'name']);
+    assert.strictEqual(result[0].name, 'jackson');
+    assert.strictEqual(result[1].name, 'jasper');
+    assert.strictEqual(result[2], null);
+  });
+
+  test('sortBy Date', function (assert) {
+    const result = sortBy(getDogs(), 'dob');
     assert.strictEqual(result[0].name, 'jasper');
     assert.strictEqual(result[1].name, 'jackson');
     assert.strictEqual(result[2].name, 'jayden');
   });
-  test('sortByDate when key does not exist', function (assert) {
+  test('sortBy Date when key does not exist', function (assert) {
     const arr = getDogs();
     arr[1] = {};
-    const result = sortByDate(arr, 'dob');
+    const result = sortBy(arr, 'dob');
     assert.strictEqual(result[0].name, 'jackson');
     assert.strictEqual(result[1].name, 'jayden');
     assert.deepEqual(result[2], {});
   });
-  test('sortByDate when item is undefined', function (assert) {
+  test('sortBy Date when item is undefined', function (assert) {
     const arr = getDogs();
     arr[1] = undefined;
-    const result = sortByDate(arr, 'dob');
+    const result = sortBy(arr, 'dob');
     assert.strictEqual(result[0].name, 'jackson');
     assert.strictEqual(result[1].name, 'jayden');
     assert.strictEqual(result[2], undefined);
   });
-  test('sortByDate when item is null', function (assert) {
+  test('sortBy Date when item is null', function (assert) {
     const arr = getDogs();
     arr[1] = null;
-    const result = sortByDate(arr, 'dob');
+    const result = sortBy(arr, 'dob');
     assert.strictEqual(result[0].name, 'jackson');
     assert.strictEqual(result[1].name, 'jayden');
     assert.strictEqual(result[2], null);
   });
 
-  test('sortByNumber', function (assert) {
-    const result = sortByNumber(getDogs(), 'goodnessRanking');
+  test('sortBy number', function (assert) {
+    const result = sortBy(getDogs(), 'goodnessRanking');
     assert.strictEqual(result[0].name, 'jasper');
     assert.strictEqual(result[1].name, 'jayden');
     assert.strictEqual(result[2].name, 'jackson');
   });
-  test('sortByNumber when key does not exist', function (assert) {
+  test('sortBy number when key does not exist', function (assert) {
     const arr = getDogs();
     arr[1] = {};
-    const result = sortByNumber(arr, 'goodnessRanking');
+    const result = sortBy(arr, 'goodnessRanking');
     assert.strictEqual(result[0].name, 'jayden');
     assert.strictEqual(result[1].name, 'jackson');
     assert.deepEqual(result[2], {});
   });
-  test('sortByNumber when item is undefined', function (assert) {
+  test('sortBy number when item is undefined', function (assert) {
     const arr = getDogs();
     arr[1] = undefined;
-    const result = sortByNumber(arr, 'goodnessRanking');
+    const result = sortBy(arr, 'goodnessRanking');
     assert.strictEqual(result[0].name, 'jayden');
     assert.strictEqual(result[1].name, 'jackson');
     assert.strictEqual(result[2], undefined);
   });
-  test('sortByNumber when item is null', function (assert) {
+  test('sortBy number when item is null', function (assert) {
     const arr = getDogs();
     arr[1] = null;
-    const result = sortByNumber(arr, 'goodnessRanking');
+    const result = sortBy(arr, 'goodnessRanking');
     assert.strictEqual(result[0].name, 'jayden');
     assert.strictEqual(result[1].name, 'jackson');
     assert.strictEqual(result[2], null);

--- a/tests/unit/utils/array-helpers-test.js
+++ b/tests/unit/utils/array-helpers-test.js
@@ -1,4 +1,12 @@
-import { mapBy, sortByDate, sortByString, sortByNumber } from 'ilios-common/utils/array-helpers';
+import {
+  mapBy,
+  sortByDate,
+  sortByString,
+  sortByNumber,
+  uniqueBy,
+  uniqueById,
+  uniqueValues,
+} from 'ilios-common/utils/array-helpers';
 import { module, test } from 'qunit';
 
 function getDogs() {
@@ -165,6 +173,123 @@ module('Unit | Utility | array-helpers', function () {
   });
   test('sortByNumber when array is undefined', function (assert) {
     let result = sortByNumber(undefined, 'goodnessRanking');
+    assert.deepEqual(result, undefined);
+  });
+
+  test('uniqueBy', function (assert) {
+    const arr = [...getDogs(), ...getDogs(), ...getDogs()];
+    assert.strictEqual(arr.length, 9);
+    const result = uniqueBy(arr, 'name');
+    assert.strictEqual(result.length, 3);
+    assert.strictEqual(result[0].name, 'jayden');
+    assert.strictEqual(result[1].name, 'jasper');
+    assert.strictEqual(result[2].name, 'jackson');
+  });
+  test('uniqueBy when key does not exist', function (assert) {
+    const arr = [{ id: 1, name: 'one' }, {}, { id: 1, name: 'one' }];
+    const result = uniqueBy(arr, 'id');
+    assert.strictEqual(result.length, 2);
+    assert.strictEqual(result[0].name, 'one');
+    assert.deepEqual(result[1], {});
+  });
+  test('uniqueBy when item is undefined', function (assert) {
+    const arr = [{ id: 1, name: 'one' }, undefined, { id: 1, name: 'one' }];
+    const result = uniqueBy(arr, 'id');
+    assert.strictEqual(result.length, 2);
+    assert.strictEqual(result[0].name, 'one');
+    assert.deepEqual(result[1], undefined);
+  });
+  test('uniqueBy when item is null', function (assert) {
+    const arr = [{ id: 1, name: 'one' }, null, { id: 1, name: 'one' }];
+    const result = uniqueBy(arr, 'id');
+    assert.strictEqual(result.length, 2);
+    assert.strictEqual(result[0].name, 'one');
+    assert.deepEqual(result[1], null);
+  });
+  test('uniqueBy when array is false', function (assert) {
+    let result = uniqueBy(false, 'name');
+    assert.false(result);
+  });
+  test('uniqueBy when array is null', function (assert) {
+    let result = uniqueBy(null, 'name');
+    assert.deepEqual(result, null);
+  });
+  test('uniqueBy when array is undefined', function (assert) {
+    let result = uniqueBy(undefined, 'name');
+    assert.deepEqual(result, undefined);
+  });
+
+  test('uniqueById', function (assert) {
+    const arr = [
+      { id: 1, name: 'one' },
+      { id: 2, name: 'two' },
+      { id: 1, name: 'one' },
+    ];
+    const result = uniqueById(arr);
+    assert.strictEqual(result.length, 2);
+    assert.strictEqual(result[0].name, 'one');
+    assert.strictEqual(result[1].name, 'two');
+  });
+  test('uniqueById when key does not exist', function (assert) {
+    const arr = [{ id: 1, name: 'one' }, {}, { id: 1, name: 'one' }];
+    const result = uniqueById(arr);
+    assert.strictEqual(result.length, 2);
+    assert.strictEqual(result[0].name, 'one');
+    assert.deepEqual(result[1], {});
+  });
+  test('uniqueById when item is undefined', function (assert) {
+    const arr = [{ id: 1, name: 'one' }, undefined, { id: 1, name: 'one' }];
+    const result = uniqueById(arr);
+    assert.strictEqual(result.length, 2);
+    assert.strictEqual(result[0].name, 'one');
+    assert.deepEqual(result[1], undefined);
+  });
+  test('uniqueById when item is null', function (assert) {
+    const arr = [{ id: 1, name: 'one' }, null, { id: 1, name: 'one' }];
+    const result = uniqueById(arr);
+    assert.strictEqual(result.length, 2);
+    assert.strictEqual(result[0].name, 'one');
+    assert.deepEqual(result[1], null);
+  });
+  test('uniqueById when array is false', function (assert) {
+    let result = uniqueById(false);
+    assert.false(result);
+  });
+  test('uniqueById when array is null', function (assert) {
+    let result = uniqueById(null);
+    assert.deepEqual(result, null);
+  });
+  test('uniqueById when array is undefined', function (assert) {
+    let result = uniqueById(undefined);
+    assert.deepEqual(result, undefined);
+  });
+
+  test('uniqueValues', function (assert) {
+    const arr = ['one', 'two', 'one'];
+    const result = uniqueValues(arr);
+    assert.strictEqual(result.length, 2);
+    assert.strictEqual(result[0], 'one');
+    assert.strictEqual(result[1], 'two');
+  });
+  test('uniqueValues when item is undefined', function (assert) {
+    const arr = ['one', undefined, null, undefined, null, 'two', 'one'];
+    const result = uniqueValues(arr);
+    assert.strictEqual(result.length, 4);
+    assert.strictEqual(result[0], 'one');
+    assert.deepEqual(result[1], undefined);
+    assert.deepEqual(result[2], null);
+    assert.deepEqual(result[3], 'two');
+  });
+  test('uniqueValues when array is false', function (assert) {
+    let result = uniqueValues(false);
+    assert.false(result);
+  });
+  test('uniqueValues when array is null', function (assert) {
+    let result = uniqueValues(null);
+    assert.deepEqual(result, null);
+  });
+  test('uniqueValues when array is undefined', function (assert) {
+    let result = uniqueValues(undefined);
     assert.deepEqual(result, undefined);
   });
 });

--- a/tests/unit/utils/array-helpers-test.js
+++ b/tests/unit/utils/array-helpers-test.js
@@ -18,6 +18,34 @@ function getDogs() {
 }
 
 module('Unit | Utility | array-helpers', function () {
+  test('when array is false', function (assert) {
+    assert.false(mapBy(false, 'name'));
+    assert.false(sortByDate(false, 'dob'));
+    assert.false(sortByString(false, 'name'));
+    assert.false(sortByNumber(false, 'goodnessRanking'));
+    assert.false(uniqueBy(false, 'name'));
+    assert.false(uniqueById(false));
+    assert.false(uniqueValues(false));
+  });
+  test('when array is null', function (assert) {
+    assert.strictEqual(mapBy(null, 'name'), null);
+    assert.strictEqual(sortByDate(null, 'dob'), null);
+    assert.strictEqual(sortByString(null, 'name'), null);
+    assert.strictEqual(sortByNumber(null, 'goodnessRanking'), null);
+    assert.strictEqual(uniqueBy(null, 'name'), null);
+    assert.strictEqual(uniqueById(null), null);
+    assert.strictEqual(uniqueValues(null), null);
+  });
+  test('when array is undefined', function (assert) {
+    assert.strictEqual(mapBy(undefined, 'name'), undefined);
+    assert.strictEqual(sortByDate(undefined, 'dob'), undefined);
+    assert.strictEqual(sortByString(undefined, 'name'), undefined);
+    assert.strictEqual(sortByNumber(undefined, 'goodnessRanking'), undefined);
+    assert.strictEqual(uniqueBy(undefined, 'name'), undefined);
+    assert.strictEqual(uniqueById(undefined), undefined);
+    assert.strictEqual(uniqueValues(undefined), undefined);
+  });
+
   test('mapBy', function (assert) {
     let result = mapBy(getDogs(), 'name');
     assert.deepEqual(result, ['jayden', 'jasper', 'jackson']);
@@ -36,15 +64,6 @@ module('Unit | Utility | array-helpers', function () {
     const arr = getDogs();
     arr[1] = null;
     assert.deepEqual(mapBy(arr, 'name'), ['jayden', null, 'jackson']);
-  });
-  test('mapBy when array is false', function (assert) {
-    assert.false(mapBy(false, 'name'));
-  });
-  test('mapBy when array is null', function (assert) {
-    assert.deepEqual(mapBy(null, 'name'), null);
-  });
-  test('mapBy when array is undefined', function (assert) {
-    assert.deepEqual(mapBy(undefined, 'name'), undefined);
   });
 
   test('sortByString', function (assert) {
@@ -77,18 +96,6 @@ module('Unit | Utility | array-helpers', function () {
     assert.strictEqual(result[1].name, 'jayden');
     assert.strictEqual(result[2], null);
   });
-  test('sortByString when array is false', function (assert) {
-    let result = sortByString(false, 'name');
-    assert.false(result);
-  });
-  test('sortByString when array is null', function (assert) {
-    let result = sortByString(null, 'name');
-    assert.deepEqual(result, null);
-  });
-  test('sortByString when array is undefined', function (assert) {
-    let result = sortByString(undefined, 'name');
-    assert.deepEqual(result, undefined);
-  });
 
   test('sortByDate', function (assert) {
     const result = sortByDate(getDogs(), 'dob');
@@ -119,18 +126,6 @@ module('Unit | Utility | array-helpers', function () {
     assert.strictEqual(result[0].name, 'jackson');
     assert.strictEqual(result[1].name, 'jayden');
     assert.strictEqual(result[2], null);
-  });
-  test('sortByDate when array is false', function (assert) {
-    let result = sortByDate(false, 'dob');
-    assert.false(result);
-  });
-  test('sortByDate when array is null', function (assert) {
-    let result = sortByDate(null, 'dob');
-    assert.deepEqual(result, null);
-  });
-  test('sortByDate when array is undefined', function (assert) {
-    let result = sortByDate(undefined, 'dob');
-    assert.deepEqual(result, undefined);
   });
 
   test('sortByNumber', function (assert) {
@@ -163,18 +158,6 @@ module('Unit | Utility | array-helpers', function () {
     assert.strictEqual(result[1].name, 'jackson');
     assert.strictEqual(result[2], null);
   });
-  test('sortByNumber when array is false', function (assert) {
-    let result = sortByNumber(false, 'goodnessRanking');
-    assert.false(result);
-  });
-  test('sortByNumber when array is null', function (assert) {
-    let result = sortByNumber(null, 'goodnessRanking');
-    assert.deepEqual(result, null);
-  });
-  test('sortByNumber when array is undefined', function (assert) {
-    let result = sortByNumber(undefined, 'goodnessRanking');
-    assert.deepEqual(result, undefined);
-  });
 
   test('uniqueBy', function (assert) {
     const arr = [...getDogs(), ...getDogs(), ...getDogs()];
@@ -205,18 +188,6 @@ module('Unit | Utility | array-helpers', function () {
     assert.strictEqual(result.length, 2);
     assert.strictEqual(result[0].name, 'one');
     assert.deepEqual(result[1], null);
-  });
-  test('uniqueBy when array is false', function (assert) {
-    let result = uniqueBy(false, 'name');
-    assert.false(result);
-  });
-  test('uniqueBy when array is null', function (assert) {
-    let result = uniqueBy(null, 'name');
-    assert.deepEqual(result, null);
-  });
-  test('uniqueBy when array is undefined', function (assert) {
-    let result = uniqueBy(undefined, 'name');
-    assert.deepEqual(result, undefined);
   });
 
   test('uniqueById', function (assert) {
@@ -251,18 +222,6 @@ module('Unit | Utility | array-helpers', function () {
     assert.strictEqual(result[0].name, 'one');
     assert.deepEqual(result[1], null);
   });
-  test('uniqueById when array is false', function (assert) {
-    let result = uniqueById(false);
-    assert.false(result);
-  });
-  test('uniqueById when array is null', function (assert) {
-    let result = uniqueById(null);
-    assert.deepEqual(result, null);
-  });
-  test('uniqueById when array is undefined', function (assert) {
-    let result = uniqueById(undefined);
-    assert.deepEqual(result, undefined);
-  });
 
   test('uniqueValues', function (assert) {
     const arr = ['one', 'two', 'one'];
@@ -279,17 +238,5 @@ module('Unit | Utility | array-helpers', function () {
     assert.deepEqual(result[1], undefined);
     assert.deepEqual(result[2], null);
     assert.deepEqual(result[3], 'two');
-  });
-  test('uniqueValues when array is false', function (assert) {
-    let result = uniqueValues(false);
-    assert.false(result);
-  });
-  test('uniqueValues when array is null', function (assert) {
-    let result = uniqueValues(null);
-    assert.deepEqual(result, null);
-  });
-  test('uniqueValues when array is undefined', function (assert) {
-    let result = uniqueValues(undefined);
-    assert.deepEqual(result, undefined);
   });
 });

--- a/tests/unit/utils/array-helpers-test.js
+++ b/tests/unit/utils/array-helpers-test.js
@@ -1,0 +1,170 @@
+import { mapBy, sortByDate, sortByString, sortByNumber } from 'ilios-common/utils/array-helpers';
+import { module, test } from 'qunit';
+
+function getDogs() {
+  return [
+    { name: 'jayden', dob: new Date(2017, 11, 11), goodnessRanking: 10 },
+    { name: 'jasper', dob: new Date(2005, 11, 11), goodnessRanking: 4 },
+    { name: 'jackson', dob: new Date(2010, 11, 11), goodnessRanking: 15 },
+  ];
+}
+
+module('Unit | Utility | array-helpers', function () {
+  test('mapBy', function (assert) {
+    let result = mapBy(getDogs(), 'name');
+    assert.deepEqual(result, ['jayden', 'jasper', 'jackson']);
+  });
+  test('mapBy when key does not exist', function (assert) {
+    const arr = getDogs();
+    arr[1] = {};
+    assert.deepEqual(mapBy(arr, 'name'), ['jayden', undefined, 'jackson']);
+  });
+  test('mapBy when item is undefined', function (assert) {
+    const arr = getDogs();
+    arr[1] = undefined;
+    assert.deepEqual(mapBy(arr, 'name'), ['jayden', undefined, 'jackson']);
+  });
+  test('mapBy when item is null', function (assert) {
+    const arr = getDogs();
+    arr[1] = null;
+    assert.deepEqual(mapBy(arr, 'name'), ['jayden', null, 'jackson']);
+  });
+  test('mapBy when array is false', function (assert) {
+    assert.false(mapBy(false, 'name'));
+  });
+  test('mapBy when array is null', function (assert) {
+    assert.deepEqual(mapBy(null, 'name'), null);
+  });
+  test('mapBy when array is undefined', function (assert) {
+    assert.deepEqual(mapBy(undefined, 'name'), undefined);
+  });
+
+  test('sortByString', function (assert) {
+    const result = sortByString(getDogs(), 'name');
+    assert.strictEqual(result[0].name, 'jackson');
+    assert.strictEqual(result[1].name, 'jasper');
+    assert.strictEqual(result[2].name, 'jayden');
+  });
+  test('sortByString when key does not exist', function (assert) {
+    const arr = getDogs();
+    arr[1] = {};
+    const result = sortByString(arr, 'name');
+    assert.strictEqual(result[0].name, 'jackson');
+    assert.strictEqual(result[1].name, 'jayden');
+    assert.deepEqual(result[2], {});
+  });
+  test('sortByString when item is undefined', function (assert) {
+    const arr = getDogs();
+    arr[1] = undefined;
+    const result = sortByString(arr, 'name');
+    assert.strictEqual(result[0].name, 'jackson');
+    assert.strictEqual(result[1].name, 'jayden');
+    assert.strictEqual(result[2], undefined);
+  });
+  test('sortByString when item is null', function (assert) {
+    const arr = getDogs();
+    arr[1] = null;
+    const result = sortByString(arr, 'name');
+    assert.strictEqual(result[0].name, 'jackson');
+    assert.strictEqual(result[1].name, 'jayden');
+    assert.strictEqual(result[2], null);
+  });
+  test('sortByString when array is false', function (assert) {
+    let result = sortByString(false, 'name');
+    assert.false(result);
+  });
+  test('sortByString when array is null', function (assert) {
+    let result = sortByString(null, 'name');
+    assert.deepEqual(result, null);
+  });
+  test('sortByString when array is undefined', function (assert) {
+    let result = sortByString(undefined, 'name');
+    assert.deepEqual(result, undefined);
+  });
+
+  test('sortByDate', function (assert) {
+    const result = sortByDate(getDogs(), 'dob');
+    assert.strictEqual(result[0].name, 'jasper');
+    assert.strictEqual(result[1].name, 'jackson');
+    assert.strictEqual(result[2].name, 'jayden');
+  });
+  test('sortByDate when key does not exist', function (assert) {
+    const arr = getDogs();
+    arr[1] = {};
+    const result = sortByDate(arr, 'dob');
+    assert.strictEqual(result[0].name, 'jackson');
+    assert.strictEqual(result[1].name, 'jayden');
+    assert.deepEqual(result[2], {});
+  });
+  test('sortByDate when item is undefined', function (assert) {
+    const arr = getDogs();
+    arr[1] = undefined;
+    const result = sortByDate(arr, 'dob');
+    assert.strictEqual(result[0].name, 'jackson');
+    assert.strictEqual(result[1].name, 'jayden');
+    assert.strictEqual(result[2], undefined);
+  });
+  test('sortByDate when item is null', function (assert) {
+    const arr = getDogs();
+    arr[1] = null;
+    const result = sortByDate(arr, 'dob');
+    assert.strictEqual(result[0].name, 'jackson');
+    assert.strictEqual(result[1].name, 'jayden');
+    assert.strictEqual(result[2], null);
+  });
+  test('sortByDate when array is false', function (assert) {
+    let result = sortByDate(false, 'dob');
+    assert.false(result);
+  });
+  test('sortByDate when array is null', function (assert) {
+    let result = sortByDate(null, 'dob');
+    assert.deepEqual(result, null);
+  });
+  test('sortByDate when array is undefined', function (assert) {
+    let result = sortByDate(undefined, 'dob');
+    assert.deepEqual(result, undefined);
+  });
+
+  test('sortByNumber', function (assert) {
+    const result = sortByNumber(getDogs(), 'goodnessRanking');
+    assert.strictEqual(result[0].name, 'jasper');
+    assert.strictEqual(result[1].name, 'jayden');
+    assert.strictEqual(result[2].name, 'jackson');
+  });
+  test('sortByNumber when key does not exist', function (assert) {
+    const arr = getDogs();
+    arr[1] = {};
+    const result = sortByNumber(arr, 'goodnessRanking');
+    assert.strictEqual(result[0].name, 'jayden');
+    assert.strictEqual(result[1].name, 'jackson');
+    assert.deepEqual(result[2], {});
+  });
+  test('sortByNumber when item is undefined', function (assert) {
+    const arr = getDogs();
+    arr[1] = undefined;
+    const result = sortByNumber(arr, 'goodnessRanking');
+    assert.strictEqual(result[0].name, 'jayden');
+    assert.strictEqual(result[1].name, 'jackson');
+    assert.strictEqual(result[2], undefined);
+  });
+  test('sortByNumber when item is null', function (assert) {
+    const arr = getDogs();
+    arr[1] = null;
+    const result = sortByNumber(arr, 'goodnessRanking');
+    assert.strictEqual(result[0].name, 'jayden');
+    assert.strictEqual(result[1].name, 'jackson');
+    assert.strictEqual(result[2], null);
+  });
+  test('sortByNumber when array is false', function (assert) {
+    let result = sortByNumber(false, 'goodnessRanking');
+    assert.false(result);
+  });
+  test('sortByNumber when array is null', function (assert) {
+    let result = sortByNumber(null, 'goodnessRanking');
+    assert.deepEqual(result, null);
+  });
+  test('sortByNumber when array is undefined', function (assert) {
+    let result = sortByNumber(undefined, 'goodnessRanking');
+    assert.deepEqual(result, undefined);
+  });
+});

--- a/tests/unit/utils/array-helpers-test.js
+++ b/tests/unit/utils/array-helpers-test.js
@@ -8,7 +8,7 @@ import {
   uniqueById,
   uniqueValues,
 } from 'ilios-common/utils/array-helpers';
-import { module, test } from 'qunit';
+import { module, test, todo } from 'qunit';
 
 function getDogs() {
   return [
@@ -37,38 +37,38 @@ function getDogs() {
 }
 
 module('Unit | Utility | array-helpers', function () {
-  test('when array is false', function (assert) {
-    assert.false(mapBy(false, 'name'));
-    assert.false(sortBy(false, 'dob'));
-    assert.false(sortBy(false, ['name', 'goodnessRanking']));
-    assert.false(uniqueBy(false, 'name'));
-    assert.false(uniqueById(false));
-    assert.false(uniqueValues(false));
-    assert.false(findBy(false, 'name', 'jayden'));
-    assert.false(findById(false, 'jayden'));
-    assert.false(filterBy(false, 'breed', 'Chihuahua'));
+  todo('when array is false', function (assert) {
+    assert.strictEqual(mapBy(false, 'name'), []);
+    assert.strictEqual(sortBy(false, 'dob'), []);
+    assert.strictEqual(sortBy(false, ['name', 'goodnessRanking']), []);
+    assert.strictEqual(uniqueBy(false, 'name'), []);
+    assert.strictEqual(uniqueById(false), []);
+    assert.strictEqual(uniqueValues(false), []);
+    assert.strictEqual(findBy(false, 'name', 'jayden'), []);
+    assert.strictEqual(findById(false, 'jayden'), []);
+    assert.strictEqual(filterBy(false, 'breed', 'Chihuahua'), []);
   });
-  test('when array is null', function (assert) {
-    assert.strictEqual(mapBy(null, 'name'), null);
-    assert.strictEqual(sortBy(null, 'name'), null);
-    assert.strictEqual(sortBy(null, ['name', 'goodnessRanking']), null);
-    assert.strictEqual(uniqueBy(null, 'name'), null);
-    assert.strictEqual(uniqueById(null), null);
-    assert.strictEqual(uniqueValues(null), null);
-    assert.strictEqual(findBy(null, 'name', 'jackson'), null);
-    assert.strictEqual(findById(null, 'jackson'), null);
-    assert.strictEqual(filterBy(null, 'breed', 'Chihuahua'), null);
+  todo('when array is null', function (assert) {
+    assert.strictEqual(mapBy(null, 'name'), []);
+    assert.strictEqual(sortBy(null, 'name'), []);
+    assert.strictEqual(sortBy(null, ['name', 'goodnessRanking']), []);
+    assert.strictEqual(uniqueBy(null, 'name'), []);
+    assert.strictEqual(uniqueById(null), []);
+    assert.strictEqual(uniqueValues(null), []);
+    assert.strictEqual(findBy(null, 'name', 'jackson'), []);
+    assert.strictEqual(findById(null, 'jackson'), []);
+    assert.strictEqual(filterBy(null, 'breed', 'Chihuahua'), []);
   });
-  test('when array is undefined', function (assert) {
-    assert.strictEqual(mapBy(undefined, 'name'), undefined);
-    assert.strictEqual(sortBy(undefined, 'name'), undefined);
-    assert.strictEqual(sortBy(undefined, ['name', 'goodnessRanking']), undefined);
-    assert.strictEqual(uniqueBy(undefined, 'name'), undefined);
-    assert.strictEqual(uniqueById(undefined), undefined);
-    assert.strictEqual(uniqueValues(undefined), undefined);
-    assert.strictEqual(findBy(undefined, 'name', 'jasper'), undefined);
-    assert.strictEqual(findById(undefined, 'jasper'), undefined);
-    assert.strictEqual(filterBy(undefined, 'breed', 'Chihuahua'), undefined);
+  todo('when array is undefined', function (assert) {
+    assert.strictEqual(mapBy(undefined, 'name'), []);
+    assert.strictEqual(sortBy(undefined, 'name'), []);
+    assert.strictEqual(sortBy(undefined, ['name', 'goodnessRanking']), []);
+    assert.strictEqual(uniqueBy(undefined, 'name'), []);
+    assert.strictEqual(uniqueById(undefined), []);
+    assert.strictEqual(uniqueValues(undefined), []);
+    assert.strictEqual(findBy(undefined, 'name', 'jasper'), []);
+    assert.strictEqual(findById(undefined, 'jasper'), []);
+    assert.strictEqual(filterBy(undefined, 'breed', 'Chihuahua'), []);
   });
 
   test('mapBy', function (assert) {

--- a/tests/unit/utils/array-helpers-test.js
+++ b/tests/unit/utils/array-helpers-test.js
@@ -245,6 +245,14 @@ module('Unit | Utility | array-helpers', function () {
     assert.strictEqual(result[0].name, 'one');
     assert.deepEqual(result[1], null);
   });
+  test('uniqueBy with multiple null and undefined', function (assert) {
+    const arr = [{ id: 1, name: 'one' }, { id: 1, name: 'one' }, null, null, undefined, undefined];
+    const result = uniqueBy(arr, 'id');
+    assert.strictEqual(result.length, 3);
+    assert.strictEqual(result[0].name, 'one');
+    assert.deepEqual(result[1], null);
+    assert.deepEqual(result[2], undefined);
+  });
 
   test('uniqueById', function (assert) {
     const arr = [

--- a/tests/unit/utils/array-helpers-test.js
+++ b/tests/unit/utils/array-helpers-test.js
@@ -1,4 +1,6 @@
 import {
+  findBy,
+  findById,
   mapBy,
   sortByDate,
   sortByString,
@@ -26,6 +28,8 @@ module('Unit | Utility | array-helpers', function () {
     assert.false(uniqueBy(false, 'name'));
     assert.false(uniqueById(false));
     assert.false(uniqueValues(false));
+    assert.false(findBy(false, 'name', 'jayden'));
+    assert.false(findById(false, 'jayden'));
   });
   test('when array is null', function (assert) {
     assert.strictEqual(mapBy(null, 'name'), null);
@@ -35,6 +39,8 @@ module('Unit | Utility | array-helpers', function () {
     assert.strictEqual(uniqueBy(null, 'name'), null);
     assert.strictEqual(uniqueById(null), null);
     assert.strictEqual(uniqueValues(null), null);
+    assert.strictEqual(findBy(null, 'name', 'jackson'), null);
+    assert.strictEqual(findById(null, 'jackson'), null);
   });
   test('when array is undefined', function (assert) {
     assert.strictEqual(mapBy(undefined, 'name'), undefined);
@@ -44,6 +50,8 @@ module('Unit | Utility | array-helpers', function () {
     assert.strictEqual(uniqueBy(undefined, 'name'), undefined);
     assert.strictEqual(uniqueById(undefined), undefined);
     assert.strictEqual(uniqueValues(undefined), undefined);
+    assert.strictEqual(findBy(undefined, 'name', 'jasper'), undefined);
+    assert.strictEqual(findById(undefined, 'jasper'), undefined);
   });
 
   test('mapBy', function (assert) {
@@ -238,5 +246,58 @@ module('Unit | Utility | array-helpers', function () {
     assert.deepEqual(result[1], undefined);
     assert.deepEqual(result[2], null);
     assert.deepEqual(result[3], 'two');
+  });
+
+  test('findBy', function (assert) {
+    const result = findBy(getDogs(), 'goodnessRanking', 10);
+    assert.ok(result);
+    assert.strictEqual(result.name, 'jayden');
+  });
+  test('findBy when key does not exist', function (assert) {
+    const arr = [{ id: 1, name: 'one' }, {}, { id: 3, name: 'three' }];
+    const result = findBy(arr, 'id', 3);
+    assert.ok(result);
+    assert.strictEqual(result.name, 'three');
+  });
+  test('findBy when item is null', function (assert) {
+    const arr = [{ id: 1, name: 'one' }, null, { id: 3, name: 'three' }];
+    const result = findBy(arr, 'id', 3);
+    assert.ok(result);
+    assert.strictEqual(result.name, 'three');
+  });
+  test('findBy when item is undefined', function (assert) {
+    const arr = [{ id: 1, name: 'one' }, undefined, { id: 3, name: 'three' }];
+    const result = findBy(arr, 'id', 3);
+    assert.ok(result);
+    assert.strictEqual(result.name, 'three');
+  });
+
+  test('findById', function (assert) {
+    const arr = [
+      { id: 1, name: 'one' },
+      { id: 2, name: 'two' },
+      { id: 3, name: 'three' },
+    ];
+    const result = findById(arr, 2);
+    assert.ok(result);
+    assert.strictEqual(result.name, 'two');
+  });
+  test('findById when key does not exist', function (assert) {
+    const arr = [{ id: 1, name: 'one' }, {}, { id: 3, name: 'three' }];
+    const result = findById(arr, 3);
+    assert.ok(result);
+    assert.strictEqual(result.name, 'three');
+  });
+  test('findById when item is null', function (assert) {
+    const arr = [{ id: 1, name: 'one' }, null, { id: 3, name: 'three' }];
+    const result = findById(arr, 3);
+    assert.ok(result);
+    assert.strictEqual(result.name, 'three');
+  });
+  test('findById when item is undefined', function (assert) {
+    const arr = [{ id: 1, name: 'one' }, undefined, { id: 3, name: 'three' }];
+    const result = findById(arr, 3);
+    assert.ok(result);
+    assert.strictEqual(result.name, 'three');
   });
 });

--- a/tests/unit/utils/array-helpers-test.js
+++ b/tests/unit/utils/array-helpers-test.js
@@ -1,6 +1,7 @@
 import {
   findBy,
   findById,
+  filterBy,
   mapBy,
   sortByDate,
   sortByString,
@@ -13,9 +14,27 @@ import { module, test } from 'qunit';
 
 function getDogs() {
   return [
-    { name: 'jayden', dob: new Date(2017, 11, 11), goodnessRanking: 10 },
-    { name: 'jasper', dob: new Date(2005, 11, 11), goodnessRanking: 4 },
-    { name: 'jackson', dob: new Date(2010, 11, 11), goodnessRanking: 15 },
+    {
+      name: 'jayden',
+      dob: new Date(2017, 11, 11),
+      goodnessRanking: 10,
+      breed: 'Chihuahua',
+      barksForNoReason: false,
+    },
+    {
+      name: 'jasper',
+      dob: new Date(2005, 11, 11),
+      goodnessRanking: 4,
+      breed: 'Terrier',
+      barksForNoReason: true,
+    },
+    {
+      name: 'jackson',
+      dob: new Date(2010, 11, 11),
+      goodnessRanking: 15,
+      breed: 'Chihuahua',
+      barksForNoReason: false,
+    },
   ];
 }
 
@@ -30,6 +49,7 @@ module('Unit | Utility | array-helpers', function () {
     assert.false(uniqueValues(false));
     assert.false(findBy(false, 'name', 'jayden'));
     assert.false(findById(false, 'jayden'));
+    assert.false(filterBy(false, 'breed', 'Chihuahua'));
   });
   test('when array is null', function (assert) {
     assert.strictEqual(mapBy(null, 'name'), null);
@@ -41,6 +61,7 @@ module('Unit | Utility | array-helpers', function () {
     assert.strictEqual(uniqueValues(null), null);
     assert.strictEqual(findBy(null, 'name', 'jackson'), null);
     assert.strictEqual(findById(null, 'jackson'), null);
+    assert.strictEqual(filterBy(null, 'breed', 'Chihuahua'), null);
   });
   test('when array is undefined', function (assert) {
     assert.strictEqual(mapBy(undefined, 'name'), undefined);
@@ -52,6 +73,7 @@ module('Unit | Utility | array-helpers', function () {
     assert.strictEqual(uniqueValues(undefined), undefined);
     assert.strictEqual(findBy(undefined, 'name', 'jasper'), undefined);
     assert.strictEqual(findById(undefined, 'jasper'), undefined);
+    assert.strictEqual(filterBy(undefined, 'breed', 'Chihuahua'), undefined);
   });
 
   test('mapBy', function (assert) {
@@ -299,5 +321,63 @@ module('Unit | Utility | array-helpers', function () {
     const result = findById(arr, 3);
     assert.ok(result);
     assert.strictEqual(result.name, 'three');
+  });
+
+  test('filterBy', function (assert) {
+    const result = filterBy(getDogs(), 'breed', 'Terrier');
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0].name, 'jasper');
+    const result2 = filterBy(getDogs(), 'breed', 'Chihuahua');
+    assert.strictEqual(result2.length, 2);
+    assert.strictEqual(result2[0].name, 'jayden');
+    assert.strictEqual(result2[1].name, 'jackson');
+  });
+  test('filterBy when key does not exist', function (assert) {
+    const arr = getDogs();
+    delete arr[2].breed;
+    const result = filterBy(arr, 'breed', 'Chihuahua');
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0].name, 'jayden');
+  });
+  test('filterBy when item is null', function (assert) {
+    const arr = getDogs();
+    arr[2] = null;
+    const result = filterBy(arr, 'breed', 'Chihuahua');
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0].name, 'jayden');
+  });
+  test('filterBy when item is undefined', function (assert) {
+    const arr = getDogs();
+    arr[2] = undefined;
+    const result = filterBy(arr, 'breed', 'Chihuahua');
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0].name, 'jayden');
+  });
+
+  test('filterBy bool', function (assert) {
+    const result = filterBy(getDogs(), 'barksForNoReason');
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0].name, 'jasper');
+  });
+  test('filterBy bool when key does not exist', function (assert) {
+    const arr = getDogs();
+    delete arr[2].barksForNoReason;
+    const result = filterBy(arr, 'barksForNoReason');
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0].name, 'jasper');
+  });
+  test('filterBy bool when item is null', function (assert) {
+    const arr = getDogs();
+    arr[2] = null;
+    const result = filterBy(arr, 'barksForNoReason');
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0].name, 'jasper');
+  });
+  test('filterBy bool when item is undefined', function (assert) {
+    const arr = getDogs();
+    arr[2] = undefined;
+    const result = filterBy(arr, 'barksForNoReason');
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0].name, 'jasper');
   });
 });


### PR DESCRIPTION
Ember data has deprecated and ember will soon deprecate extensions to the Array prototype. By adding the `ember-disable-prototype-extensions` package we can ensure that these extensions are not used anywhere in our code and I've gone through and replaced every usage.

For convenience I added an array helpers utility set of functions that does some of the things we used to get from ember, in other cases a better alternative exists already in JS.