### PR TITLE
Replace access to string with toString in tests

### DIFF
--- a/tests/unit/models/session-type-test.js
+++ b/tests/unit/models/session-type-test.js
@@ -18,7 +18,7 @@ module('Unit | Model | SessionType', function (hooks) {
     const model = this.store.createRecord('session-type');
     assert.strictEqual(model.safeCalendarColor, '');
     model.set('calendarColor', '#ffffff');
-    assert.strictEqual(model.safeCalendarColor.string, '#ffffff');
+    assert.strictEqual(model.safeCalendarColor.toString(), '#ffffff');
   });
 
   test('sessionCount', async function (assert) {

--- a/tests/unit/utils/calendar-event-tooltip-test.js
+++ b/tests/unit/utils/calendar-event-tooltip-test.js
@@ -22,7 +22,7 @@ module('Unit | Utility | calendar-event-tooltip', function (hooks) {
       this.intl,
       'hh'
     );
-    assert.strictEqual(result.string, 'TBD<br />08 - 08<br />test');
+    assert.strictEqual(result.toString(), 'TBD<br />08 - 08<br />test');
   });
   test('offering-based event', function (assert) {
     const today = DateTime.fromObject({ hour: 8 });
@@ -42,7 +42,7 @@ module('Unit | Utility | calendar-event-tooltip', function (hooks) {
       'hh'
     );
     assert.strictEqual(
-      result.string,
+      result.toString(),
       'room 101<br />08 - 08<br />test<br /> Taught By Larry, Curly et al.<br />Course: Intro 101<br />Session Type: lecture'
     );
   });
@@ -65,7 +65,7 @@ module('Unit | Utility | calendar-event-tooltip', function (hooks) {
       'hh'
     );
     assert.strictEqual(
-      result.string,
+      result.toString(),
       'room 101<br />ILM - Due By 08<br />test<br /> Taught By Larry, Curly et al.<br />Course: Intro 101<br />Session Type: lecture'
     );
   });


### PR DESCRIPTION
These are the results of htmlSafe(ing) a string and the API for accessing the string itself has changed in the latest versions of ember.