### PR TITLE
fixes regression in sorting of offerings in list.

### DIFF
--- a/addon/utils/offering-date-block.js
+++ b/addon/utils/offering-date-block.js
@@ -57,7 +57,7 @@ const OfferingDateBlock = OfferingBlock.extend({
 const OfferingTimeBlock = OfferingBlock.extend({
   init() {
     this._super(...arguments);
-    this.set('sortOfferingsBy', ['learnerGroups[0].title']);
+    this.set('sortOfferingsBy', ['learnerGroups.firstObject.title']);
   },
   timeKey: null,
   isMultiDay: computed('startDate', 'endDate', function () {


### PR DESCRIPTION
the first element of an EmberData collection cannot be accessed via array index, b/c it's not an array (yet).
reverting the change introduced in b7b791.

fixes https://github.com/ilios/ilios/issues/4437