### PR TITLE
Left Align Link Buttons

### DIFF
--- a/app/styles/ilios-common/components/detail-learningmaterials.scss
+++ b/app/styles/ilios-common/components/detail-learningmaterials.scss
@@ -101,7 +101,6 @@
       }
       .lm-title {
         @include m.ilios-link-button;
-        text-align: left;
       }
     }
 

--- a/app/styles/ilios-common/components/monthly-calendar.scss
+++ b/app/styles/ilios-common/components/monthly-calendar.scss
@@ -63,7 +63,6 @@
         button {
           @include m.ilios-link-button;
           width: 100%;
-          text-align: left;
         }
       }
 

--- a/app/styles/ilios-common/components/offering-manager.scss
+++ b/app/styles/ilios-common/components/offering-manager.scss
@@ -18,13 +18,6 @@
     display: flex;
     flex-direction: column;
     overflow-wrap: anywhere;
-    .copy-btn {
-      @include m.ilios-link-button;
-
-      &.copying {
-        color: c.$fernGreen;
-      }
-    }
   }
 
   .offering-manager-instructors {

--- a/app/styles/ilios-common/components/weekly-calendar.scss
+++ b/app/styles/ilios-common/components/weekly-calendar.scss
@@ -135,6 +135,7 @@
         @include m.ilios-link-button;
         display: flex;
         flex-direction: column;
+        text-align: center;
       }
     }
   }

--- a/app/styles/ilios-common/mixins/ilios-button.scss
+++ b/app/styles/ilios-common/mixins/ilios-button.scss
@@ -38,4 +38,5 @@
 @mixin ilios-link-button () {
   @include ilios-button-reset;
   color: c.$blueMunsell;
+  text-align: left;
 }

--- a/app/styles/ilios-common/mixins/objectives.scss
+++ b/app/styles/ilios-common/mixins/objectives.scss
@@ -176,10 +176,6 @@
     }
   }
 
-  .link-button {
-    text-align: left;
-  }
-
   .bigadd {
     background-color: c.$fernGreen;
     color: c.$white;


### PR DESCRIPTION
Just like links, link-buttons should default to a left alignment. I removed any duplicate left-align styles and added center alignment where it seemed warranted. I also removed a double style assignment for the copy button on offering url.