### PR TITLE
Bump package version when needed

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
     time: "02:30"
     timezone: America/Los_Angeles
   open-pull-requests-limit: 10
+  versioning-strategy: increase-if-necessary
   ignore:
   - dependency-name: broccoli-asset-rev
   - dependency-name: concurrently


### PR DESCRIPTION
Since common is a library dependabot tried to only update the lock version. That doesn't work for us, we want to push new things up to frontend so this version should be increased