### PR TITLE
fixes save-and-close objective sort manager bug.

### DIFF
--- a/addon/components/course/objective-list.hbs
+++ b/addon/components/course/objective-list.hbs
@@ -4,7 +4,7 @@
   {{did-insert (perform this.load)}}
   {{did-update (perform this.load) @course}}
 >
-  {{#if (and (is-array this.courseObjectives) this.isSorting)}}
+  {{#if this.isSorting}}
     <ObjectiveSortManager
       @subject={{@course}}
       @close={{set this.isSorting false}}

--- a/addon/components/session/objective-list.hbs
+++ b/addon/components/session/objective-list.hbs
@@ -2,7 +2,7 @@
   class="session-objective-list"
   data-test-session-objective-list
 >
-  {{#if (and (is-array this.sessionObjectives) this.isSorting)}}
+  {{#if this.isSorting}}
     <ObjectiveSortManager
       @subject={{@session}}
       @close={{set this.isSorting false}}


### PR DESCRIPTION
removing the array check from the conditional and just checking is-sorting state fixes the issue of the order manager component not closing after saving.

refs https://github.com/ilios/ilios/issues/4502