### PR TITLE
Increase timeout for floating tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
   floating:
     name: "Floating Dependencies"
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
These are taking a very long time to run, not sure why but we can kick up the timeout so they're allowed to finish.