### PR TITLE
Convert automerge to be a pull request action

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,8 +1,5 @@
 name: Dependabot auto-merge
-on: pull_request_target
-permissions:
-  pull-requests: write
-  contents: write
+on: pull_request:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
@@ -47,6 +44,7 @@ jobs:
           echo ${{contains(steps.metadata.outputs.dependency-names, matrix.safe-dependency)}}
           echo ${{steps.metadata.outputs.update-type == 'version-update:semver-minor'}}
           echo ${{steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+      - uses: actions/checkout@v3
       - name: Enable auto-merge for Dependabot PRs
         if: ${{contains(steps.metadata.outputs.dependency-names, matrix.safe-dependency) && (steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch') }}
         run: gh pr merge --auto --merge


### PR DESCRIPTION
We were using the special pull_request_target event here to be able to merge, but now that we're using the github CLI we may be able to do this with a normal pull request event and a checkout.

This might not work, giving it a try.