### PR TITLE
Mark modifiers as non eager for v4

### DIFF
--- a/addon/modifiers/autofocus.js
+++ b/addon/modifiers/autofocus.js
@@ -1,3 +1,3 @@
 import { modifier } from 'ember-modifier';
 
-export default modifier((element) => element.focus());
+export default modifier((element) => element.focus(), { eager: false });

--- a/addon/modifiers/mouse-hover-toggle.js
+++ b/addon/modifiers/mouse-hover-toggle.js
@@ -1,13 +1,16 @@
 import { modifier } from 'ember-modifier';
 
-export default modifier(function mouseHoverToggle(element, [setter]) {
-  const handleMouseOver = () => setter(true);
-  const handleMouseOut = () => setter(false);
-  element.addEventListener('mouseover', handleMouseOver);
-  element.addEventListener('mouseout', handleMouseOut);
+export default modifier(
+  function mouseHoverToggle(element, [setter]) {
+    const handleMouseOver = () => setter(true);
+    const handleMouseOut = () => setter(false);
+    element.addEventListener('mouseover', handleMouseOver);
+    element.addEventListener('mouseout', handleMouseOut);
 
-  return () => {
-    element.removeEventListener('mouseover', handleMouseOver);
-    element.removeEventListener('mouseout', handleMouseOut);
-  };
-});
+    return () => {
+      element.removeEventListener('mouseover', handleMouseOver);
+      element.removeEventListener('mouseout', handleMouseOut);
+    };
+  },
+  { eager: false }
+);

--- a/addon/modifiers/scroll-into-view.js
+++ b/addon/modifiers/scroll-into-view.js
@@ -1,10 +1,13 @@
 import { modifier } from 'ember-modifier';
 import { next } from '@ember/runloop';
 
-export default modifier(function scrollIntoView(element, [block = 'start']) {
-  next(() => {
-    if (element) {
-      element.scrollIntoView({ block });
-    }
-  });
-});
+export default modifier(
+  function scrollIntoView(element, [block = 'start']) {
+    next(() => {
+      if (element) {
+        element.scrollIntoView({ block });
+      }
+    });
+  },
+  { eager: false }
+);

--- a/tests/dummy/config/deprecation-workflow.js
+++ b/tests/dummy/config/deprecation-workflow.js
@@ -9,7 +9,6 @@ window.deprecationWorkflow.config = {
     { handler: 'silence', matchId: 'common.competency-is-not-domain' },
     { handler: 'silence', matchId: 'common.school-cohorts' },
     { handler: 'silence', matchId: 'common.curriculum-inventory-report-is-finalized' },
-    { handler: 'silence', matchId: 'ember-modifier.function-based-options' },
     { handler: 'silence', matchId: 'ember-data:deprecate-promise-proxies' }, //https://github.com/emberjs/data/issues/7997
     { handler: 'silence', matchId: 'ember-data:deprecate-non-strict-relationships' },
     { handler: 'silence', matchId: 'ember-data:deprecate-early-static' },


### PR DESCRIPTION
Ember Modifiers v4 has changed the way arguments are evaluated in a modifier, for us this doesn't have much effect because we were consuming all the arguments passed to the modifier anyway.