### PR TITLE
Add concurrently to ignored dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
   open-pull-requests-limit: 10
   ignore:
   - dependency-name: broccoli-asset-rev
+  - dependency-name: concurrently
   - dependency-name: "@ember/optional-features"
   - dependency-name: "@ember/test-helpers"
   - dependency-name: "@embroider/test-setup"


### PR DESCRIPTION
This is provided by ember-cli blueprints and we don't need to keep it up to date ourselves.