### PR TITLE
Bump API to v3.8

### DIFF
--- a/config/api-version.js
+++ b/config/api-version.js
@@ -1,3 +1,3 @@
 /* eslint-env node */
 
-module.exports = 'v3.7';
+module.exports = 'v3.8';


### PR DESCRIPTION
No changes are required in common, this version bump is for GraphQL reporting in the frontend.