### PR TITLE
resets filters to "Course/Session Type" when filters are hidden.

### DIFF
--- a/addon/controllers/dashboard/calendar.js
+++ b/addon/controllers/dashboard/calendar.js
@@ -82,7 +82,7 @@ export default class DashboardCalendarController extends Controller {
     if (this.showFilters) {
       this.showFilters = false;
       this.academicYear = null;
-      this.courseFilters = null;
+      this.courseFilters = true;
     } else {
       this.showFilters = true;
     }


### PR DESCRIPTION
fixes https://github.com/ilios/ilios/issues/4654