### PR TITLE
breadcrumb style improvements

### DIFF
--- a/app/styles/ilios-common/components/breadcrumbs.scss
+++ b/app/styles/ilios-common/components/breadcrumbs.scss
@@ -7,7 +7,7 @@
   $breadcrumb-arrow-color: $breadcrumb-border-color;
   $breadcrumb-background: $slightWhite;
   $breadcrumb-color: $tealBlue;
-  $breadcrumb-color-hover: $orange;
+  $breadcrumb-link-color-hover: $orange;
   $breadcrumb-color-active: $breadcrumb-color;
 
   display: inline-block;
@@ -17,7 +17,7 @@
   a {
     &:focus,
     &:hover {
-      color: $breadcrumb-color-hover;
+      color: $breadcrumb-link-color-hover;
     }
   }
 

--- a/app/styles/ilios-common/components/breadcrumbs.scss
+++ b/app/styles/ilios-common/components/breadcrumbs.scss
@@ -6,7 +6,6 @@
   $breadcrumb-height: 2rem;
   $breadcrumb-arrow-color: $breadcrumb-border-color;
   $breadcrumb-background: $slightWhite;
-  $breadcrumb-inactive-hover-color: $breadcrumb-background;
   $breadcrumb-color: $tealBlue;
   $breadcrumb-color-hover: $orange;
   $breadcrumb-color-active: $breadcrumb-color;
@@ -40,7 +39,6 @@
 
     &:focus,
     &:hover {
-      background-color: $breadcrumb-inactive-hover-color;
       color: $breadcrumb-color-hover;
     }
 

--- a/app/styles/ilios-common/components/breadcrumbs.scss
+++ b/app/styles/ilios-common/components/breadcrumbs.scss
@@ -8,7 +8,6 @@
   $breadcrumb-background: $slightWhite;
   $breadcrumb-color: $tealBlue;
   $breadcrumb-link-color-hover: $orange;
-  $breadcrumb-color-active: $breadcrumb-color;
 
   display: inline-block;
   margin: .8rem;
@@ -72,10 +71,8 @@
 
     &:last-child,
     &:last-child:hover {
-      background-color: $breadcrumb-background;
       border-bottom-right-radius: 3px;
       border-top-right-radius: 3px;
-      color: $breadcrumb-color-active;
       cursor: default;
       padding-right: math.div($breadcrumb-height, 2);
     }

--- a/app/styles/ilios-common/components/breadcrumbs.scss
+++ b/app/styles/ilios-common/components/breadcrumbs.scss
@@ -14,6 +14,13 @@
   margin: .8rem;
   text-align: left;
 
+  a {
+    &:focus,
+    &:hover {
+      color: $breadcrumb-color-hover;
+    }
+  }
+
   /* stylelint-disable property-disallowed-list */
   span {
     background-color: $breadcrumb-background;
@@ -35,11 +42,6 @@
       border-left: $breadcrumb-border;
       border-top-left-radius: 3px;
       padding-left: math.div($breadcrumb-height, 2);
-    }
-
-    &:focus,
-    &:hover {
-      color: $breadcrumb-color-hover;
     }
 
     &::after,


### PR DESCRIPTION
the breadcrumb styles were initially defined under the assumption that every crumb contains a clickable link, except for the last element.
that turns out to be too narrow in scope - we need the ability to have non-clickable/non-linked crumbs at arbitrary points in the hierarchy, and _don't_ want them to styled as something actionable (e.g. on  hover). 

the changes proposed here re-apply some of the these hover/focus styles onto anchor tags and remove them from their container elements. 
the rest is cleanup.

for visual regression review, i recommend having a look at course visualizations.