### PR TITLE
Stop Testing Before Releasing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,18 +5,6 @@ on:
     types: [published]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: 14
-    - name: install dependencies
-      run: npm ci --ignore-scripts
-    - name: test
-      run: npm run test:ember
-
   publish-npm:
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
All of our commits get tested as they get merged having this extra step was a nice bit of additional checking, but it's slowing down releases and if we have a flaky test it is a real problem. So, I'm switching off test tests, we'll only worry about deploying.