### PR TITLE
Enable Percy Snapshots for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,24 @@ jobs:
           npm run browserstack:disconnect
           npm run browserstack:results
 
+  percy:
+    name: Percy Visual Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [test]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 16.x
+        cache: npm
+    - name: install dependencies
+      run: npm ci
+    - name: test
+      run: npm run test:percy
+      env:
+        PERCY_TOKEN: 0de8ba013a51dea7cb1e9e94813a8370339285c967dcc84de59fb8cc13015456
+
   firefox-test:
     name: Browser Tests (Firefox)
     runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,6 +77,8 @@
         "@ember/test-helpers": "^2.9.3",
         "@embroider/test-setup": "^2.1.1",
         "@ilios/ember-template-lint-plugin": "^3.0.0",
+        "@percy/cli": "^1.24.0",
+        "@percy/ember": "^4.2.0",
         "babel-eslint": "^10.1.0",
         "broccoli-asset-rev": "^3.0.0",
         "concurrently": "^7.6.0",
@@ -3325,6 +3327,347 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@percy/cli": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.24.0.tgz",
+      "integrity": "sha512-n8dxQfA2GoPk468EQ+sO7P/P5sBl3Q+s7UrljQhf4wPt4l+CBmoxMML8Ib71MyISzwxY7bOSw2QMr26r6n06/A==",
+      "dev": true,
+      "dependencies": {
+        "@percy/cli-app": "1.24.0",
+        "@percy/cli-build": "1.24.0",
+        "@percy/cli-command": "1.24.0",
+        "@percy/cli-config": "1.24.0",
+        "@percy/cli-exec": "1.24.0",
+        "@percy/cli-snapshot": "1.24.0",
+        "@percy/cli-upload": "1.24.0",
+        "@percy/client": "1.24.0",
+        "@percy/logger": "1.24.0"
+      },
+      "bin": {
+        "percy": "bin/run.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/cli-app": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli-app/-/cli-app-1.24.0.tgz",
+      "integrity": "sha512-z7ksv+SvdgDuAZ4WDnluuLuS72xb18DKauuwikSKipdICHHFQuXdRc0ngloADC/6IFzp0JhiukiRanntbBkPvg==",
+      "dev": true,
+      "dependencies": {
+        "@percy/cli-command": "1.24.0",
+        "@percy/cli-exec": "1.24.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/cli-build": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.24.0.tgz",
+      "integrity": "sha512-p/wmO0OzqJ2Uou7QNAdxioqKmxu7U+6Al02GvVhYcPja/MkVjfJT/jDl+XstXawR76txQW9QWrNsK5YOAWUupQ==",
+      "dev": true,
+      "dependencies": {
+        "@percy/cli-command": "1.24.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/cli-command": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.24.0.tgz",
+      "integrity": "sha512-n4qyDdUc+TiX/YykGg59IS1DBmm4UdA7ZaiTdw/D5AZohzwwVbwL+Q4QMYqcohtfYZ/F8UT7Qy3Jma3+YKTnxw==",
+      "dev": true,
+      "dependencies": {
+        "@percy/config": "1.24.0",
+        "@percy/core": "1.24.0",
+        "@percy/logger": "1.24.0"
+      },
+      "bin": {
+        "percy-cli-readme": "bin/readme.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/cli-config": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.24.0.tgz",
+      "integrity": "sha512-7T70Y3vC0hIGBe+WOmdzspN8N5uflBRwuPoRXn2PdzxvH55hUhCGFT/Wxb8C6rTMJ9k++POkxMoQaSErVANYYg==",
+      "dev": true,
+      "dependencies": {
+        "@percy/cli-command": "1.24.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/cli-exec": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.24.0.tgz",
+      "integrity": "sha512-T5B8HLjPde0js5lkO14uk02QZKmgxILjALh5SX9VFL2Qx4cUXw+A29epPPv6OLI2x2oww8e5nTdlnmykX8n4kQ==",
+      "dev": true,
+      "dependencies": {
+        "@percy/cli-command": "1.24.0",
+        "cross-spawn": "^7.0.3",
+        "which": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/cli-snapshot": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.24.0.tgz",
+      "integrity": "sha512-zxoE1SbdTvUlP7QAjTs7+M7U8cHEDF1ec7ov06m1i+bul68YhZ0S+P4a1Mbt6oWBsAxjYz06h4jnq32JitbSDg==",
+      "dev": true,
+      "dependencies": {
+        "@percy/cli-command": "1.24.0",
+        "yaml": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/cli-upload": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.24.0.tgz",
+      "integrity": "sha512-/4XNzMAhbccYSsPhw/KWRVjnd13nd17LB178dVNX4UEtaETDbBF+VZSlU3scgs8mlpuqY8b8bHDaSJNfI71UwQ==",
+      "dev": true,
+      "dependencies": {
+        "@percy/cli-command": "1.24.0",
+        "fast-glob": "^3.2.11",
+        "image-size": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/cli-upload/node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@percy/cli-upload/node_modules/fast-glob": {
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/@percy/client": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.24.0.tgz",
+      "integrity": "sha512-mCMIGryE+0oxJN6v+riZ+XqnubEL9rajLOJI7xNOj5gNBNNvwgvkpTiNId9d6LNZVhA7dN9ZHTW+zFK+i4nU8A==",
+      "dev": true,
+      "dependencies": {
+        "@percy/env": "1.24.0",
+        "@percy/logger": "1.24.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/config": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.24.0.tgz",
+      "integrity": "sha512-FOV8VkW/MjLI7PXzKSjxFBK7z0ND1s8LtXuLQNIrux3oiCKHIVBAQWIV86LLnXSSn+G5i3tfQua9YED5ATyNFQ==",
+      "dev": true,
+      "dependencies": {
+        "@percy/logger": "1.24.0",
+        "ajv": "^8.6.2",
+        "cosmiconfig": "^7.0.0",
+        "yaml": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/config/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@percy/config/node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "dev": true,
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@percy/config/node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@percy/config/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "node_modules/@percy/config/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
+    "node_modules/@percy/core": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.24.0.tgz",
+      "integrity": "sha512-wys1k3RmENOWT4MeS2+8yGHNqzYuy64lqPi36dFoHwZHzSGHH52+6EPPDb+gXLFIxBUHVTwbdaNimstIO3F9Ww==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@percy/client": "1.24.0",
+        "@percy/config": "1.24.0",
+        "@percy/dom": "1.24.0",
+        "@percy/logger": "1.24.0",
+        "content-disposition": "^0.5.4",
+        "cross-spawn": "^7.0.3",
+        "extract-zip": "^2.0.1",
+        "fast-glob": "^3.2.11",
+        "micromatch": "^4.0.4",
+        "mime-types": "^2.1.34",
+        "path-to-regexp": "^6.2.0",
+        "rimraf": "^3.0.2",
+        "ws": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/core/node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@percy/core/node_modules/fast-glob": {
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/@percy/core/node_modules/path-to-regexp": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
+      "dev": true
+    },
+    "node_modules/@percy/core/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@percy/dom": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.24.0.tgz",
+      "integrity": "sha512-URMLvsOPkCKayx/Wtyj5IymmIhzrtf4en6IKeW2sSTsm7X+kJQ+3wOa3017mX3HXJPIS5xEJKpiCR7hP9BtcUA==",
+      "dev": true
+    },
+    "node_modules/@percy/ember": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@percy/ember/-/ember-4.2.0.tgz",
+      "integrity": "sha512-D/WckDD2tQetdn8uq46nQA1rOVgov8jsZG4uN7snAq6SrOpxNxacONg37QPwczmICBc7o/NlipCAUteukmtKzg==",
+      "dev": true,
+      "dependencies": {
+        "@percy/sdk-utils": "^1.18.0",
+        "ember-cli-babel": "^7.26.11"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@percy/env": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.24.0.tgz",
+      "integrity": "sha512-fUUWWDZJ71kv+Po5yOaoS8t7eLmQL5NN6hqRdLhgqN9PZnu+OKIGaeK1GNaTWiHL9+zANRBc1pZjQWhRlleWVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/logger": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.24.0.tgz",
+      "integrity": "sha512-yaAo08FMED1o8jZycTEnTob1CZIVGaNluJc4R9fCRw7wWS88IAu4F9sdbzUZQZwZ/QGvtfI+55dNQaaesk69Bw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/sdk-utils": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@percy/sdk-utils/-/sdk-utils-1.24.0.tgz",
+      "integrity": "sha512-kfYxX0rHP5N2Da6HyfjRCVaeNahAO9XV5WD4SKWKKjdKVkV/Z5/XjVgSKlTBLSYxnWDzYJJ4UHZV43Mw+facMA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@popperjs/core": {
       "version": "2.11.7",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz",
@@ -3574,6 +3917,12 @@
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
     },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "dev": true
+    },
     "node_modules/@types/qs": {
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
@@ -3637,6 +3986,16 @@
       "version": "13.7.15",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.15.tgz",
       "integrity": "sha512-yeinDVQunb03AEP8luErFcyf/7Lf7AzKCD0NXfgVoGCCQDNpZET8Jgq74oBgqKld3hafLbfzt/3inUdQvaFeXQ=="
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.5",
@@ -7499,6 +7858,15 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/buffer-from": {
@@ -18548,6 +18916,41 @@
         "node": ">=8"
       }
     },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extract-zip/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fake-xml-http-request": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/fake-xml-http-request/-/fake-xml-http-request-2.1.2.tgz",
@@ -18923,6 +19326,15 @@
       "dev": true,
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "dependencies": {
+        "pend": "~1.2.0"
       }
     },
     "node_modules/figgy-pudding": {
@@ -20571,6 +20983,21 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/image-size": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.0.2.tgz",
+      "integrity": "sha512-xfOoWjceHntRb3qFCrh5ZFORYH8XCdYpASltMhZ/Q0KZiOwjdE/Yl2QCiWdwD+lygV5bMCvauzgu5PxBX/Yerg==",
+      "dev": true,
+      "dependencies": {
+        "queue": "6.0.2"
+      },
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/immutable": {
@@ -24334,6 +24761,12 @@
         "node": ">=0.12"
       }
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true
+    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -25093,6 +25526,15 @@
       "integrity": "sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==",
       "engines": {
         "node": ">=0.4.x"
+      }
+    },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "~2.0.3"
       }
     },
     "node_modules/queue-microtask": {
@@ -29973,6 +30415,15 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/yaml": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
+      "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -30007,6 +30458,16 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yocto-queue": {
@@ -32346,6 +32807,275 @@
         "fastq": "^1.6.0"
       }
     },
+    "@percy/cli": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.24.0.tgz",
+      "integrity": "sha512-n8dxQfA2GoPk468EQ+sO7P/P5sBl3Q+s7UrljQhf4wPt4l+CBmoxMML8Ib71MyISzwxY7bOSw2QMr26r6n06/A==",
+      "dev": true,
+      "requires": {
+        "@percy/cli-app": "1.24.0",
+        "@percy/cli-build": "1.24.0",
+        "@percy/cli-command": "1.24.0",
+        "@percy/cli-config": "1.24.0",
+        "@percy/cli-exec": "1.24.0",
+        "@percy/cli-snapshot": "1.24.0",
+        "@percy/cli-upload": "1.24.0",
+        "@percy/client": "1.24.0",
+        "@percy/logger": "1.24.0"
+      }
+    },
+    "@percy/cli-app": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli-app/-/cli-app-1.24.0.tgz",
+      "integrity": "sha512-z7ksv+SvdgDuAZ4WDnluuLuS72xb18DKauuwikSKipdICHHFQuXdRc0ngloADC/6IFzp0JhiukiRanntbBkPvg==",
+      "dev": true,
+      "requires": {
+        "@percy/cli-command": "1.24.0",
+        "@percy/cli-exec": "1.24.0"
+      }
+    },
+    "@percy/cli-build": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.24.0.tgz",
+      "integrity": "sha512-p/wmO0OzqJ2Uou7QNAdxioqKmxu7U+6Al02GvVhYcPja/MkVjfJT/jDl+XstXawR76txQW9QWrNsK5YOAWUupQ==",
+      "dev": true,
+      "requires": {
+        "@percy/cli-command": "1.24.0"
+      }
+    },
+    "@percy/cli-command": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.24.0.tgz",
+      "integrity": "sha512-n4qyDdUc+TiX/YykGg59IS1DBmm4UdA7ZaiTdw/D5AZohzwwVbwL+Q4QMYqcohtfYZ/F8UT7Qy3Jma3+YKTnxw==",
+      "dev": true,
+      "requires": {
+        "@percy/config": "1.24.0",
+        "@percy/core": "1.24.0",
+        "@percy/logger": "1.24.0"
+      }
+    },
+    "@percy/cli-config": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.24.0.tgz",
+      "integrity": "sha512-7T70Y3vC0hIGBe+WOmdzspN8N5uflBRwuPoRXn2PdzxvH55hUhCGFT/Wxb8C6rTMJ9k++POkxMoQaSErVANYYg==",
+      "dev": true,
+      "requires": {
+        "@percy/cli-command": "1.24.0"
+      }
+    },
+    "@percy/cli-exec": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.24.0.tgz",
+      "integrity": "sha512-T5B8HLjPde0js5lkO14uk02QZKmgxILjALh5SX9VFL2Qx4cUXw+A29epPPv6OLI2x2oww8e5nTdlnmykX8n4kQ==",
+      "dev": true,
+      "requires": {
+        "@percy/cli-command": "1.24.0",
+        "cross-spawn": "^7.0.3",
+        "which": "^2.0.2"
+      }
+    },
+    "@percy/cli-snapshot": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.24.0.tgz",
+      "integrity": "sha512-zxoE1SbdTvUlP7QAjTs7+M7U8cHEDF1ec7ov06m1i+bul68YhZ0S+P4a1Mbt6oWBsAxjYz06h4jnq32JitbSDg==",
+      "dev": true,
+      "requires": {
+        "@percy/cli-command": "1.24.0",
+        "yaml": "^2.0.0"
+      }
+    },
+    "@percy/cli-upload": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.24.0.tgz",
+      "integrity": "sha512-/4XNzMAhbccYSsPhw/KWRVjnd13nd17LB178dVNX4UEtaETDbBF+VZSlU3scgs8mlpuqY8b8bHDaSJNfI71UwQ==",
+      "dev": true,
+      "requires": {
+        "@percy/cli-command": "1.24.0",
+        "fast-glob": "^3.2.11",
+        "image-size": "^1.0.0"
+      },
+      "dependencies": {
+        "@nodelib/fs.stat": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+          "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+          "dev": true
+        },
+        "fast-glob": {
+          "version": "3.2.12",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+          "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.stat": "^2.0.2",
+            "@nodelib/fs.walk": "^1.2.3",
+            "glob-parent": "^5.1.2",
+            "merge2": "^1.3.0",
+            "micromatch": "^4.0.4"
+          }
+        }
+      }
+    },
+    "@percy/client": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.24.0.tgz",
+      "integrity": "sha512-mCMIGryE+0oxJN6v+riZ+XqnubEL9rajLOJI7xNOj5gNBNNvwgvkpTiNId9d6LNZVhA7dN9ZHTW+zFK+i4nU8A==",
+      "dev": true,
+      "requires": {
+        "@percy/env": "1.24.0",
+        "@percy/logger": "1.24.0"
+      }
+    },
+    "@percy/config": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.24.0.tgz",
+      "integrity": "sha512-FOV8VkW/MjLI7PXzKSjxFBK7z0ND1s8LtXuLQNIrux3oiCKHIVBAQWIV86LLnXSSn+G5i3tfQua9YED5ATyNFQ==",
+      "dev": true,
+      "requires": {
+        "@percy/logger": "1.24.0",
+        "ajv": "^8.6.2",
+        "cosmiconfig": "^7.0.0",
+        "yaml": "^2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "cosmiconfig": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+          "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+          "dev": true,
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.2.1",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.10.0"
+          },
+          "dependencies": {
+            "yaml": {
+              "version": "1.10.2",
+              "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+              "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+              "dev": true
+            }
+          }
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        }
+      }
+    },
+    "@percy/core": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.24.0.tgz",
+      "integrity": "sha512-wys1k3RmENOWT4MeS2+8yGHNqzYuy64lqPi36dFoHwZHzSGHH52+6EPPDb+gXLFIxBUHVTwbdaNimstIO3F9Ww==",
+      "dev": true,
+      "requires": {
+        "@percy/client": "1.24.0",
+        "@percy/config": "1.24.0",
+        "@percy/dom": "1.24.0",
+        "@percy/logger": "1.24.0",
+        "content-disposition": "^0.5.4",
+        "cross-spawn": "^7.0.3",
+        "extract-zip": "^2.0.1",
+        "fast-glob": "^3.2.11",
+        "micromatch": "^4.0.4",
+        "mime-types": "^2.1.34",
+        "path-to-regexp": "^6.2.0",
+        "rimraf": "^3.0.2",
+        "ws": "^8.0.0"
+      },
+      "dependencies": {
+        "@nodelib/fs.stat": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+          "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+          "dev": true
+        },
+        "fast-glob": {
+          "version": "3.2.12",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+          "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.stat": "^2.0.2",
+            "@nodelib/fs.walk": "^1.2.3",
+            "glob-parent": "^5.1.2",
+            "merge2": "^1.3.0",
+            "micromatch": "^4.0.4"
+          }
+        },
+        "path-to-regexp": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+          "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
+    "@percy/dom": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.24.0.tgz",
+      "integrity": "sha512-URMLvsOPkCKayx/Wtyj5IymmIhzrtf4en6IKeW2sSTsm7X+kJQ+3wOa3017mX3HXJPIS5xEJKpiCR7hP9BtcUA==",
+      "dev": true
+    },
+    "@percy/ember": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@percy/ember/-/ember-4.2.0.tgz",
+      "integrity": "sha512-D/WckDD2tQetdn8uq46nQA1rOVgov8jsZG4uN7snAq6SrOpxNxacONg37QPwczmICBc7o/NlipCAUteukmtKzg==",
+      "dev": true,
+      "requires": {
+        "@percy/sdk-utils": "^1.18.0",
+        "ember-cli-babel": "^7.26.11"
+      }
+    },
+    "@percy/env": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.24.0.tgz",
+      "integrity": "sha512-fUUWWDZJ71kv+Po5yOaoS8t7eLmQL5NN6hqRdLhgqN9PZnu+OKIGaeK1GNaTWiHL9+zANRBc1pZjQWhRlleWVA==",
+      "dev": true
+    },
+    "@percy/logger": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.24.0.tgz",
+      "integrity": "sha512-yaAo08FMED1o8jZycTEnTob1CZIVGaNluJc4R9fCRw7wWS88IAu4F9sdbzUZQZwZ/QGvtfI+55dNQaaesk69Bw==",
+      "dev": true
+    },
+    "@percy/sdk-utils": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@percy/sdk-utils/-/sdk-utils-1.24.0.tgz",
+      "integrity": "sha512-kfYxX0rHP5N2Da6HyfjRCVaeNahAO9XV5WD4SKWKKjdKVkV/Z5/XjVgSKlTBLSYxnWDzYJJ4UHZV43Mw+facMA==",
+      "dev": true
+    },
     "@popperjs/core": {
       "version": "2.11.7",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz",
@@ -32583,6 +33313,12 @@
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
     },
+    "@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "dev": true
+    },
     "@types/qs": {
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
@@ -32646,6 +33382,16 @@
       "version": "13.7.15",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.15.tgz",
       "integrity": "sha512-yeinDVQunb03AEP8luErFcyf/7Lf7AzKCD0NXfgVoGCCQDNpZET8Jgq74oBgqKld3hafLbfzt/3inUdQvaFeXQ=="
+    },
+    "@types/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@webassemblyjs/ast": {
       "version": "1.11.5",
@@ -35922,6 +36668,12 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true
     },
     "buffer-from": {
       "version": "1.1.2",
@@ -44668,6 +45420,29 @@
       "integrity": "sha512-AEo4zm+TenK7zQorGK1f9mJ8L14hnTDi2ZQPR+Mub1NX8zimka1mXpV5LpH8x9HoUmFSHZCfLHqWvp0Y4FxxzQ==",
       "dev": true
     },
+    "extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "requires": {
+        "@types/yauzl": "^2.9.1",
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        }
+      }
+    },
     "fake-xml-http-request": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/fake-xml-http-request/-/fake-xml-http-request-2.1.2.tgz",
@@ -44985,6 +45760,15 @@
       "dev": true,
       "requires": {
         "bser": "2.1.1"
+      }
+    },
+    "fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "requires": {
+        "pend": "~1.2.0"
       }
     },
     "figgy-pudding": {
@@ -46291,6 +47075,15 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
+    },
+    "image-size": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.0.2.tgz",
+      "integrity": "sha512-xfOoWjceHntRb3qFCrh5ZFORYH8XCdYpASltMhZ/Q0KZiOwjdE/Yl2QCiWdwD+lygV5bMCvauzgu5PxBX/Yerg==",
+      "dev": true,
+      "requires": {
+        "queue": "6.0.2"
+      }
     },
     "immutable": {
       "version": "4.3.0",
@@ -49312,6 +50105,12 @@
         "sha.js": "^2.4.8"
       }
     },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true
+    },
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -49865,6 +50664,15 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA=="
+    },
+    "queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "dev": true,
+      "requires": {
+        "inherits": "~2.0.3"
+      }
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -53730,6 +54538,12 @@
         }
       }
     },
+    "yaml": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
+      "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
+      "dev": true
+    },
     "yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -53758,6 +54572,16 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true
+    },
+    "yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test:ember-compatibility": "ember try:each",
     "test:ember:browserstack": "ember test --test-port=7774 --host=127.0.0.1 --config-file=testem.browserstack.js",
     "test:browserstack": "npm-run-all browserstack:connect test:ember:browserstack browserstack:disconnect browserstack:results",
+    "test:percy": "percy exec -- npm run test:ember",
     "browserstack:connect": "ember browserstack:connect",
     "browserstack:disconnect": "ember browserstack:disconnect",
     "browserstack:results": "ember browserstack:results"
@@ -125,6 +126,8 @@
     "@ember/test-helpers": "^2.9.3",
     "@embroider/test-setup": "^2.1.1",
     "@ilios/ember-template-lint-plugin": "^3.0.0",
+    "@percy/cli": "^1.24.0",
+    "@percy/ember": "^4.2.0",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "concurrently": "^7.6.0",

--- a/tests/acceptance/course-visualizations-instructor-test.js
+++ b/tests/acceptance/course-visualizations-instructor-test.js
@@ -4,6 +4,7 @@ import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/course-visualizations-instructor';
 import { setupAuthentication } from 'ilios-common';
 import { DateTime } from 'luxon';
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | course visualizations - instructor', function (hooks) {
   setupApplicationTest(hooks);
@@ -12,6 +13,7 @@ module('Acceptance | course visualizations - instructor', function (hooks) {
   });
 
   test('it renders', async function (assert) {
+    assert.expect(21);
     const instructor = this.server.create('user');
     const vocabulary1 = this.server.create('vocabulary');
     const vocabulary2 = this.server.create('vocabulary');
@@ -77,6 +79,7 @@ module('Acceptance | course visualizations - instructor', function (hooks) {
     await waitFor('.loaded');
     await waitFor('svg .bars');
     await waitFor('svg .chart');
+    await percySnapshot(assert);
     assert.strictEqual(page.root.termsChart.chart.bars.length, 3);
     assert.strictEqual(page.root.termsChart.chart.labels.length, 3);
     assert.strictEqual(

--- a/tests/acceptance/course-visualizations-instructor-test.js
+++ b/tests/acceptance/course-visualizations-instructor-test.js
@@ -76,7 +76,7 @@ module('Acceptance | course visualizations - instructor', function (hooks) {
     assert.strictEqual(page.root.breadcrumb.crumbs[2].link, '/data/courses/1/instructors');
     assert.strictEqual(page.root.breadcrumb.crumbs[3].text, '1 guy M. Mc1son');
     // wait for charts to load
-    await waitFor('.loaded');
+    await waitFor('.loaded', { count: 2 });
     await waitFor('svg .bars');
     await waitFor('svg .chart');
     await percySnapshot(assert);

--- a/tests/acceptance/course-visualizations-instructors-test.js
+++ b/tests/acceptance/course-visualizations-instructors-test.js
@@ -4,6 +4,7 @@ import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/course-visualizations-instructors';
 import { setupAuthentication } from 'ilios-common';
 import { DateTime } from 'luxon';
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | course visualizations - instructors', function (hooks) {
   setupApplicationTest(hooks);
@@ -12,6 +13,7 @@ module('Acceptance | course visualizations - instructors', function (hooks) {
   });
 
   test('it renders', async function (assert) {
+    assert.expect(12);
     const instructor1 = this.server.create('user');
     const instructor2 = this.server.create('user');
     const vocabulary1 = this.server.create('vocabulary');
@@ -65,6 +67,7 @@ module('Acceptance | course visualizations - instructors', function (hooks) {
       year: 2022,
     });
     await page.visit({ courseId: course.id });
+    await percySnapshot(assert);
     assert.strictEqual(currentURL(), '/data/courses/1/instructors');
     assert.strictEqual(page.root.title, 'course 0 2022');
     assert.strictEqual(page.root.breadcrumb.crumbs.length, 3);

--- a/tests/acceptance/course-visualizations-instructors-test.js
+++ b/tests/acceptance/course-visualizations-instructors-test.js
@@ -67,7 +67,6 @@ module('Acceptance | course visualizations - instructors', function (hooks) {
       year: 2022,
     });
     await page.visit({ courseId: course.id });
-    await percySnapshot(assert);
     assert.strictEqual(currentURL(), '/data/courses/1/instructors');
     assert.strictEqual(page.root.title, 'course 0 2022');
     assert.strictEqual(page.root.breadcrumb.crumbs.length, 3);
@@ -79,6 +78,7 @@ module('Acceptance | course visualizations - instructors', function (hooks) {
     // wait for charts to load
     await waitFor('.loaded');
     await waitFor('svg .bars');
+    await percySnapshot(assert);
     assert.strictEqual(page.root.instructorsChart.chart.bars.length, 2);
     assert.strictEqual(page.root.instructorsChart.chart.labels.length, 2);
     assert.strictEqual(

--- a/tests/acceptance/course-visualizations-objectives-test.js
+++ b/tests/acceptance/course-visualizations-objectives-test.js
@@ -3,6 +3,7 @@ import { currentURL, waitFor } from '@ember/test-helpers';
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/course-visualizations-objectives';
 import { setupAuthentication } from 'ilios-common';
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | course visualizations - objectives', function (hooks) {
   setupApplicationTest(hooks);
@@ -11,6 +12,7 @@ module('Acceptance | course visualizations - objectives', function (hooks) {
   });
 
   test('it renders', async function (assert) {
+    assert.expect(14);
     const school = this.server.create('school');
     const course = this.server.create('course', { year: 2021, school });
     const courseObjectives = this.server.createList('courseObjective', 3, {
@@ -68,6 +70,7 @@ module('Acceptance | course visualizations - objectives', function (hooks) {
     // wait for charts to load
     await waitFor('.loaded');
     await waitFor('svg .chart');
+    await percySnapshot(assert);
     assert.strictEqual(page.root.objectivesChart.chart.slices.length, 2);
     assert.strictEqual(page.root.objectivesChart.chart.slices[0].text, '77.8%');
     assert.strictEqual(page.root.objectivesChart.chart.slices[1].text, '22.2%');

--- a/tests/acceptance/course-visualizations-session-type-test.js
+++ b/tests/acceptance/course-visualizations-session-type-test.js
@@ -4,6 +4,7 @@ import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/course-visualizations-session-type';
 import { setupAuthentication } from 'ilios-common';
 import { DateTime } from 'luxon';
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | course visualizations - session-type', function (hooks) {
   setupApplicationTest(hooks);
@@ -12,6 +13,7 @@ module('Acceptance | course visualizations - session-type', function (hooks) {
   });
 
   test('it renders', async function (assert) {
+    assert.expect(16);
     const sessionType = this.server.create('sessionType');
     const vocabulary1 = this.server.create('vocabulary');
     const vocabulary2 = this.server.create('vocabulary');
@@ -65,6 +67,7 @@ module('Acceptance | course visualizations - session-type', function (hooks) {
     // wait for charts to load
     await waitFor('.loaded');
     await waitFor('svg .bars');
+    await percySnapshot(assert);
     assert.strictEqual(page.root.title, 'course 0 2022');
     assert.strictEqual(page.root.sessionTypeChart.chart.bars.length, 3);
     assert.strictEqual(page.root.sessionTypeChart.chart.labels.length, 3);

--- a/tests/acceptance/course-visualizations-session-types-test.js
+++ b/tests/acceptance/course-visualizations-session-types-test.js
@@ -4,6 +4,7 @@ import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/course-visualizations-session-types';
 import { setupAuthentication } from 'ilios-common';
 import { DateTime } from 'luxon';
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | course visualizations - session-types', function (hooks) {
   setupApplicationTest(hooks);
@@ -12,6 +13,7 @@ module('Acceptance | course visualizations - session-types', function (hooks) {
   });
 
   test('it renders', async function (assert) {
+    assert.expect(14);
     const sessionType1 = this.server.create('sessionType');
     const sessionType2 = this.server.create('sessionType');
     const sessionType3 = this.server.create('sessionType');
@@ -67,6 +69,7 @@ module('Acceptance | course visualizations - session-types', function (hooks) {
     // wait for charts to load
     await waitFor('.loaded');
     await waitFor('svg .bars');
+    await percySnapshot(assert);
     assert.strictEqual(page.root.title, 'course 0 2022');
     assert.strictEqual(page.root.sessionTypesChart.chart.bars.length, 3);
     assert.strictEqual(page.root.sessionTypesChart.chart.labels.length, 3);

--- a/tests/acceptance/course-visualizations-test.js
+++ b/tests/acceptance/course-visualizations-test.js
@@ -3,7 +3,6 @@ import { currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/course-visualizations';
 import { setupAuthentication } from 'ilios-common';
-import percySnapshot from '@percy/ember';
 
 module('Acceptance | course visualizations', function (hooks) {
   setupApplicationTest(hooks);
@@ -20,7 +19,6 @@ module('Acceptance | course visualizations', function (hooks) {
   test('visiting /data/courses/1', async function (assert) {
     assert.expect(5);
     await page.visit({ courseId: 1 });
-    await percySnapshot(assert);
     assert.strictEqual(currentURL(), '/data/courses/1');
     assert.ok(page.visualizations.objectives.isVisible);
     assert.ok(page.visualizations.sessionTypes.isVisible);

--- a/tests/acceptance/course-visualizations-test.js
+++ b/tests/acceptance/course-visualizations-test.js
@@ -3,6 +3,7 @@ import { currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/course-visualizations';
 import { setupAuthentication } from 'ilios-common';
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | course visualizations', function (hooks) {
   setupApplicationTest(hooks);
@@ -17,7 +18,9 @@ module('Acceptance | course visualizations', function (hooks) {
   });
 
   test('visiting /data/courses/1', async function (assert) {
+    assert.expect(5);
     await page.visit({ courseId: 1 });
+    await percySnapshot(assert);
     assert.strictEqual(currentURL(), '/data/courses/1');
     assert.ok(page.visualizations.objectives.isVisible);
     assert.ok(page.visualizations.sessionTypes.isVisible);

--- a/tests/acceptance/course-visualizations-vocabularies-test.js
+++ b/tests/acceptance/course-visualizations-vocabularies-test.js
@@ -4,6 +4,7 @@ import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/course-visualizations-vocabularies';
 import { setupAuthentication } from 'ilios-common';
 import { DateTime } from 'luxon';
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | course visualizations - vocabularies', function (hooks) {
   setupApplicationTest(hooks);
@@ -12,6 +13,7 @@ module('Acceptance | course visualizations - vocabularies', function (hooks) {
   });
 
   test('it renders', async function (assert) {
+    assert.expect(12);
     const sessionType = this.server.create('sessionType');
     const vocabulary1 = this.server.create('vocabulary');
     const vocabulary2 = this.server.create('vocabulary');
@@ -66,6 +68,7 @@ module('Acceptance | course visualizations - vocabularies', function (hooks) {
     // wait for charts to load
     await waitFor('.loaded');
     await waitFor('svg .chart');
+    await percySnapshot(assert);
     assert.strictEqual(page.root.vocabulariesChart.chart.slices.length, 2);
     assert.strictEqual(page.root.vocabulariesChart.chart.slices[0].text, 'Vocabulary 1');
     assert.strictEqual(page.root.vocabulariesChart.chart.slices[1].text, 'Vocabulary 2');

--- a/tests/acceptance/course-visualizations-vocabulary-test.js
+++ b/tests/acceptance/course-visualizations-vocabulary-test.js
@@ -4,6 +4,7 @@ import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/course-visualizations-vocabulary';
 import { setupAuthentication } from 'ilios-common';
 import { DateTime } from 'luxon';
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | course visualizations - vocabulary', function (hooks) {
   setupApplicationTest(hooks);
@@ -12,6 +13,7 @@ module('Acceptance | course visualizations - vocabulary', function (hooks) {
   });
 
   test('it renders', async function (assert) {
+    assert.expect(17);
     const vocabulary = this.server.create('vocabulary');
     const term1 = this.server.create('term', {
       vocabulary,
@@ -69,6 +71,7 @@ module('Acceptance | course visualizations - vocabulary', function (hooks) {
     // wait for charts to load
     await waitFor('.loaded');
     await waitFor('svg .bars');
+    await percySnapshot(assert);
     assert.strictEqual(page.root.termsChart.chart.bars.length, 3);
     assert.strictEqual(page.root.termsChart.chart.labels.length, 3);
     assert.strictEqual(page.root.termsChart.chart.labels[0].text, 'term 1: 30 Minutes');

--- a/tests/acceptance/course/cohorts-test.js
+++ b/tests/acceptance/course/cohorts-test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import { setupAuthentication } from 'ilios-common';
 import page from 'ilios-common/page-objects/course';
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | Course - Cohorts', function (hooks) {
   setupApplicationTest(hooks);
@@ -46,6 +47,7 @@ module('Acceptance | Course - Cohorts', function (hooks) {
   test('list cohorts', async function (assert) {
     assert.expect(4);
     await page.visit({ courseId: this.course.id, details: true });
+    await percySnapshot(assert);
     assert.strictEqual(page.details.cohorts.current.length, 1);
     assert.strictEqual(page.details.cohorts.current[0].school, 'school 0');
     assert.strictEqual(page.details.cohorts.current[0].program, 'program 0');
@@ -56,6 +58,7 @@ module('Acceptance | Course - Cohorts', function (hooks) {
     assert.expect(4);
     await page.visit({ courseId: this.course.id, details: true });
     await page.details.cohorts.manage();
+    await percySnapshot(assert);
     assert.strictEqual(page.details.cohorts.selected.length, 1);
     assert.strictEqual(page.details.cohorts.selected[0].name, 'school 0 | program 0 | cohort 0');
     assert.strictEqual(page.details.cohorts.selectable.length, 1);

--- a/tests/acceptance/course/competencies-test.js
+++ b/tests/acceptance/course/competencies-test.js
@@ -3,6 +3,7 @@ import { setupAuthentication } from 'ilios-common';
 
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/course';
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | Course - Competencies', function (hooks) {
   setupApplicationTest(hooks);
@@ -50,8 +51,10 @@ module('Acceptance | Course - Competencies', function (hooks) {
   });
 
   test('collapsed competencies renders', async function (assert) {
+    assert.expect(5);
     this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, details: true });
+    await percySnapshot(assert);
     assert.strictEqual(page.details.collapsedCompetencies.title, 'Competencies (1)');
     assert.strictEqual(page.details.collapsedCompetencies.headers[0].text, 'School');
     assert.strictEqual(page.details.collapsedCompetencies.headers[1].text, 'Competencies');

--- a/tests/acceptance/course/leadership-test.js
+++ b/tests/acceptance/course/leadership-test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import { setupAuthentication } from 'ilios-common';
 import page from 'ilios-common/page-objects/course';
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | Course - Leadership', function (hooks) {
   setupApplicationTest(hooks);
@@ -26,6 +27,7 @@ module('Acceptance | Course - Leadership', function (hooks) {
   test('collapsed leadership', async function (assert) {
     assert.expect(10);
     await page.visit({ courseId: this.course.id, details: true });
+    await percySnapshot(assert);
 
     assert.strictEqual(page.details.leadershipCollapsed.title, 'Course Leadership');
     assert.strictEqual(page.details.leadershipCollapsed.headers.length, 1);
@@ -53,6 +55,7 @@ module('Acceptance | Course - Leadership', function (hooks) {
       details: true,
       courseLeadershipDetails: true,
     });
+    await percySnapshot(assert);
 
     assert.strictEqual(page.details.leadershipExpanded.title, 'Course Leadership');
     const { directors, administrators, studentAdvisors } =

--- a/tests/acceptance/course/learningmaterials-test.js
+++ b/tests/acceptance/course/learningmaterials-test.js
@@ -6,6 +6,7 @@ import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/course';
 
 const today = DateTime.fromObject({ hour: 8 });
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | Course - Learning Materials', function (hooks) {
   setupApplicationTest(hooks);
@@ -104,8 +105,10 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
     });
 
     test('list learning materials', async function (assert) {
+      assert.expect(39);
       this.user.update({ administeredSchools: [this.school] });
       await page.visit({ courseId: this.course.id, details: true });
+      await percySnapshot(assert);
       assert.strictEqual(currentRouteName(), 'course.index');
 
       assert.strictEqual(page.details.learningMaterials.current.length, 4);
@@ -851,8 +854,10 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
     });
 
     test('list learning materials', async function (assert) {
+      assert.expect(10);
       this.user.update({ administeredSchools: [this.school] });
       await page.visit({ courseId: this.course1.id, details: true });
+      await percySnapshot(assert);
       assert.strictEqual(currentRouteName(), 'course.index');
 
       assert.strictEqual(page.details.learningMaterials.current.length, 1);

--- a/tests/acceptance/course/mesh-test.js
+++ b/tests/acceptance/course/mesh-test.js
@@ -3,6 +3,7 @@ import { setupAuthentication } from 'ilios-common';
 
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/course';
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | Course - Mesh Terms', function (hooks) {
   setupApplicationTest(hooks);
@@ -36,6 +37,7 @@ module('Acceptance | Course - Mesh Terms', function (hooks) {
   test('list mesh', async function (assert) {
     assert.expect(4);
     await page.visit({ courseId: this.course.id, details: true });
+    await percySnapshot(assert);
     assert.strictEqual(page.details.meshTerms.current.length, 3);
     assert.strictEqual(page.details.meshTerms.current[0].title, 'descriptor 0');
     assert.strictEqual(page.details.meshTerms.current[1].title, 'descriptor 1');
@@ -46,6 +48,7 @@ module('Acceptance | Course - Mesh Terms', function (hooks) {
     assert.expect(24);
     this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, details: true });
+    await percySnapshot(assert);
     assert.strictEqual(page.details.meshTerms.current.length, 3);
     await page.details.meshTerms.manage();
     assert.strictEqual(page.details.meshTerms.meshManager.selectedTerms.length, 3);

--- a/tests/acceptance/course/objectivecreate-test.js
+++ b/tests/acceptance/course/objectivecreate-test.js
@@ -2,6 +2,8 @@ import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/course';
+import percySnapshot from '@percy/ember';
+
 module('Acceptance | Course - Objective Create', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
@@ -28,6 +30,7 @@ module('Acceptance | Course - Objective Create', function (hooks) {
       details: true,
       courseObjectiveDetails: true,
     });
+    await percySnapshot(assert);
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 1);
     assert.strictEqual(
       page.details.objectives.objectiveList.objectives[0].description.text,

--- a/tests/acceptance/course/objectivelist-test.js
+++ b/tests/acceptance/course/objectivelist-test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/course';
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | Course - Objective List', function (hooks) {
   setupApplicationTest(hooks);
@@ -51,6 +52,7 @@ module('Acceptance | Course - Objective List', function (hooks) {
       details: true,
       courseObjectiveDetails: true,
     });
+    await percySnapshot(assert);
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 13);
 
     assert.strictEqual(

--- a/tests/acceptance/course/objectiveparents-allow-multiple-test.js
+++ b/tests/acceptance/course/objectiveparents-allow-multiple-test.js
@@ -3,6 +3,7 @@ import { setupAuthentication } from 'ilios-common';
 
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/course';
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | Course - Multiple Objective  Parents', function (hooks) {
   setupApplicationTest(hooks);
@@ -47,6 +48,7 @@ module('Acceptance | Course - Multiple Objective  Parents', function (hooks) {
       details: true,
       courseObjectiveDetails: true,
     });
+    await percySnapshot(assert);
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 1);
 
     assert.strictEqual(

--- a/tests/acceptance/course/objectiveparents-test.js
+++ b/tests/acceptance/course/objectiveparents-test.js
@@ -3,6 +3,7 @@ import { setupAuthentication } from 'ilios-common';
 
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/course';
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | Course - Objective Parents', function (hooks) {
   setupApplicationTest(hooks);
@@ -53,6 +54,7 @@ module('Acceptance | Course - Objective Parents', function (hooks) {
       details: true,
       courseObjectiveDetails: true,
     });
+    await percySnapshot(assert);
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 2);
 
     assert.strictEqual(

--- a/tests/acceptance/course/objectiveterms-test.js
+++ b/tests/acceptance/course/objectiveterms-test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/course';
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | Course - Objective Vocabulary Terms', function (hooks) {
   setupApplicationTest(hooks);
@@ -32,6 +33,7 @@ module('Acceptance | Course - Objective Vocabulary Terms', function (hooks) {
       details: true,
       courseObjectiveDetails: true,
     });
+    await percySnapshot(assert);
     assert.strictEqual(
       page.details.objectives.objectiveList.objectives[0].selectedTerms.list.length,
       1

--- a/tests/acceptance/course/overview-test.js
+++ b/tests/acceptance/course/overview-test.js
@@ -5,6 +5,7 @@ import { setupAuthentication } from 'ilios-common';
 import { t } from 'ember-intl/test-support';
 import page from 'ilios-common/page-objects/course';
 import { DateTime } from 'luxon';
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | Course - Overview', function (hooks) {
   setupApplicationTest(hooks);
@@ -33,6 +34,7 @@ module('Acceptance | Course - Overview', function (hooks) {
     });
 
     test('collapsed', async function (assert) {
+      assert.expect(6);
       const courseModel = await this.owner
         .lookup('service:store')
         .findRecord('course', this.course.id);
@@ -40,6 +42,7 @@ module('Acceptance | Course - Overview', function (hooks) {
         .lookup('service:store')
         .findRecord('courseClerkshipType', this.clerkshipType.id);
       await page.visit({ courseId: courseModel.id });
+      await percySnapshot(assert);
       assert.strictEqual(
         page.details.overview.startDate.text,
         'Start: ' + this.intl.formatDate(courseModel.startDate)
@@ -58,6 +61,7 @@ module('Acceptance | Course - Overview', function (hooks) {
     });
 
     test('expanded', async function (assert) {
+      assert.expect(6);
       const courseModel = await this.owner
         .lookup('service:store')
         .findRecord('course', this.course.id);
@@ -65,6 +69,7 @@ module('Acceptance | Course - Overview', function (hooks) {
         .lookup('service:store')
         .findRecord('courseClerkshipType', this.clerkshipType.id);
       await page.visit({ courseId: courseModel.id, details: true });
+      await percySnapshot(assert);
       assert.strictEqual(
         page.details.overview.startDate.text,
         'Start: ' + this.intl.formatDate(courseModel.startDate)
@@ -83,16 +88,20 @@ module('Acceptance | Course - Overview', function (hooks) {
     });
 
     test('open and close details', async function (assert) {
+      assert.expect(6);
       const courseModel = await this.owner
         .lookup('service:store')
         .findRecord('course', this.course.id);
       await page.visit({ courseId: courseModel.id });
+      await percySnapshot(assert);
       assert.strictEqual(page.details.titles, 2);
       assert.strictEqual(currentURL(), '/courses/1');
       await page.details.collapseControl();
+      await percySnapshot(assert);
       assert.ok(page.details.titles > 2);
       assert.strictEqual(currentURL(), '/courses/1?details=true');
       await page.details.collapseControl();
+      await percySnapshot(assert);
       assert.strictEqual(page.details.titles, 2);
       assert.strictEqual(currentURL(), '/courses/1');
     });

--- a/tests/acceptance/course/printcourse-test.js
+++ b/tests/acceptance/course/printcourse-test.js
@@ -2,6 +2,7 @@ import { find, findAll, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'dummy/tests/helpers';
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | Course - Print Course', function (hooks) {
   setupApplicationTest(hooks);
@@ -58,8 +59,10 @@ module('Acceptance | Course - Print Course', function (hooks) {
   });
 
   test('print course header', async function (assert) {
+    assert.expect(2);
     await setupAuthentication({ school: this.school });
     await visit('/course/1/print');
+    await percySnapshot(assert);
     assert.dom('[data-test-course-header] [data-test-course-title]').hasText('Back to the Future');
     assert.dom('[data-test-course-header] [data-test-course-year]').hasText('2013');
   });

--- a/tests/acceptance/course/publicationcheck-test.js
+++ b/tests/acceptance/course/publicationcheck-test.js
@@ -3,6 +3,7 @@ import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/course-publication-check';
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | Course - Publication Check', function (hooks) {
   setupApplicationTest(hooks);
@@ -40,7 +41,9 @@ module('Acceptance | Course - Publication Check', function (hooks) {
   });
 
   test('full course count', async function (assert) {
+    assert.expect(6);
     await page.visit({ courseId: this.fullCourse.id });
+    await percySnapshot(assert);
     assert.strictEqual(currentRouteName(), 'course.publication_check');
     assert.strictEqual(page.publicationcheck.courseTitle, 'course 0');
     assert.strictEqual(page.publicationcheck.cohorts, 'Yes (1)');

--- a/tests/acceptance/course/session/ilm-test.js
+++ b/tests/acceptance/course/session/ilm-test.js
@@ -3,6 +3,7 @@ import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/session';
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | Session - Independent Learning', function (hooks) {
   setupApplicationTest(hooks);
@@ -27,11 +28,14 @@ module('Acceptance | Session - Independent Learning', function (hooks) {
   });
 
   test('initial selected instructors', async function (assert) {
+    assert.expect(18);
     await page.visit({
       courseId: 1,
       sessionId: 1,
       sessionLearnergroupDetails: true,
     });
+    await percySnapshot(assert);
+
     assert.strictEqual(currentRouteName(), 'session.index');
     assert.strictEqual(page.details.instructors.title, 'Instructors and Instructor Groups (3/3)');
 

--- a/tests/acceptance/course/session/leadership-test.js
+++ b/tests/acceptance/course/session/leadership-test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import { setupAuthentication } from 'ilios-common';
 import page from 'ilios-common/page-objects/session';
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | Session - Leadership', function (hooks) {
   setupApplicationTest(hooks);
@@ -30,6 +31,7 @@ module('Acceptance | Session - Leadership', function (hooks) {
   test('collapsed leadership', async function (assert) {
     assert.expect(8);
     await page.visit({ courseId: 1, sessionId: 1 });
+    await percySnapshot(assert);
 
     assert.strictEqual(page.details.leadershipCollapsed.title, 'Session Leadership');
     assert.strictEqual(page.details.leadershipCollapsed.headers.length, 1);

--- a/tests/acceptance/course/session/learner-groups-test.js
+++ b/tests/acceptance/course/session/learner-groups-test.js
@@ -3,6 +3,7 @@ import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/session';
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | Session - Learner Groups', function (hooks) {
   setupApplicationTest(hooks);
@@ -50,6 +51,7 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
     });
 
     test('initial selected learner groups', async function (assert) {
+      assert.expect(10);
       this.server.create('ilmSession', {
         sessionId: 1,
         learnerGroupIds: [1, 2, 4],
@@ -57,6 +59,7 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
       });
 
       await page.visit({ courseId: 1, sessionId: 1 });
+      await percySnapshot(assert);
 
       assert.strictEqual(currentRouteName(), 'session.index');
       const { selectedLearners, selectedLearnerGroups } =

--- a/tests/acceptance/course/session/learningmaterials-test.js
+++ b/tests/acceptance/course/session/learningmaterials-test.js
@@ -6,6 +6,7 @@ import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/session';
 
 const today = DateTime.fromObject({ hour: 8 });
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | Session - Learning Materials', function (hooks) {
   setupApplicationTest(hooks);
@@ -106,7 +107,9 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
     });
 
     test('list learning materials', async function (assert) {
+      assert.expect(39);
       await page.visit({ courseId: 1, sessionId: 1 });
+      await percySnapshot(assert);
       assert.strictEqual(currentRouteName(), 'session.index');
 
       assert.strictEqual(page.details.learningMaterials.current.length, 4);
@@ -850,7 +853,9 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
     });
 
     test('list learning materials', async function (assert) {
+      assert.expect(10);
       await page.visit({ courseId: 1, sessionId: 1 });
+      await percySnapshot(assert);
       assert.strictEqual(currentRouteName(), 'session.index');
 
       assert.strictEqual(page.details.learningMaterials.current.length, 1);

--- a/tests/acceptance/course/session/mesh-test.js
+++ b/tests/acceptance/course/session/mesh-test.js
@@ -3,6 +3,7 @@ import { setupAuthentication } from 'ilios-common';
 
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/session';
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | Session - Mesh Terms', function (hooks) {
   setupApplicationTest(hooks);
@@ -39,6 +40,7 @@ module('Acceptance | Session - Mesh Terms', function (hooks) {
   test('list mesh', async function (assert) {
     assert.expect(4);
     await page.visit({ courseId: 1, sessionId: 1 });
+    await percySnapshot(assert);
     assert.strictEqual(page.details.meshTerms.current.length, 3);
     assert.strictEqual(page.details.meshTerms.current[0].title, 'descriptor 0');
     assert.strictEqual(page.details.meshTerms.current[1].title, 'descriptor 1');

--- a/tests/acceptance/course/session/objectivelist-test.js
+++ b/tests/acceptance/course/session/objectivelist-test.js
@@ -3,6 +3,7 @@ import { setupAuthentication } from 'ilios-common';
 
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/session';
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | Session - Objective List', function (hooks) {
   setupApplicationTest(hooks);
@@ -48,6 +49,7 @@ module('Acceptance | Session - Objective List', function (hooks) {
       sessionId: 1,
       sessionObjectiveDetails: true,
     });
+    await percySnapshot(assert);
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 13);
 
     assert.strictEqual(

--- a/tests/acceptance/course/session/objectiveparents-test.js
+++ b/tests/acceptance/course/session/objectiveparents-test.js
@@ -3,6 +3,7 @@ import { setupAuthentication } from 'ilios-common';
 
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/session';
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | Session - Objective Parents', function (hooks) {
   setupApplicationTest(hooks);
@@ -33,6 +34,7 @@ module('Acceptance | Session - Objective Parents', function (hooks) {
       sessionId: 1,
       sessionObjectiveDetails: true,
     });
+    await percySnapshot(assert);
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 2);
 
     assert.strictEqual(

--- a/tests/acceptance/course/session/objectiveterms-test.js
+++ b/tests/acceptance/course/session/objectiveterms-test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/session';
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | Session - Objective Vocabulary Terms', function (hooks) {
   setupApplicationTest(hooks);
@@ -33,6 +34,7 @@ module('Acceptance | Session - Objective Vocabulary Terms', function (hooks) {
       sessionId: 1,
       sessionObjectiveDetails: true,
     });
+    await percySnapshot(assert);
     assert.strictEqual(
       page.details.objectives.objectiveList.objectives[0].selectedTerms.list.length,
       1

--- a/tests/acceptance/course/session/offerings-test.js
+++ b/tests/acceptance/course/session/offerings-test.js
@@ -3,6 +3,7 @@ import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/session';
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | Session - Offerings', function (hooks) {
   setupApplicationTest(hooks);
@@ -78,6 +79,7 @@ module('Acceptance | Session - Offerings', function (hooks) {
   test('basics', async function (assert) {
     assert.expect(2);
     await page.visit({ courseId: 1, sessionId: 1 });
+    await percySnapshot(assert);
 
     assert.strictEqual(page.details.offerings.header.title, 'Offerings (3)');
     assert.strictEqual(page.details.offerings.dateBlocks.length, 3);

--- a/tests/acceptance/course/session/overview-test.js
+++ b/tests/acceptance/course/session/overview-test.js
@@ -5,6 +5,7 @@ import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import { enableFeature } from 'ember-feature-flags/test-support';
 import page from 'ilios-common/page-objects/session';
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | Session - Overview', function (hooks) {
   setupApplicationTest(hooks);
@@ -20,6 +21,7 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('check fields', async function (assert) {
+    assert.expect(4);
     await setupAuthentication({
       school: this.school,
       administeredSchools: [this.school],
@@ -30,6 +32,7 @@ module('Acceptance | Session - Overview', function (hooks) {
       instructionalNotes: 'session notes',
     });
     await page.visit({ courseId: 1, sessionId: 1 });
+    await percySnapshot(assert);
     assert.strictEqual(page.details.overview.sessionType.value, 'session type 0');
     assert.strictEqual(page.details.overview.sessionDescription.value, session.description);
     assert.strictEqual(page.details.overview.instructionalNotes.value, 'session notes');

--- a/tests/acceptance/course/session/publicationcheck-test.js
+++ b/tests/acceptance/course/session/publicationcheck-test.js
@@ -3,6 +3,7 @@ import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/session-publication-check';
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | Session - Publication Check', function (hooks) {
   setupApplicationTest(hooks);
@@ -21,6 +22,7 @@ module('Acceptance | Session - Publication Check', function (hooks) {
   });
 
   test('full session count', async function (assert) {
+    assert.expect(6);
     const session = this.server.create('session', {
       course: this.course,
       terms: [this.term],
@@ -30,6 +32,7 @@ module('Acceptance | Session - Publication Check', function (hooks) {
     this.server.create('sessionObjective', { session });
     this.server.create('offering', { session });
     await page.visit({ courseId: this.course.id, sessionId: session.id });
+    await percySnapshot(assert);
     assert.strictEqual(currentRouteName(), 'session.publication_check');
     assert.strictEqual(page.sessionTitle, 'session 0');
     assert.strictEqual(page.offerings, 'Yes (1)');

--- a/tests/acceptance/course/session/publish-test.js
+++ b/tests/acceptance/course/session/publish-test.js
@@ -4,6 +4,7 @@ import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/session';
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | Session - Publish', function (hooks) {
   setupApplicationTest(hooks);
@@ -50,7 +51,9 @@ module('Acceptance | Session - Publish', function (hooks) {
   });
 
   test('check published session', async function (assert) {
+    assert.expect(6);
     await page.visit({ courseId: this.course.id, sessionId: this.publishedSession.id });
+    await percySnapshot(assert);
     assert.strictEqual(currentRouteName(), 'session.index');
     assert.strictEqual(page.details.overview.publicationMenu.toggle.text, 'Published');
     await page.details.overview.publicationMenu.toggle.click();

--- a/tests/acceptance/course/session/terms-test.js
+++ b/tests/acceptance/course/session/terms-test.js
@@ -3,6 +3,7 @@ import { setupAuthentication } from 'ilios-common';
 
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/session';
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | Session - Terms', function (hooks) {
   setupApplicationTest(hooks);
@@ -37,6 +38,7 @@ module('Acceptance | Session - Terms', function (hooks) {
   test('taxonomy summary', async function (assert) {
     assert.expect(9);
     await page.visit({ courseId: 1, sessionId: 1 });
+    await percySnapshot(assert);
     assert.strictEqual(page.details.collapsedTaxonomies.title, 'Terms (1)');
     assert.strictEqual(page.details.collapsedTaxonomies.headers.length, 3);
     assert.strictEqual(page.details.collapsedTaxonomies.headers[0].title, 'Vocabulary');

--- a/tests/acceptance/course/sessionlist-test.js
+++ b/tests/acceptance/course/sessionlist-test.js
@@ -7,6 +7,8 @@ import page from 'ilios-common/page-objects/sessions';
 import sessionPage from 'ilios-common/page-objects/session';
 
 const today = DateTime.fromObject({ hour: 8 });
+import percySnapshot from '@percy/ember';
+
 module('Acceptance | Course - Session List', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
@@ -74,7 +76,9 @@ module('Acceptance | Course - Session List', function (hooks) {
   });
 
   test('session list', async function (assert) {
+    assert.expect(37);
     await page.visit({ courseId: this.course.id, details: true });
+    await percySnapshot(assert);
     const { sessions } = page.courseSessions.sessionsGrid;
 
     assert.strictEqual(sessions.length, 4);
@@ -129,7 +133,9 @@ module('Acceptance | Course - Session List', function (hooks) {
   });
 
   test('expanded offering', async function (assert) {
+    assert.expect(24);
     await page.visit({ courseId: this.course.id, details: true });
+    await percySnapshot(assert);
     const { sessions } = page.courseSessions.sessionsGrid;
 
     assert.strictEqual(sessions.length, 4);
@@ -170,7 +176,9 @@ module('Acceptance | Course - Session List', function (hooks) {
   });
 
   test('no offerings', async function (assert) {
+    assert.expect(8);
     await page.visit({ courseId: this.course.id, details: true });
+    await percySnapshot(assert);
     const { sessions } = page.courseSessions.sessionsGrid;
 
     assert.strictEqual(sessions.length, 4);
@@ -206,6 +214,7 @@ module('Acceptance | Course - Session List', function (hooks) {
   });
 
   test('expand all sessions', async function (assert) {
+    assert.expect(7);
     this.server.create('offering', { session: this.session2 });
     this.server.create('offering', { session: this.session3 });
     this.server.create('offering', { session: this.session4 });
@@ -215,9 +224,11 @@ module('Acceptance | Course - Session List', function (hooks) {
     assert.strictEqual(expandedSessions.length, 0);
     assert.notOk(page.courseSessions.sessionsGridHeader.expandCollapse.allAreExpanded);
     await page.courseSessions.sessionsGridHeader.expandCollapse.toggle.click();
+    await percySnapshot(assert);
     assert.strictEqual(expandedSessions.length, 4);
     assert.ok(page.courseSessions.sessionsGridHeader.expandCollapse.allAreExpanded);
     await page.courseSessions.sessionsGridHeader.expandCollapse.toggle.click();
+    await percySnapshot(assert);
     assert.strictEqual(expandedSessions.length, 0);
     assert.notOk(page.courseSessions.sessionsGridHeader.expandCollapse.allAreExpanded);
   });

--- a/tests/acceptance/course/terms-test.js
+++ b/tests/acceptance/course/terms-test.js
@@ -3,6 +3,7 @@ import { setupAuthentication } from 'ilios-common';
 
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/course';
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | Course - Terms', function (hooks) {
   setupApplicationTest(hooks);
@@ -34,6 +35,7 @@ module('Acceptance | Course - Terms', function (hooks) {
   test('taxonomy summary', async function (assert) {
     assert.expect(9);
     await page.visit({ courseId: this.course.id, details: true });
+    await percySnapshot(assert);
     assert.strictEqual(
       page.details.collapsedTaxonomies.title,
       'Terms (' + this.course.terms.length + ')'
@@ -73,6 +75,7 @@ module('Acceptance | Course - Terms', function (hooks) {
       details: true,
       courseTaxonomyDetails: true,
     });
+    await percySnapshot(assert);
     assert.strictEqual(page.details.taxonomies.vocabularies.length, 1);
     await page.details.taxonomies.manage();
 

--- a/tests/acceptance/dashboard/calendar-test.js
+++ b/tests/acceptance/dashboard/calendar-test.js
@@ -15,6 +15,7 @@ import { setupApplicationTest } from 'dummy/tests/helpers';
 import { map } from 'rsvp';
 import page from 'ilios-common/page-objects/dashboard-calendar';
 import { freezeDateAt, unfreezeDate } from 'ilios-common';
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | Dashboard Calendar', function (hooks) {
   setupApplicationTest(hooks);
@@ -91,6 +92,7 @@ module('Acceptance | Dashboard Calendar', function (hooks) {
   });
 
   test('load month calendar', async function (assert) {
+    assert.expect(4);
     const today = DateTime.fromObject({ hour: 8, minute: 8, second: 8 });
     const startOfMonth = today.startOf('month');
     const endOfMonth = today.endOf('month').set({ hour: 22, minute: 59 });
@@ -109,6 +111,7 @@ module('Acceptance | Dashboard Calendar', function (hooks) {
       lastModified: today.minus({ year: 1 }),
     });
     await visit('/dashboard/calendar?view=month');
+    await percySnapshot(assert);
     assert.strictEqual(currentRouteName(), 'dashboard.calendar');
     const events = findAll('[data-test-ilios-calendar-event]');
     assert.strictEqual(events.length, 2);
@@ -137,6 +140,7 @@ module('Acceptance | Dashboard Calendar', function (hooks) {
   });
 
   test('load week calendar', async function (assert) {
+    assert.expect(9);
     const startOfWeek = DateTime.fromJSDate(
       this.owner.lookup('service:locale-days').firstDayOfThisWeek
     );
@@ -166,6 +170,7 @@ module('Acceptance | Dashboard Calendar', function (hooks) {
       lastModified: DateTime.now().minus({ year: 1 }),
     });
     await page.visit({ show: 'calendar' });
+    await percySnapshot(assert);
     assert.strictEqual(currentRouteName(), 'dashboard.calendar');
 
     assert.strictEqual(page.calendar.weeklyCalendar.dayHeadings.length, 7);
@@ -183,6 +188,7 @@ module('Acceptance | Dashboard Calendar', function (hooks) {
   });
 
   test('load week calendar on Sunday', async function (assert) {
+    assert.expect(10);
     freezeDateAt(
       DateTime.fromObject({
         year: 2022,
@@ -220,6 +226,7 @@ module('Acceptance | Dashboard Calendar', function (hooks) {
       lastModified: DateTime.now().minus({ year: 1 }),
     });
     await page.visit({ show: 'calendar' });
+    await percySnapshot(assert);
     assert.strictEqual(currentRouteName(), 'dashboard.calendar');
 
     assert.strictEqual(page.calendar.weeklyCalendar.dayHeadings.length, 7);
@@ -238,6 +245,7 @@ module('Acceptance | Dashboard Calendar', function (hooks) {
   });
 
   test('load day calendar', async function (assert) {
+    assert.expect(3);
     const today = DateTime.fromObject({ hour: 8, minute: 8, second: 8 });
     const tomorow = today.plus({ day: 1 });
     const yesterday = today.minus({ day: 1 });
@@ -263,6 +271,7 @@ module('Acceptance | Dashboard Calendar', function (hooks) {
       lastModified: today.minus({ year: 1 }),
     });
     await visit('/dashboard/calendar?view=day');
+    await percySnapshot(assert);
     assert.strictEqual(currentRouteName(), 'dashboard.calendar');
 
     assert.strictEqual(page.calendar.dailyCalendar.events.length, 1);
@@ -406,6 +415,7 @@ module('Acceptance | Dashboard Calendar', function (hooks) {
   });
 
   test('show user events', async function (assert) {
+    assert.expect(1);
     const today = DateTime.fromObject({ hour: 8, minute: 8, second: 8 });
     this.server.create('userevent', {
       user: this.user.id,
@@ -420,6 +430,7 @@ module('Acceptance | Dashboard Calendar', function (hooks) {
       offering: 2,
     });
     await page.visit({ show: 'calendar' });
+    await percySnapshot(assert);
     assert.strictEqual(page.calendar.weeklyCalendar.events.length, 2);
   });
 
@@ -427,6 +438,7 @@ module('Acceptance | Dashboard Calendar', function (hooks) {
     return await click(find(findAll('.togglemyschedule label')[1]));
   };
   test('show school events', async function (assert) {
+    assert.expect(1);
     const today = DateTime.fromObject({ hour: 8, minute: 8, second: 8 });
     this.server.create('schoolevent', {
       school: 1,
@@ -442,6 +454,7 @@ module('Acceptance | Dashboard Calendar', function (hooks) {
     });
     await page.visit();
     await chooseSchoolEvents();
+    await percySnapshot(assert);
     assert.strictEqual(page.calendar.weeklyCalendar.events.length, 2);
   });
 
@@ -626,6 +639,7 @@ module('Acceptance | Dashboard Calendar', function (hooks) {
   });
 
   test('clear all filters', async function (assert) {
+    assert.expect(9);
     const vocabulary = this.server.create('vocabulary', {
       school: this.school,
     });
@@ -650,8 +664,10 @@ module('Acceptance | Dashboard Calendar', function (hooks) {
     assert.dom(sessiontype).isChecked('filter is checked');
     assert.dom(course).isChecked('filter is checked');
     assert.dom(term).isChecked('filter is checked');
+    await percySnapshot(assert);
 
     await click(clearFilter);
+    await percySnapshot(assert);
     assert.ok(isEmpty(find(clearFilter)), 'clear filter button is inactive');
     assert.dom(sessiontype).isNotChecked('filter is unchecked');
     assert.dom(course).isNotChecked('filter is unchecked');
@@ -735,6 +751,7 @@ module('Acceptance | Dashboard Calendar', function (hooks) {
   });
 
   test('week summary displays the whole week', async function (assert) {
+    assert.expect(3);
     const startOfTheWeek = DateTime.fromJSDate(
       this.owner.lookup('service:locale-days').firstDayOfThisWeek
     ).set({ minute: 2 });
@@ -760,6 +777,7 @@ module('Acceptance | Dashboard Calendar', function (hooks) {
     const events = `${dashboard} .event`;
 
     await visit('/dashboard/week');
+    await percySnapshot(assert);
 
     const eventBLocks = findAll(events);
     assert.strictEqual(eventBLocks.length, 2);
@@ -851,6 +869,7 @@ module('Acceptance | Dashboard Calendar', function (hooks) {
   });
 
   test('test tooltip', async function (assert) {
+    assert.expect(1);
     const today = DateTime.fromObject({ hour: 8, minute: 8, second: 8 });
     this.server.create('userevent', {
       user: this.user.id,
@@ -860,6 +879,7 @@ module('Acceptance | Dashboard Calendar', function (hooks) {
     });
     await page.visit({ show: 'calendar', view: 'week' });
     await triggerEvent('[data-test-weekly-calendar-event]', 'mouseover');
+    await percySnapshot(assert);
     assert.dom('[data-test-ilios-calendar-event-tooltip]').exists();
   });
 

--- a/tests/acceptance/dashboard/materials-test.js
+++ b/tests/acceptance/dashboard/materials-test.js
@@ -4,6 +4,7 @@ import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import page from 'ilios-common/page-objects/dashboard-materials';
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | Dashboard Materials', function (hooks) {
   setupApplicationTest(hooks);
@@ -156,6 +157,7 @@ module('Acceptance | Dashboard Materials', function (hooks) {
       };
     });
     await page.visit();
+    await percySnapshot(assert);
     assert.ok(page.materials.dashboardViewPicker.materials.isActive);
     assert.notOk(page.materials.dashboardViewPicker.calendar.isActive);
     assert.notOk(page.materials.dashboardViewPicker.week.isActive);
@@ -301,6 +303,7 @@ module('Acceptance | Dashboard Materials', function (hooks) {
     });
 
     await page.visit({ showAll: true });
+    await percySnapshot(assert);
     assert.ok(page.materials.dashboardViewPicker.isVisible);
     assert.ok(page.materials.header.displayToggle.secondButton.isChecked);
     assert.strictEqual(page.materials.courseFilter.options.length, 6);
@@ -519,12 +522,14 @@ module('Acceptance | Dashboard Materials', function (hooks) {
   });
 
   test('mark material status', async function (assert) {
+    assert.expect(13);
     this.server.get(`/api/usermaterials/:id`, () => {
       return {
         userMaterials: this.currentMaterials,
       };
     });
     await page.visit();
+    await percySnapshot(assert);
 
     const materials = page.materials.table.rows;
     assert.strictEqual(materials.length, 6);
@@ -541,6 +546,7 @@ module('Acceptance | Dashboard Materials', function (hooks) {
     await materials[4].status.click();
     await materials[4].status.click();
     await materials[5].status.click();
+    await percySnapshot(assert);
 
     assert.ok(materials[0].status.isChecked);
     assert.notOk(materials[1].status.isChecked);

--- a/tests/acceptance/dashboard/waag-test.js
+++ b/tests/acceptance/dashboard/waag-test.js
@@ -5,6 +5,7 @@ import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/dashboard-week';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | Dashboard Week at a Glance', function (hooks) {
   setupApplicationTest(hooks);
@@ -16,6 +17,7 @@ module('Acceptance | Dashboard Week at a Glance', function (hooks) {
   });
 
   test('shows events', async function (assert) {
+    assert.expect(4);
     const { firstDayOfThisWeek, lastDayOfThisWeek } = this.owner.lookup('service:locale-days');
     const startOfWeek = DateTime.fromJSDate(firstDayOfThisWeek);
     const endOfWeek = DateTime.fromJSDate(lastDayOfThisWeek);
@@ -39,6 +41,7 @@ module('Acceptance | Dashboard Week at a Glance', function (hooks) {
       offering: 2,
     });
     await page.visit({ show: 'week' });
+    await percySnapshot(assert);
     assert.strictEqual(currentRouteName(), 'dashboard.week');
 
     assert.strictEqual(page.week.weekGlance.events.length, 2);
@@ -47,6 +50,7 @@ module('Acceptance | Dashboard Week at a Glance', function (hooks) {
   });
 
   test('shows all pre work', async function (assert) {
+    assert.expect(13);
     const prerequisites = [1, 2, 3].map((id) => {
       return {
         user: Number(this.user.id),
@@ -90,6 +94,7 @@ module('Acceptance | Dashboard Week at a Glance', function (hooks) {
       prerequisites,
     });
     await page.visit();
+    await percySnapshot(assert);
     assert.strictEqual(currentRouteName(), 'dashboard.week');
 
     assert.strictEqual(page.week.weekGlance.events.length, 1);


### PR DESCRIPTION
Adding percy visual diffs to many of our tests in order to catch regressions that make ilios ugly. I could not find a way to protect the percy write only token and still allow tests to run from forks so I've added the token directly to the yaml in the same way we do on our simple charts runs.

I'm not sure if I'm over or under running percy here, we'll have to fine tune how many snapshots and where to take them as time goes on.