### PR TITLE
Use our internationalization library to format dates

### DIFF
--- a/addon/components/date-picker.js
+++ b/addon/components/date-picker.js
@@ -5,6 +5,7 @@ import { tracked } from '@glimmer/tracking';
 import flatpickr from 'flatpickr';
 import { later } from '@ember/runloop';
 import { isTesting } from '@embroider/macros';
+import { next } from '@ember/runloop';
 
 export default class DatePickerComponent extends Component {
   @service intl;
@@ -40,7 +41,7 @@ export default class DatePickerComponent extends Component {
       locale,
       defaultDate: this.args.value,
       formatDate: (dateObj) => this.intl.formatDate(dateObj),
-      onChange: (selectedDates) => this.args.onChange(selectedDates[0]),
+      onChange: (selectedDates) => this.onChange(selectedDates[0]),
       onOpen: () => {
         later(() => {
           this.isOpen = true;
@@ -60,5 +61,10 @@ export default class DatePickerComponent extends Component {
     if (this._flatPickerInstance) {
       this._flatPickerInstance.destroy();
     }
+  }
+
+  async onChange(date) {
+    await this.args.onChange(date);
+    await next(() => {});
   }
 }

--- a/tests/acceptance/course/learningmaterials-test.js
+++ b/tests/acceptance/course/learningmaterials-test.js
@@ -631,7 +631,7 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
       await page.details.learningMaterials.manager.save();
       assert.ok(page.details.learningMaterials.current[0].isTimedRelease);
       await page.details.learningMaterials.current[0].details();
-      const formattedNewDate = newDate.toJSDate().toLocaleString('en-us', {
+      const formattedNewDate = this.intl.formatDate(newDate.toJSDate(), {
         month: 'numeric',
         day: 'numeric',
         year: 'numeric',
@@ -673,14 +673,14 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
       await page.details.learningMaterials.manager.save();
       assert.ok(page.details.learningMaterials.current[0].isTimedRelease);
       await page.details.learningMaterials.current[0].details();
-      const formattedStartDate = newStartDate.toJSDate().toLocaleString('en', {
+      const formattedStartDate = this.intl.formatDate(newStartDate.toJSDate(), {
         month: 'numeric',
         day: 'numeric',
         year: 'numeric',
         hour: 'numeric',
         minute: 'numeric',
       });
-      const formattedEndDate = newEndDate.toJSDate().toLocaleString('en', {
+      const formattedEndDate = this.intl.formatDate(newEndDate.toJSDate(), {
         month: 'numeric',
         day: 'numeric',
         year: 'numeric',
@@ -708,7 +708,7 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
       await page.details.learningMaterials.manager.save();
       assert.ok(page.details.learningMaterials.current[0].isTimedRelease);
       await page.details.learningMaterials.current[0].details();
-      const formattedNewDate = newDate.toJSDate().toLocaleString('en-us', {
+      const formattedNewDate = this.intl.formatDate(newDate.toJSDate(), {
         month: 'numeric',
         day: 'numeric',
         year: 'numeric',
@@ -744,7 +744,7 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
       await page.details.learningMaterials.manager.save();
 
       assert.ok(page.details.learningMaterials.manager.hasEndDateValidationError);
-      const formattedDate = newDate.toJSDate().toLocaleString('en-us', {
+      const formattedDate = this.intl.formatDate(newDate.toJSDate(), {
         month: 'numeric',
         day: 'numeric',
         year: 'numeric',

--- a/tests/acceptance/course/session/learningmaterials-test.js
+++ b/tests/acceptance/course/session/learningmaterials-test.js
@@ -632,7 +632,7 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
       await page.details.learningMaterials.manager.save();
       assert.ok(page.details.learningMaterials.current[0].isTimedRelease);
       await page.details.learningMaterials.current[0].details();
-      const formattedNewDate = newDate.toJSDate().toLocaleString('en-us', {
+      const formattedNewDate = this.intl.formatDate(newDate.toJSDate(), {
         month: 'numeric',
         day: 'numeric',
         year: 'numeric',
@@ -674,14 +674,14 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
       await page.details.learningMaterials.manager.save();
       assert.ok(page.details.learningMaterials.current[0].isTimedRelease);
       await page.details.learningMaterials.current[0].details();
-      const formattedStartDate = newStartDate.toJSDate().toLocaleString('en', {
+      const formattedStartDate = this.intl.formatDate(newStartDate.toJSDate(), {
         month: 'numeric',
         day: 'numeric',
         year: 'numeric',
         hour: 'numeric',
         minute: 'numeric',
       });
-      const formattedEndDate = newEndDate.toJSDate().toLocaleString('en', {
+      const formattedEndDate = this.intl.formatDate(newEndDate.toJSDate(), {
         month: 'numeric',
         day: 'numeric',
         year: 'numeric',
@@ -709,7 +709,7 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
       await page.details.learningMaterials.manager.save();
       assert.ok(page.details.learningMaterials.current[0].isTimedRelease);
       await page.details.learningMaterials.current[0].details();
-      const formattedNewDate = newDate.toJSDate().toLocaleString('en-us', {
+      const formattedNewDate = this.intl.formatDate(newDate.toJSDate(), {
         month: 'numeric',
         day: 'numeric',
         year: 'numeric',
@@ -745,7 +745,7 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
       await page.details.learningMaterials.manager.save();
 
       assert.ok(page.details.learningMaterials.manager.hasEndDateValidationError);
-      const formattedDate = newDate.toJSDate().toLocaleString('en-us', {
+      const formattedDate = this.intl.formatDate(newDate.toJSDate(), {
         month: 'numeric',
         day: 'numeric',
         year: 'numeric',

--- a/tests/acceptance/course/sessionlist-test.js
+++ b/tests/acceptance/course/sessionlist-test.js
@@ -85,7 +85,7 @@ module('Acceptance | Course - Session List', function (hooks) {
     assert.strictEqual(sessions[0].termCount, '0');
     assert.strictEqual(
       sessions[0].firstOffering,
-      today.toJSDate().toLocaleString('en', {
+      this.intl.formatDate(today.toJSDate(), {
         month: 'numeric',
         day: 'numeric',
         year: 'numeric',
@@ -330,7 +330,7 @@ module('Acceptance | Course - Session List', function (hooks) {
     assert.strictEqual(sessions.length, 4);
     assert.strictEqual(
       sessions[0].firstOffering,
-      today.toJSDate().toLocaleString('en', {
+      this.intl.formatDate(today.toJSDate(), {
         month: 'numeric',
         day: 'numeric',
         year: 'numeric',
@@ -350,7 +350,7 @@ module('Acceptance | Course - Session List', function (hooks) {
 
     assert.strictEqual(
       sessions[0].firstOffering,
-      newDate.toJSDate().toLocaleString('en', {
+      this.intl.formatDate(newDate.toJSDate(), {
         month: 'numeric',
         day: 'numeric',
         year: 'numeric',
@@ -411,7 +411,7 @@ module('Acceptance | Course - Session List', function (hooks) {
     assert.strictEqual(sessions.length, 4);
     assert.strictEqual(
       sessions[0].firstOffering,
-      today.toJSDate().toLocaleString('en', {
+      this.intl.formatDate(today.toJSDate(), {
         month: 'numeric',
         day: 'numeric',
         year: 'numeric',


### PR DESCRIPTION
This helps with cross browser support for these tests.