### PR TITLE
Be Explicit About Days With No Events

### DIFF
--- a/addon-test-support/ilios-common/page-objects/components/daily-calendar.js
+++ b/addon-test-support/ilios-common/page-objects/components/daily-calendar.js
@@ -1,4 +1,4 @@
-import { create, collection, text } from 'ember-cli-page-object';
+import { create, collection, text, isPresent } from 'ember-cli-page-object';
 
 const definition = {
   scope: '[data-test-daily-calendar]',
@@ -7,6 +7,7 @@ const definition = {
   events: collection('[data-test-daily-calendar-event]', {
     name: text('[data-test-name]'),
   }),
+  hasNoEvents: isPresent('[data-test-no-events]'),
 };
 
 export default definition;

--- a/addon-test-support/ilios-common/page-objects/components/monthly-calendar.js
+++ b/addon-test-support/ilios-common/page-objects/components/monthly-calendar.js
@@ -19,6 +19,7 @@ const definition = {
     events: collection('[data-test-ilios-calendar-event]'),
     hasShowMore: isPresent('[data-test-show-more-button]'),
     showMore: clickable('[data-test-show-more-button]'),
+    hasNoEvents: isPresent('[data-test-no-events]'),
   }),
   events: collection('[data-test-ilios-calendar-event-month]'),
 };

--- a/addon-test-support/ilios-common/page-objects/components/weekly-calendar.js
+++ b/addon-test-support/ilios-common/page-objects/components/weekly-calendar.js
@@ -1,4 +1,4 @@
-import { clickable, create, collection, hasClass, text } from 'ember-cli-page-object';
+import { clickable, create, collection, hasClass, text, isPresent } from 'ember-cli-page-object';
 
 const definition = {
   scope: '[data-test-weekly-calendar]',
@@ -23,6 +23,11 @@ const definition = {
     isFifthDayOfWeek: hasClass('day-5'),
     isSixthDayOfWeek: hasClass('day-6'),
     isSeventhDayOfWeek: hasClass('day-7'),
+    hasNoEvents: isPresent('[data-test-no-events]'),
+  }),
+  days: collection('[data-test-events-day]', {
+    events: collection('[data-test-weekly-calendar-event]'),
+    hasNoEvents: isPresent('[data-test-no-events]'),
   }),
 };
 

--- a/addon/components/daily-calendar.hbs
+++ b/addon/components/daily-calendar.hbs
@@ -30,6 +30,8 @@
           @allDayEvents={{this.sortedEvents}}
           @selectEvent={{fn @selectEvent event}}
         />
+      {{else}}
+        <span class="no-events" data-test-no-events>{{t "general.noEvents"}}</span>
       {{/each}}
     </div>
     {{#each this.hours as |hour|}}

--- a/addon/components/monthly-calendar.hbs
+++ b/addon/components/monthly-calendar.hbs
@@ -27,6 +27,8 @@
               @selectEvent={{fn @selectEvent event}}
             />
           {{/if}}
+        {{else}}
+          <span class="no-events" data-test-no-events>{{t "general.noEvents"}}</span>
         {{/each}}
         {{#if (gt day.events.length 2)}}
           <button

--- a/addon/components/weekly-calendar.hbs
+++ b/addon/components/weekly-calendar.hbs
@@ -26,7 +26,7 @@
       {{/each}}
     </div>
     {{#each this.days as |day|}}
-      <div class="events day-{{day.dayOfWeek}}">
+      <div class="events day-{{day.dayOfWeek}}" data-test-events-day>
         <h3 class="day-name" data-test-day-name>
           <button
             type="button"
@@ -42,6 +42,8 @@
             @allDayEvents={{day.events}}
             @selectEvent={{fn this.selectEvent event}}
           />
+        {{else}}
+          <span class="no-events" data-test-no-events>{{t "general.noEvents"}}</span>
         {{/each}}
       </div>
     {{/each}}

--- a/app/styles/ilios-common/components/daily-calendar.scss
+++ b/app/styles/ilios-common/components/daily-calendar.scss
@@ -67,6 +67,10 @@
           grid-column: ($day + 1);
         }
       }
+
+      .no-events {
+        @include m.visually-hidden();
+      }
     }
 
     .hour,

--- a/app/styles/ilios-common/components/monthly-calendar.scss
+++ b/app/styles/ilios-common/components/monthly-calendar.scss
@@ -56,6 +56,10 @@
         }
       }
 
+      .no-events {
+        @include m.visually-hidden();
+      }
+
       .day-number {
         margin: 0 0 .25rem 0;
         padding: 0;

--- a/app/styles/ilios-common/components/weekly-calendar.scss
+++ b/app/styles/ilios-common/components/weekly-calendar.scss
@@ -71,6 +71,10 @@
           grid-column: ($day + 1);
         }
       }
+
+      .no-events {
+        @include m.visually-hidden();
+      }
     }
 
     .hour,

--- a/tests/integration/components/daily-calendar-test.js
+++ b/tests/integration/components/daily-calendar-test.js
@@ -46,6 +46,7 @@ module('Integration | Component | daily-calendar', function (hooks) {
 
     assert.strictEqual(component.longDayOfWeek, 'Wednesday, January 9, 2019');
     assert.strictEqual(component.shortDayOfWeek, '1/9/2019');
+    assert.ok(component.hasNoEvents);
 
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
@@ -76,6 +77,7 @@ module('Integration | Component | daily-calendar', function (hooks) {
     assert.strictEqual(component.events.length, 2);
     assert.strictEqual(component.events[0].name, 'event 0');
     assert.strictEqual(component.events[1].name, 'event 1');
+    assert.notOk(component.hasNoEvents);
 
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
@@ -112,6 +114,7 @@ module('Integration | Component | daily-calendar', function (hooks) {
     assert.strictEqual(component.events[3].name, 'event 5');
     assert.strictEqual(component.events[4].name, 'event 1');
     assert.strictEqual(component.events[5].name, 'event 3');
+    assert.notOk(component.hasNoEvents);
 
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');

--- a/tests/integration/components/monthly-calendar-test.js
+++ b/tests/integration/components/monthly-calendar-test.js
@@ -14,6 +14,7 @@ module('Integration | Component | monthly-calendar', function (hooks) {
   setupMirage(hooks);
 
   test('it renders empty and is accessible', async function (assert) {
+    assert.expect(66);
     const january9th2019 = DateTime.fromObject({
       year: 2019,
       month: 1,
@@ -34,6 +35,11 @@ module('Integration | Component | monthly-calendar', function (hooks) {
     assert.strictEqual(component.days.length, 31);
     assert.ok(component.days[0].isThirdDayOfWeek);
     assert.ok(component.days[0].isFirstWeek);
+
+    for (let i = 0; i < 31; i++) {
+      assert.strictEqual(component.days[i].events.length, 0);
+      assert.ok(component.days[i].hasNoEvents);
+    }
 
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
@@ -67,6 +73,7 @@ module('Integration | Component | monthly-calendar', function (hooks) {
     assert.ok(component.days[8].isSecondWeek);
     assert.strictEqual(component.days[8].events.length, 2);
     assert.notOk(component.days[8].hasShowMore);
+    assert.notOk(component.days[8].hasNoEvents);
 
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
@@ -100,6 +107,7 @@ module('Integration | Component | monthly-calendar', function (hooks) {
     assert.ok(component.days[8].isSecondWeek);
     assert.strictEqual(component.days[8].events.length, 2);
     assert.ok(component.days[8].hasShowMore);
+    assert.notOk(component.days[8].hasNoEvents);
 
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');

--- a/tests/integration/components/weekly-calendar-test.js
+++ b/tests/integration/components/weekly-calendar-test.js
@@ -32,6 +32,7 @@ module('Integration | Component | weekly-calendar', function (hooks) {
   };
 
   test('it renders empty and is accessible', async function (assert) {
+    assert.expect(21);
     const january9th2019 = DateTime.fromObject({
       year: 2019,
       month: 1,
@@ -53,6 +54,12 @@ module('Integration | Component | weekly-calendar', function (hooks) {
     assert.strictEqual(component.dayHeadings.length, 7);
     assert.ok(component.dayHeadings[0].isFirstDayOfWeek);
     assert.strictEqual(component.dayHeadings[0].text, 'Sunday Sun Jan 6 6');
+    assert.strictEqual(component.days.length, 7);
+
+    for (let i = 0; i < 7; i++) {
+      assert.strictEqual(component.days[i].events.length, 0);
+      assert.ok(component.days[i].hasNoEvents);
+    }
 
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
@@ -87,6 +94,21 @@ module('Integration | Component | weekly-calendar', function (hooks) {
     assert.strictEqual(component.events[0].name, 'event 0');
     assert.ok(component.events[1].isFourthDayOfWeek);
     assert.strictEqual(component.events[1].name, 'event 1');
+
+    assert.strictEqual(component.days[0].events.length, 0);
+    assert.ok(component.days[0].hasNoEvents);
+    assert.strictEqual(component.days[1].events.length, 0);
+    assert.ok(component.days[1].hasNoEvents);
+    assert.strictEqual(component.days[2].events.length, 0);
+    assert.ok(component.days[2].hasNoEvents);
+    assert.strictEqual(component.days[3].events.length, 2);
+    assert.notOk(component.days[3].hasNoEvents);
+    assert.strictEqual(component.days[4].events.length, 0);
+    assert.ok(component.days[4].hasNoEvents);
+    assert.strictEqual(component.days[5].events.length, 0);
+    assert.ok(component.days[5].hasNoEvents);
+    assert.strictEqual(component.days[6].events.length, 0);
+    assert.ok(component.days[6].hasNoEvents);
 
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
@@ -138,6 +160,21 @@ module('Integration | Component | weekly-calendar', function (hooks) {
 
     assert.ok(component.events[5].isSixthDayOfWeek);
     assert.strictEqual(component.events[5].name, 'event 3');
+
+    assert.strictEqual(component.days[0].events.length, 0);
+    assert.ok(component.days[0].hasNoEvents);
+    assert.strictEqual(component.days[1].events.length, 2);
+    assert.notOk(component.days[1].hasNoEvents);
+    assert.strictEqual(component.days[2].events.length, 0);
+    assert.ok(component.days[2].hasNoEvents);
+    assert.strictEqual(component.days[3].events.length, 2);
+    assert.notOk(component.days[3].hasNoEvents);
+    assert.strictEqual(component.days[4].events.length, 0);
+    assert.ok(component.days[4].hasNoEvents);
+    assert.strictEqual(component.days[5].events.length, 2);
+    assert.notOk(component.days[5].hasNoEvents);
+    assert.strictEqual(component.days[6].events.length, 0);
+    assert.ok(component.days[6].hasNoEvents);
 
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -210,6 +210,7 @@ general:
   noAvailableLearners: "No learners available; No cohort is attached to this course."
   noCohorts: "There are no cohorts in this course"
   noCourseLearningMaterialsAvailable: "No Course Learning Materials Available"
+  noEvents: No Events
   none: None
   noOfferings: "This session has no offerings"
   noResultsFound: "No results found. Please try again."

--- a/translations/es.yaml
+++ b/translations/es.yaml
@@ -210,6 +210,7 @@ general:
   noAvailableLearners: "No aprendedores disponible; Este curso no contiene ninguna clase de la graduación."
   noCohorts: "No hay ningún clase de la graduación en este curso"
   noCourseLearningMaterialsAvailable: "Ningunos Materiales Didácticos del Curso Disponibles"
+  noEvents: no eventos
   none: "Ningún"
   noOfferings: "Esta sesión no tiene ningunos ofrecimientos"
   noResultsFound: "Ningún resultado encontrado. Por favor intente otra vez."

--- a/translations/fr.yaml
+++ b/translations/fr.yaml
@@ -210,6 +210,7 @@ general:
   noAvailableLearners: "Pas d'étudiants sont disponibles; pas de cohorte est attaché à ce cours."
   noCohorts: "Il n'y a aucun des cohortes dans ce cours"
   noCourseLearningMaterialsAvailable: "Aucun Matériels D'étude de Cours"
+  noEvents: aucuns événements
   none: Nul
   noOfferings: "Ce session n'a aucun des offres"
   noResultsFound: "Aucun résultat n’a été trouvé. Veuillez réessayer."


### PR DESCRIPTION
For users of assistive technology it can be confusing to view our calendar which contains a list of days, but may not contain any events. They may no know if there is truly nothing on the calendar or if we've coded our site poorly. This a11y fix ensures that days without events contain a "no events" marker along with being visually empty.