### PR TITLE
Improve Login Experience

### DIFF
--- a/tests/dummy/app/controllers/login.js
+++ b/tests/dummy/app/controllers/login.js
@@ -21,9 +21,10 @@ export default class LoginController extends Controller {
         },
       });
       if (response.ok) {
-        const obj = await response.json();
         const authenticator = 'authenticator:ilios-jwt';
-        this.session.authenticate(authenticator, { jwt: obj.jwt });
+        this.session.authenticate(authenticator, { jwt: this.jwt });
+      } else {
+        this.error = await response.text();
       }
     }
   });

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -19,12 +19,9 @@ module.exports = function (environment) {
     },
     'ember-simple-auth-token': {
       serverTokenEndpoint: '/auth/login',
-      serverTokenRefreshEndpoint: '/auth/token',
       tokenPropertyName: 'jwt',
-      refreshTokenPropertyName: 'jwt',
-      authorizationHeaderName: 'X-JWT-Authorization',
+      refreshAccessTokens: false,
       authorizationPrefix: 'Token ',
-      refreshLeeway: 300,
     },
     serverVariables: {
       tagPrefix: 'iliosconfig',


### PR DESCRIPTION
I've aligned our configuration with the frontend to remove token refresh and updated the login itself to use the token we pass and not a refreshed version. We still attempt to use the token to get a new token to ensure the passed token is valid and when there are errors in that process they will now display correctly.