### PR TITLE
Fix token refresh and expiration

### DIFF
--- a/addon/authenticators/ilios-jwt.js
+++ b/addon/authenticators/ilios-jwt.js
@@ -21,7 +21,13 @@ export default class IliosJWT extends JwtTokenAuthenticator {
       const tokenData = this.getTokenData(token);
       const expiresAt = get(tokenData, this.tokenExpireName);
 
-      this.scheduleAccessTokenRefresh(expiresAt, token);
+      if (this.refreshAccessTokens) {
+        this.scheduleAccessTokenRefresh(expiresAt, token);
+      }
+
+      if (this.tokenExpirationInvalidateSession) {
+        this.scheduleAccessTokenExpiration(expiresAt);
+      }
 
       const response = {};
       response[this.tokenPropertyName] = token;


### PR DESCRIPTION
Couple of issues fixed here, first we weren't respecting our own configuration, second we weren't scheduling token expiration. Both of these were causing repeated error messages when someone attempted to do some work with an expired token which shows up as authentication errors in our logs.