### PR TITLE
Expand dashboard waag and materials to fill space

### DIFF
--- a/app/styles/ilios-common/components/dashboard/materials.scss
+++ b/app/styles/ilios-common/components/dashboard/materials.scss
@@ -7,8 +7,6 @@
     text-align: center;
   }
   .dashboard-materials-content {
-    max-height: 40em;
-    overflow-y: scroll;
     padding: .5rem;
 
     .header {

--- a/app/styles/ilios-common/components/dashboard/week.scss
+++ b/app/styles/ilios-common/components/dashboard/week.scss
@@ -2,8 +2,6 @@
   @include dashboard-component;
 
   .dashboard-week-content {
-    max-height: 40em;
-    overflow-y: scroll;
     padding: 0 1em 1em;
 
     .weeklylink {


### PR DESCRIPTION
Now that we've dropped the reports and courses blocks from the dashboard we should use the entire space.