### PR TITLE
adds option for showing an edit-icon edit-in-place component

### DIFF
--- a/addon/components/editable-field.hbs
+++ b/addon/components/editable-field.hbs
@@ -30,6 +30,13 @@
                 {{on "click" (fn this.setIsEditing true)}}
               >
                 {{displayText}}
+                {{#if @showIcon}}
+                  <FaIcon
+                    data-test-edit-icon
+                    @icon="pen-to-square"
+                    class="enabled"
+                  />
+                {{/if}}
               </button>
               {{#if isTruncated}}
                 <FaIcon @icon="ellipsis" @transform="down-6" />

--- a/addon/components/editable-field.hbs
+++ b/addon/components/editable-field.hbs
@@ -22,15 +22,15 @@
               @onEdit={{fn this.setIsEditing true}}
               as |displayText expand collapse isTruncated expanded|
             >
-              <span
-                class="clickable editable"
+              <button
+                class="link-button editable"
                 aria-label={{t "general.edit"}}
                 data-test-edit
-                role="button"
+                type="button"
                 {{on "click" (fn this.setIsEditing true)}}
               >
                 {{displayText}}
-              </span>
+              </button>
               {{#if isTruncated}}
                 <FaIcon @icon="ellipsis" @transform="down-6" />
                 <button
@@ -60,15 +60,15 @@
             </TruncateText>
           {{/if}}
         {{else}}
-          <span
-            class="clickable editable"
+          <button
+            class="link-button editable"
             aria-label={{t "general.edit"}}
             data-test-edit
-            role="button"
+            type="button"
             {{on "click" (fn this.setIsEditing true)}}
           >
             {{@clickPrompt}}
-          </span>
+          </button>
         {{/if}}
       </span>
     {{else}}

--- a/tests/integration/components/editable-field-test.js
+++ b/tests/integration/components/editable-field-test.js
@@ -11,8 +11,15 @@ module('Integration | Component | editable field', function (hooks) {
   test('it renders value', async function (assert) {
     await render(hbs`<EditableField @value="woot!" />
 `);
-
     assert.dom(this.element).hasText('woot!');
+    assert.dom('[data-test-edit-icon]', this.element).isNotVisible();
+  });
+
+  test('edit icon is present', async function (assert) {
+    await render(hbs`<EditableField @value="woot!" @showIcon={{true}} />
+`);
+    assert.dom(this.element).hasText('woot!');
+    assert.dom('[data-test-edit-icon]', this.element).isVisible();
   });
 
   test('it renders clickPrompt', async function (assert) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1410427/219509485-49830288-f49d-4e7a-abce-b572cbbc58ba.png)

we'll need this in at least one place (namely, the subject report header) to visually indicate edit-in-place fields better - to set them apart from "regular" links.

the span to button conversion is unrelated to this (aka "while i was in there").