### PR TITLE
Update Ember Simple Auth to v6 RC 1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,6 @@
         "ember-modifier": "^4.0.0",
         "ember-moment": "^10.0.0",
         "ember-promise-helpers": "2.0.0",
-        "ember-simple-auth": "^6.0.0-rc.1",
         "ember-simple-auth-token": "^5.0.0",
         "ember-simple-charts": "^10.3.0",
         "ember-test-selectors": "^6.0.0",
@@ -126,7 +125,7 @@
       },
       "engines": {
         "node": "16.* || >= 18",
-        "npm": ">= 8"
+        "npm": ">= 8.3"
       },
       "peerDependencies": {
         "@fortawesome/free-brands-svg-icons": "6.4.0",
@@ -3597,20 +3596,20 @@
       }
     },
     "node_modules/@percy/cli": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.24.1.tgz",
-      "integrity": "sha512-sbQUcUW0uz/JDQDcH/UpTAPIt/wx8G855tVufdS6kazWaLMpcFfbXNxh/xuTr4wUgdB0ERLp4P91oCQqNYXR9g==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.24.2.tgz",
+      "integrity": "sha512-FFD6V0LOztEs58DmnSYOoh36ZCl9P0s9UVe/bhkyvN2aUR/3XYAxzFAjgkPgP/v66fEIc4vfpvLVnSeozKZdIg==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-app": "1.24.1",
-        "@percy/cli-build": "1.24.1",
-        "@percy/cli-command": "1.24.1",
-        "@percy/cli-config": "1.24.1",
-        "@percy/cli-exec": "1.24.1",
-        "@percy/cli-snapshot": "1.24.1",
-        "@percy/cli-upload": "1.24.1",
-        "@percy/client": "1.24.1",
-        "@percy/logger": "1.24.1"
+        "@percy/cli-app": "1.24.2",
+        "@percy/cli-build": "1.24.2",
+        "@percy/cli-command": "1.24.2",
+        "@percy/cli-config": "1.24.2",
+        "@percy/cli-exec": "1.24.2",
+        "@percy/cli-snapshot": "1.24.2",
+        "@percy/cli-upload": "1.24.2",
+        "@percy/client": "1.24.2",
+        "@percy/logger": "1.24.2"
       },
       "bin": {
         "percy": "bin/run.cjs"
@@ -3620,39 +3619,39 @@
       }
     },
     "node_modules/@percy/cli-app": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@percy/cli-app/-/cli-app-1.24.1.tgz",
-      "integrity": "sha512-LFgPfVFY487U43D/TkGyF4My6Urym/jQcYYmglzTUFLITan/a9ICiVyyK/CL1dS74CUjWbtFPAfs4glez3qewA==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-app/-/cli-app-1.24.2.tgz",
+      "integrity": "sha512-OFSKEFILXBbLUylaYdQMWpgcV1YbRuXUiXrLDn6k6yNXzn5KlN/5UWhukvf4xgjmoZu61tOj71J0pKnxWKFvRw==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-command": "1.24.1",
-        "@percy/cli-exec": "1.24.1"
+        "@percy/cli-command": "1.24.2",
+        "@percy/cli-exec": "1.24.2"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/cli-build": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.24.1.tgz",
-      "integrity": "sha512-iayHaZOdo5eOkjRHkSeplKqxrElZ/FDOtQSj/u5gU9UHqivgeE/kD0i66yWjuc0WR0B2F8PKbLXsJyv8z82xKg==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.24.2.tgz",
+      "integrity": "sha512-gc+HNPC9zm2PP6Tb71PMB5xKmW6yG0xqgicrHeqpgIAww3IfJHchzntqOP2wLwB7X5DixzuiIhKwr/dwdkkgXw==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-command": "1.24.1"
+        "@percy/cli-command": "1.24.2"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/cli-command": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.24.1.tgz",
-      "integrity": "sha512-R6DAwLYH7o2cSckm3Nn0hIKvyygk5hMMlHenegbGF4Lu7f7p5K1Gtk0feZXw3DitpxEW4UKincr4KDofjRc2cg==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.24.2.tgz",
+      "integrity": "sha512-n0wB7thn768dtgwNAvyibp1UgeqpRqTJKV+j7/2mfQ1QEtI09ABpFzJ4nMQ6/rciv0LkIO85TiKD7vD/MPPzcQ==",
       "dev": true,
       "dependencies": {
-        "@percy/config": "1.24.1",
-        "@percy/core": "1.24.1",
-        "@percy/logger": "1.24.1"
+        "@percy/config": "1.24.2",
+        "@percy/core": "1.24.2",
+        "@percy/logger": "1.24.2"
       },
       "bin": {
         "percy-cli-readme": "bin/readme.js"
@@ -3662,24 +3661,24 @@
       }
     },
     "node_modules/@percy/cli-config": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.24.1.tgz",
-      "integrity": "sha512-8jNxTCRSxKqg1/1vrDw5Xp+5z2G43LNlSDJPM0Eymb5dH6g9yeqxyqkqgxiv1KH5AaQMVJ3Lfcqlzyy5NCI4RQ==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.24.2.tgz",
+      "integrity": "sha512-dt8S96FfQYlvoP1JK+fh9aSTA8BA5qGEcztTZu2tCBTx3DTNwyDIeiuIiCyFJ0+zoZQaq9SjQ8CUAx20bzmPLw==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-command": "1.24.1"
+        "@percy/cli-command": "1.24.2"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/cli-exec": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.24.1.tgz",
-      "integrity": "sha512-3mF0YwVsxrbECBXt2zc54L7AU6W+MSF2zgJtyZaBvyvN57pznvH6ZJGr2ZR4Ck7PiYgF1zZ3N31GlbWmutKCzQ==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.24.2.tgz",
+      "integrity": "sha512-hulbUG/Q/JRnD8Mcx+1cvSDhfl2dcULddj9pnv5VSVMrp/52EkVEEBzH05vB84XVrF+oJpOg224c7n0aMDtJdw==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-command": "1.24.1",
+        "@percy/cli-command": "1.24.2",
         "cross-spawn": "^7.0.3",
         "which": "^2.0.2"
       },
@@ -3688,12 +3687,12 @@
       }
     },
     "node_modules/@percy/cli-snapshot": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.24.1.tgz",
-      "integrity": "sha512-/CzwvPRzMvQj/MiLY8QSrQE27VJvEc0EaG4qaY9iMXgarXa7+jqWzZuqoFYEIks36K7MyBqt5PGyh/g27XN3Fg==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.24.2.tgz",
+      "integrity": "sha512-seGl7kc359Lg+G4YGRu/RNxZGPDxDijp6BwYr51JcO53OJIkrmOXmQ8mgibzRkJxqsxLSNxv5h1ywxySG0uyYA==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-command": "1.24.1",
+        "@percy/cli-command": "1.24.2",
         "yaml": "^2.0.0"
       },
       "engines": {
@@ -3701,12 +3700,12 @@
       }
     },
     "node_modules/@percy/cli-upload": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.24.1.tgz",
-      "integrity": "sha512-P1ypjUAge01HdsRqrkmIeYsEKqQLQZ5xskKMBGc7mjRSPSYMuGLyHSc0p0nGpclCFp59pDzKfvCGnNJ/ZbEiAQ==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.24.2.tgz",
+      "integrity": "sha512-qGDBa+m5OSkctTBdRXP4h4O2Y4DJULz+xSztGju6djGBXBuZRpN88bPvuymhTCQnGa7FIGuUKCfuujLOw6cWsg==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-command": "1.24.1",
+        "@percy/cli-command": "1.24.2",
         "fast-glob": "^3.2.11",
         "image-size": "^1.0.0"
       },
@@ -3715,25 +3714,25 @@
       }
     },
     "node_modules/@percy/client": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.24.1.tgz",
-      "integrity": "sha512-KFxF6JMQKQHmx5cGsAUNDNpIXIwflkAJQb/L+mwbODvT09wkYBNUjw9O5Lde6xKY7tDqOUrbdO81XfvZl6JgRA==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.24.2.tgz",
+      "integrity": "sha512-ey9WGxwlWFPWGgqU+LpaixHFDeczKRD5YzYT0oIZ+q8/2zpodlGDuezM6f+0wNSZpIIZWPwReHuosjkVSXgpfw==",
       "dev": true,
       "dependencies": {
-        "@percy/env": "1.24.1",
-        "@percy/logger": "1.24.1"
+        "@percy/env": "1.24.2",
+        "@percy/logger": "1.24.2"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/config": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.24.1.tgz",
-      "integrity": "sha512-SDM59al8dDE05Ivs87khxsPB0S/rIfoLdTWMlM81GKHf5hklmKKB/I2afzUmjIaG564cguIXNtevKOhmbZ7iPQ==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.24.2.tgz",
+      "integrity": "sha512-RD/cORj4dIxtTTsbbPgE2iN23N5XL1FRuVj37R0xcbJbnyPDuFc8TJER9Z4pdeUtfh+E2iG+SRj+OyP28yGjKQ==",
       "dev": true,
       "dependencies": {
-        "@percy/logger": "1.24.1",
+        "@percy/logger": "1.24.2",
         "ajv": "^8.6.2",
         "cosmiconfig": "^8.0.0",
         "yaml": "^2.0.0"
@@ -3743,16 +3742,16 @@
       }
     },
     "node_modules/@percy/core": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.24.1.tgz",
-      "integrity": "sha512-lByp0765X4wnJFeNqjp8+nZBdVIG7/+cz5gBCwfktuZmsYZje8/HCa0agQTjEx5ETvoXyjPKCpI144nqHqvTFg==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.24.2.tgz",
+      "integrity": "sha512-gGzZdVO+/CF7jIUqpXeFzG8AvbSJzZ21duZGrp9I7rD8AQd6PIq/kXjO9QNShoSi+tnC1GvfKw3Gorr3tGhpaw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@percy/client": "1.24.1",
-        "@percy/config": "1.24.1",
-        "@percy/dom": "1.24.1",
-        "@percy/logger": "1.24.1",
+        "@percy/client": "1.24.2",
+        "@percy/config": "1.24.2",
+        "@percy/dom": "1.24.2",
+        "@percy/logger": "1.24.2",
         "content-disposition": "^0.5.4",
         "cross-spawn": "^7.0.3",
         "extract-zip": "^2.0.1",
@@ -3768,9 +3767,9 @@
       }
     },
     "node_modules/@percy/dom": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.24.1.tgz",
-      "integrity": "sha512-wdf0hrQerIhla9vpl0CeOhRBXCAkTWXzIqyrcXxje/rwYXw6PfanYnB48yKCbLyaPY8MRIV5JMP8fxzhJF6Rdg==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.24.2.tgz",
+      "integrity": "sha512-C5nRMpHNGKS8xPflmYJCO2x6870wiR7TagMx+KOiIHfMEx/4LZhwPP4dkVS4WGeCfcKHOhi8BkJnhuSbL7WWDw==",
       "dev": true
     },
     "node_modules/@percy/ember": {
@@ -3787,27 +3786,27 @@
       }
     },
     "node_modules/@percy/env": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.24.1.tgz",
-      "integrity": "sha512-h/KLpK2z2Cw2dR5vHfuItsAlpUBjNJBmwVmlvb/nbdxAh4slz1a2QGzdFiskpU4YMDy6GebpN+cOkPXQcI8SaQ==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.24.2.tgz",
+      "integrity": "sha512-y2uzAF4jojzuBPOaY/TxA5WwvxfXFv4UKlgbVBGWVDwmgG9ZO/ahUqRTyvG4bgC48NNAeckNxKgADQG5oWR6+g==",
       "dev": true,
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/logger": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.24.1.tgz",
-      "integrity": "sha512-dJWGl+tZdPrg4uZglkGaom/1l4Cagruki9ZqsModNvvEN4LoXCbrIBd45GxlNkNhLbUDbvvvpTz1Lqu8wRwB8A==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.24.2.tgz",
+      "integrity": "sha512-wsmDUsY6MOmjE9TvkF/voL1r6btAMxIPggYOE6JIenrUc6ZBxIPZ9SYJWA63w8v4KWsRUOMqPBRCEUy7VpnPEw==",
       "dev": true,
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/sdk-utils": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@percy/sdk-utils/-/sdk-utils-1.24.1.tgz",
-      "integrity": "sha512-8yiziR0/5+1soNmD3IWqVrgF8gPRRqkTQRCLN2l5Wue53a6BOMzrx9gkUp1WFeEEHCA9z0lVnE5eMRYcCkaXgA==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@percy/sdk-utils/-/sdk-utils-1.24.2.tgz",
+      "integrity": "sha512-gjCaWcm43q4ao8NAKjvvo7kR3JU41V6xi2IVF5cvoyOUtXGRgBta+VPh6unGVLwfAoDUj2/lVcSPRdoOSwgJWg==",
       "dev": true,
       "engines": {
         "node": ">=14"
@@ -13891,37 +13890,6 @@
         "node": "8.* || >= 10.*"
       }
     },
-    "node_modules/ember-factory-for-polyfill": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.3.1.tgz",
-      "integrity": "sha512-y3iG2iCzH96lZMTWQw6LWNLAfOmDC4pXKbZP6FxG8lt7GGaNFkZjwsf+Z5GAe7kxfD7UG4lVkF7x37K82rySGA==",
-      "dependencies": {
-        "ember-cli-version-checker": "^2.1.0"
-      },
-      "engines": {
-        "node": "^4.5 || 6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-factory-for-polyfill/node_modules/ember-cli-version-checker": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-      "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-      "dependencies": {
-        "resolve": "^1.3.3",
-        "semver": "^5.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/ember-factory-for-polyfill/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/ember-feature-flags": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/ember-feature-flags/-/ember-feature-flags-6.0.0.tgz",
@@ -14214,38 +14182,6 @@
       },
       "engines": {
         "node": "12.* || 14.* || >= 16"
-      }
-    },
-    "node_modules/ember-getowner-polyfill": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz",
-      "integrity": "sha512-rwGMJgbGzxIAiWYjdpAh04Abvt0s3HuS/VjHzUFhVyVg2pzAuz45B9AzOxYXzkp88vFC7FPaiA4kE8NxNk4A4Q==",
-      "dependencies": {
-        "ember-cli-version-checker": "^2.1.0",
-        "ember-factory-for-polyfill": "^1.3.1"
-      },
-      "engines": {
-        "node": "^4.5 || 6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-getowner-polyfill/node_modules/ember-cli-version-checker": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-      "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-      "dependencies": {
-        "resolve": "^1.3.3",
-        "semver": "^5.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/ember-getowner-polyfill/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/ember-in-element-polyfill": {
@@ -17591,35 +17527,6 @@
         "node": ">=10.*"
       }
     },
-    "node_modules/ember-simple-auth-token/node_modules/ember-cookies": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-0.5.2.tgz",
-      "integrity": "sha512-nZ7oG97kBcO9UHjO95ryABpnVx62Bhxo7lIsBJNmWvFXleILm9DGueiAynzXxuYWWPuKIeeSbYakrS1869tNTw==",
-      "dependencies": {
-        "ember-cli-babel": "^7.1.0",
-        "ember-getowner-polyfill": "^1.1.0 || ^2.0.0"
-      },
-      "engines": {
-        "node": "8.* || 10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-simple-auth-token/node_modules/ember-simple-auth": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ember-simple-auth/-/ember-simple-auth-5.0.0.tgz",
-      "integrity": "sha512-wGf2jTvOKo11jNmWYBIZhgMx32kvAJEMNJNCpbdx0Ak6X+4uzO8l203C5kDH0idZej/2dHgYkcVaEzl2HCVFwA==",
-      "dependencies": {
-        "ember-cli-babel": "^7.20.5",
-        "ember-cli-is-package-missing": "^1.0.0",
-        "ember-cookies": "^0.5.0",
-        "silent-error": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "peerDependencies": {
-        "ember-fetch": "^8.0.1"
-      }
-    },
     "node_modules/ember-simple-charts": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/ember-simple-charts/-/ember-simple-charts-10.3.0.tgz",
@@ -18006,6 +17913,23 @@
       "dev": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/ember-template-lint/node_modules/resolve": {
+      "version": "1.22.3",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.3.tgz",
+      "integrity": "sha512-P8ur/gp/AmbEzjr729bZnLjXK5Z+4P0zhIJgBgzqRih7hL7BOukHGtSTA3ACMY467GRFz3duQsi0bDZdR7DKdw==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.12.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ember-template-lint/node_modules/yocto-queue": {
@@ -19053,9 +18977,9 @@
       "dev": true
     },
     "node_modules/eslint-plugin-ember": {
-      "version": "11.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-ember/-/eslint-plugin-ember-11.6.0.tgz",
-      "integrity": "sha512-M/M63t/Y5yr/yuWUbtUZ/tE5B5A8/+6LOR6fJlXpLZR4XMtN3KueYsuEIDGP6AInmq5tjDPmBXX0wV+FkjQmvA==",
+      "version": "11.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-ember/-/eslint-plugin-ember-11.7.0.tgz",
+      "integrity": "sha512-LZvdGam1/R1suDwjFBcEmzQmd34aKqOD91X1JnJHymdiKUiHEeveW30O/ZTvM0CrTjuibZSh0lLLXH2+4/GdgA==",
       "dev": true,
       "dependencies": {
         "@ember-data/rfc395-data": "^0.0.4",
@@ -26954,11 +26878,11 @@
       "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "node_modules/resolve": {
-      "version": "1.22.3",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.3.tgz",
-      "integrity": "sha512-P8ur/gp/AmbEzjr729bZnLjXK5Z+4P0zhIJgBgzqRih7hL7BOukHGtSTA3ACMY467GRFz3duQsi0bDZdR7DKdw==",
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
       "dependencies": {
-        "is-core-module": "^2.12.0",
+        "is-core-module": "^2.11.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -33885,125 +33809,125 @@
       }
     },
     "@percy/cli": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.24.1.tgz",
-      "integrity": "sha512-sbQUcUW0uz/JDQDcH/UpTAPIt/wx8G855tVufdS6kazWaLMpcFfbXNxh/xuTr4wUgdB0ERLp4P91oCQqNYXR9g==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.24.2.tgz",
+      "integrity": "sha512-FFD6V0LOztEs58DmnSYOoh36ZCl9P0s9UVe/bhkyvN2aUR/3XYAxzFAjgkPgP/v66fEIc4vfpvLVnSeozKZdIg==",
       "dev": true,
       "requires": {
-        "@percy/cli-app": "1.24.1",
-        "@percy/cli-build": "1.24.1",
-        "@percy/cli-command": "1.24.1",
-        "@percy/cli-config": "1.24.1",
-        "@percy/cli-exec": "1.24.1",
-        "@percy/cli-snapshot": "1.24.1",
-        "@percy/cli-upload": "1.24.1",
-        "@percy/client": "1.24.1",
-        "@percy/logger": "1.24.1"
+        "@percy/cli-app": "1.24.2",
+        "@percy/cli-build": "1.24.2",
+        "@percy/cli-command": "1.24.2",
+        "@percy/cli-config": "1.24.2",
+        "@percy/cli-exec": "1.24.2",
+        "@percy/cli-snapshot": "1.24.2",
+        "@percy/cli-upload": "1.24.2",
+        "@percy/client": "1.24.2",
+        "@percy/logger": "1.24.2"
       }
     },
     "@percy/cli-app": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@percy/cli-app/-/cli-app-1.24.1.tgz",
-      "integrity": "sha512-LFgPfVFY487U43D/TkGyF4My6Urym/jQcYYmglzTUFLITan/a9ICiVyyK/CL1dS74CUjWbtFPAfs4glez3qewA==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-app/-/cli-app-1.24.2.tgz",
+      "integrity": "sha512-OFSKEFILXBbLUylaYdQMWpgcV1YbRuXUiXrLDn6k6yNXzn5KlN/5UWhukvf4xgjmoZu61tOj71J0pKnxWKFvRw==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.24.1",
-        "@percy/cli-exec": "1.24.1"
+        "@percy/cli-command": "1.24.2",
+        "@percy/cli-exec": "1.24.2"
       }
     },
     "@percy/cli-build": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.24.1.tgz",
-      "integrity": "sha512-iayHaZOdo5eOkjRHkSeplKqxrElZ/FDOtQSj/u5gU9UHqivgeE/kD0i66yWjuc0WR0B2F8PKbLXsJyv8z82xKg==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.24.2.tgz",
+      "integrity": "sha512-gc+HNPC9zm2PP6Tb71PMB5xKmW6yG0xqgicrHeqpgIAww3IfJHchzntqOP2wLwB7X5DixzuiIhKwr/dwdkkgXw==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.24.1"
+        "@percy/cli-command": "1.24.2"
       }
     },
     "@percy/cli-command": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.24.1.tgz",
-      "integrity": "sha512-R6DAwLYH7o2cSckm3Nn0hIKvyygk5hMMlHenegbGF4Lu7f7p5K1Gtk0feZXw3DitpxEW4UKincr4KDofjRc2cg==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.24.2.tgz",
+      "integrity": "sha512-n0wB7thn768dtgwNAvyibp1UgeqpRqTJKV+j7/2mfQ1QEtI09ABpFzJ4nMQ6/rciv0LkIO85TiKD7vD/MPPzcQ==",
       "dev": true,
       "requires": {
-        "@percy/config": "1.24.1",
-        "@percy/core": "1.24.1",
-        "@percy/logger": "1.24.1"
+        "@percy/config": "1.24.2",
+        "@percy/core": "1.24.2",
+        "@percy/logger": "1.24.2"
       }
     },
     "@percy/cli-config": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.24.1.tgz",
-      "integrity": "sha512-8jNxTCRSxKqg1/1vrDw5Xp+5z2G43LNlSDJPM0Eymb5dH6g9yeqxyqkqgxiv1KH5AaQMVJ3Lfcqlzyy5NCI4RQ==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.24.2.tgz",
+      "integrity": "sha512-dt8S96FfQYlvoP1JK+fh9aSTA8BA5qGEcztTZu2tCBTx3DTNwyDIeiuIiCyFJ0+zoZQaq9SjQ8CUAx20bzmPLw==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.24.1"
+        "@percy/cli-command": "1.24.2"
       }
     },
     "@percy/cli-exec": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.24.1.tgz",
-      "integrity": "sha512-3mF0YwVsxrbECBXt2zc54L7AU6W+MSF2zgJtyZaBvyvN57pznvH6ZJGr2ZR4Ck7PiYgF1zZ3N31GlbWmutKCzQ==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.24.2.tgz",
+      "integrity": "sha512-hulbUG/Q/JRnD8Mcx+1cvSDhfl2dcULddj9pnv5VSVMrp/52EkVEEBzH05vB84XVrF+oJpOg224c7n0aMDtJdw==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.24.1",
+        "@percy/cli-command": "1.24.2",
         "cross-spawn": "^7.0.3",
         "which": "^2.0.2"
       }
     },
     "@percy/cli-snapshot": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.24.1.tgz",
-      "integrity": "sha512-/CzwvPRzMvQj/MiLY8QSrQE27VJvEc0EaG4qaY9iMXgarXa7+jqWzZuqoFYEIks36K7MyBqt5PGyh/g27XN3Fg==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.24.2.tgz",
+      "integrity": "sha512-seGl7kc359Lg+G4YGRu/RNxZGPDxDijp6BwYr51JcO53OJIkrmOXmQ8mgibzRkJxqsxLSNxv5h1ywxySG0uyYA==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.24.1",
+        "@percy/cli-command": "1.24.2",
         "yaml": "^2.0.0"
       }
     },
     "@percy/cli-upload": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.24.1.tgz",
-      "integrity": "sha512-P1ypjUAge01HdsRqrkmIeYsEKqQLQZ5xskKMBGc7mjRSPSYMuGLyHSc0p0nGpclCFp59pDzKfvCGnNJ/ZbEiAQ==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.24.2.tgz",
+      "integrity": "sha512-qGDBa+m5OSkctTBdRXP4h4O2Y4DJULz+xSztGju6djGBXBuZRpN88bPvuymhTCQnGa7FIGuUKCfuujLOw6cWsg==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.24.1",
+        "@percy/cli-command": "1.24.2",
         "fast-glob": "^3.2.11",
         "image-size": "^1.0.0"
       }
     },
     "@percy/client": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.24.1.tgz",
-      "integrity": "sha512-KFxF6JMQKQHmx5cGsAUNDNpIXIwflkAJQb/L+mwbODvT09wkYBNUjw9O5Lde6xKY7tDqOUrbdO81XfvZl6JgRA==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.24.2.tgz",
+      "integrity": "sha512-ey9WGxwlWFPWGgqU+LpaixHFDeczKRD5YzYT0oIZ+q8/2zpodlGDuezM6f+0wNSZpIIZWPwReHuosjkVSXgpfw==",
       "dev": true,
       "requires": {
-        "@percy/env": "1.24.1",
-        "@percy/logger": "1.24.1"
+        "@percy/env": "1.24.2",
+        "@percy/logger": "1.24.2"
       }
     },
     "@percy/config": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.24.1.tgz",
-      "integrity": "sha512-SDM59al8dDE05Ivs87khxsPB0S/rIfoLdTWMlM81GKHf5hklmKKB/I2afzUmjIaG564cguIXNtevKOhmbZ7iPQ==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.24.2.tgz",
+      "integrity": "sha512-RD/cORj4dIxtTTsbbPgE2iN23N5XL1FRuVj37R0xcbJbnyPDuFc8TJER9Z4pdeUtfh+E2iG+SRj+OyP28yGjKQ==",
       "dev": true,
       "requires": {
-        "@percy/logger": "1.24.1",
+        "@percy/logger": "1.24.2",
         "ajv": "^8.6.2",
         "cosmiconfig": "^8.0.0",
         "yaml": "^2.0.0"
       }
     },
     "@percy/core": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.24.1.tgz",
-      "integrity": "sha512-lByp0765X4wnJFeNqjp8+nZBdVIG7/+cz5gBCwfktuZmsYZje8/HCa0agQTjEx5ETvoXyjPKCpI144nqHqvTFg==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.24.2.tgz",
+      "integrity": "sha512-gGzZdVO+/CF7jIUqpXeFzG8AvbSJzZ21duZGrp9I7rD8AQd6PIq/kXjO9QNShoSi+tnC1GvfKw3Gorr3tGhpaw==",
       "dev": true,
       "requires": {
-        "@percy/client": "1.24.1",
-        "@percy/config": "1.24.1",
-        "@percy/dom": "1.24.1",
-        "@percy/logger": "1.24.1",
+        "@percy/client": "1.24.2",
+        "@percy/config": "1.24.2",
+        "@percy/dom": "1.24.2",
+        "@percy/logger": "1.24.2",
         "content-disposition": "^0.5.4",
         "cross-spawn": "^7.0.3",
         "extract-zip": "^2.0.1",
@@ -34016,9 +33940,9 @@
       }
     },
     "@percy/dom": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.24.1.tgz",
-      "integrity": "sha512-wdf0hrQerIhla9vpl0CeOhRBXCAkTWXzIqyrcXxje/rwYXw6PfanYnB48yKCbLyaPY8MRIV5JMP8fxzhJF6Rdg==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.24.2.tgz",
+      "integrity": "sha512-C5nRMpHNGKS8xPflmYJCO2x6870wiR7TagMx+KOiIHfMEx/4LZhwPP4dkVS4WGeCfcKHOhi8BkJnhuSbL7WWDw==",
       "dev": true
     },
     "@percy/ember": {
@@ -34032,21 +33956,21 @@
       }
     },
     "@percy/env": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.24.1.tgz",
-      "integrity": "sha512-h/KLpK2z2Cw2dR5vHfuItsAlpUBjNJBmwVmlvb/nbdxAh4slz1a2QGzdFiskpU4YMDy6GebpN+cOkPXQcI8SaQ==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.24.2.tgz",
+      "integrity": "sha512-y2uzAF4jojzuBPOaY/TxA5WwvxfXFv4UKlgbVBGWVDwmgG9ZO/ahUqRTyvG4bgC48NNAeckNxKgADQG5oWR6+g==",
       "dev": true
     },
     "@percy/logger": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.24.1.tgz",
-      "integrity": "sha512-dJWGl+tZdPrg4uZglkGaom/1l4Cagruki9ZqsModNvvEN4LoXCbrIBd45GxlNkNhLbUDbvvvpTz1Lqu8wRwB8A==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.24.2.tgz",
+      "integrity": "sha512-wsmDUsY6MOmjE9TvkF/voL1r6btAMxIPggYOE6JIenrUc6ZBxIPZ9SYJWA63w8v4KWsRUOMqPBRCEUy7VpnPEw==",
       "dev": true
     },
     "@percy/sdk-utils": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@percy/sdk-utils/-/sdk-utils-1.24.1.tgz",
-      "integrity": "sha512-8yiziR0/5+1soNmD3IWqVrgF8gPRRqkTQRCLN2l5Wue53a6BOMzrx9gkUp1WFeEEHCA9z0lVnE5eMRYcCkaXgA==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@percy/sdk-utils/-/sdk-utils-1.24.2.tgz",
+      "integrity": "sha512-gjCaWcm43q4ao8NAKjvvo7kR3JU41V6xi2IVF5cvoyOUtXGRgBta+VPh6unGVLwfAoDUj2/lVcSPRdoOSwgJWg==",
       "dev": true
     },
     "@popperjs/core": {
@@ -42354,30 +42278,6 @@
         "ember-cli-babel": "^7.19.0"
       }
     },
-    "ember-factory-for-polyfill": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.3.1.tgz",
-      "integrity": "sha512-y3iG2iCzH96lZMTWQw6LWNLAfOmDC4pXKbZP6FxG8lt7GGaNFkZjwsf+Z5GAe7kxfD7UG4lVkF7x37K82rySGA==",
-      "requires": {
-        "ember-cli-version-checker": "^2.1.0"
-      },
-      "dependencies": {
-        "ember-cli-version-checker": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-          "requires": {
-            "resolve": "^1.3.3",
-            "semver": "^5.3.0"
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
-      }
-    },
     "ember-feature-flags": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/ember-feature-flags/-/ember-feature-flags-6.0.0.tgz",
@@ -42594,31 +42494,6 @@
       "requires": {
         "@embroider/macros": "^0.50.0 || ^1.0.0",
         "ember-cli-babel": "^7.26.6"
-      }
-    },
-    "ember-getowner-polyfill": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz",
-      "integrity": "sha512-rwGMJgbGzxIAiWYjdpAh04Abvt0s3HuS/VjHzUFhVyVg2pzAuz45B9AzOxYXzkp88vFC7FPaiA4kE8NxNk4A4Q==",
-      "requires": {
-        "ember-cli-version-checker": "^2.1.0",
-        "ember-factory-for-polyfill": "^1.3.1"
-      },
-      "dependencies": {
-        "ember-cli-version-checker": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-          "requires": {
-            "resolve": "^1.3.3",
-            "semver": "^5.3.0"
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
       }
     },
     "ember-in-element-polyfill": {
@@ -45279,29 +45154,7 @@
       "requires": {
         "ember-cli-babel": "^6.6.0 || ^7.0.0",
         "ember-fetch": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
-        "ember-simple-auth": "^1.6.0 || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
-      },
-      "dependencies": {
-        "ember-cookies": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-0.5.2.tgz",
-          "integrity": "sha512-nZ7oG97kBcO9UHjO95ryABpnVx62Bhxo7lIsBJNmWvFXleILm9DGueiAynzXxuYWWPuKIeeSbYakrS1869tNTw==",
-          "requires": {
-            "ember-cli-babel": "^7.1.0",
-            "ember-getowner-polyfill": "^1.1.0 || ^2.0.0"
-          }
-        },
-        "ember-simple-auth": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ember-simple-auth/-/ember-simple-auth-5.0.0.tgz",
-          "integrity": "sha512-wGf2jTvOKo11jNmWYBIZhgMx32kvAJEMNJNCpbdx0Ak6X+4uzO8l203C5kDH0idZej/2dHgYkcVaEzl2HCVFwA==",
-          "requires": {
-            "ember-cli-babel": "^7.20.5",
-            "ember-cli-is-package-missing": "^1.0.0",
-            "ember-cookies": "^0.5.0",
-            "silent-error": "^1.0.0"
-          }
-        }
+        "ember-simple-auth": "^6.0.0-rc.1"
       }
     },
     "ember-simple-charts": {
@@ -45589,6 +45442,17 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
           "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
           "dev": true
+        },
+        "resolve": {
+          "version": "1.22.3",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.3.tgz",
+          "integrity": "sha512-P8ur/gp/AmbEzjr729bZnLjXK5Z+4P0zhIJgBgzqRih7hL7BOukHGtSTA3ACMY467GRFz3duQsi0bDZdR7DKdw==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.12.0",
+            "path-parse": "^1.0.7",
+            "supports-preserve-symlinks-flag": "^1.0.0"
+          }
         },
         "yocto-queue": {
           "version": "1.0.0",
@@ -46502,9 +46366,9 @@
       "dev": true
     },
     "eslint-plugin-ember": {
-      "version": "11.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-ember/-/eslint-plugin-ember-11.6.0.tgz",
-      "integrity": "sha512-M/M63t/Y5yr/yuWUbtUZ/tE5B5A8/+6LOR6fJlXpLZR4XMtN3KueYsuEIDGP6AInmq5tjDPmBXX0wV+FkjQmvA==",
+      "version": "11.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-ember/-/eslint-plugin-ember-11.7.0.tgz",
+      "integrity": "sha512-LZvdGam1/R1suDwjFBcEmzQmd34aKqOD91X1JnJHymdiKUiHEeveW30O/ZTvM0CrTjuibZSh0lLLXH2+4/GdgA==",
       "dev": true,
       "requires": {
         "@ember-data/rfc395-data": "^0.0.4",
@@ -52625,11 +52489,11 @@
       "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "resolve": {
-      "version": "1.22.3",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.3.tgz",
-      "integrity": "sha512-P8ur/gp/AmbEzjr729bZnLjXK5Z+4P0zhIJgBgzqRih7hL7BOukHGtSTA3ACMY467GRFz3duQsi0bDZdR7DKdw==",
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
       "requires": {
-        "is-core-module": "^2.12.0",
+        "is-core-module": "^2.11.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "ember-modifier": "^4.0.0",
         "ember-moment": "^10.0.0",
         "ember-promise-helpers": "2.0.0",
+        "ember-simple-auth": "^6.0.0-rc.1",
         "ember-simple-auth-token": "^5.0.0",
         "ember-simple-charts": "^10.3.0",
         "ember-test-selectors": "^6.0.0",
@@ -13614,15 +13615,14 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/ember-cookies": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-0.5.2.tgz",
-      "integrity": "sha512-nZ7oG97kBcO9UHjO95ryABpnVx62Bhxo7lIsBJNmWvFXleILm9DGueiAynzXxuYWWPuKIeeSbYakrS1869tNTw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-1.0.0.tgz",
+      "integrity": "sha512-/kugyQInCkELQAdWMX9ud5AGiQrmkDGV16kOBSCRN3I8jCsaU2uzh8bGFyjyTSFc1cTdIO0Rwm9+ImbgHMzjpA==",
       "dependencies": {
-        "ember-cli-babel": "^7.1.0",
-        "ember-getowner-polyfill": "^1.1.0 || ^2.0.0"
+        "@embroider/addon-shim": "^1.7.1"
       },
       "engines": {
-        "node": "8.* || 10.* || >= 12.*"
+        "node": ">= 16.*"
       }
     },
     "node_modules/ember-could-get-used-to-this": {
@@ -17561,13 +17561,14 @@
       }
     },
     "node_modules/ember-simple-auth": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ember-simple-auth/-/ember-simple-auth-5.0.0.tgz",
-      "integrity": "sha512-wGf2jTvOKo11jNmWYBIZhgMx32kvAJEMNJNCpbdx0Ak6X+4uzO8l203C5kDH0idZej/2dHgYkcVaEzl2HCVFwA==",
+      "version": "6.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/ember-simple-auth/-/ember-simple-auth-6.0.0-rc.1.tgz",
+      "integrity": "sha512-s5ts3Fl4fmsWXBQCcw8R58iwhWMejQo1Hk7Dxp9eN2V2dwtkXKUoFCtPwzgaaX+esjAouQ/q8LS5eWjpiIX4OA==",
       "dependencies": {
+        "ember-auto-import": "^2.4.2",
         "ember-cli-babel": "^7.20.5",
         "ember-cli-is-package-missing": "^1.0.0",
-        "ember-cookies": "^0.5.0",
+        "ember-cookies": "^1.0.0",
         "silent-error": "^1.0.0"
       },
       "engines": {
@@ -17588,6 +17589,35 @@
       },
       "engines": {
         "node": ">=10.*"
+      }
+    },
+    "node_modules/ember-simple-auth-token/node_modules/ember-cookies": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-0.5.2.tgz",
+      "integrity": "sha512-nZ7oG97kBcO9UHjO95ryABpnVx62Bhxo7lIsBJNmWvFXleILm9DGueiAynzXxuYWWPuKIeeSbYakrS1869tNTw==",
+      "dependencies": {
+        "ember-cli-babel": "^7.1.0",
+        "ember-getowner-polyfill": "^1.1.0 || ^2.0.0"
+      },
+      "engines": {
+        "node": "8.* || 10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-simple-auth-token/node_modules/ember-simple-auth": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ember-simple-auth/-/ember-simple-auth-5.0.0.tgz",
+      "integrity": "sha512-wGf2jTvOKo11jNmWYBIZhgMx32kvAJEMNJNCpbdx0Ak6X+4uzO8l203C5kDH0idZej/2dHgYkcVaEzl2HCVFwA==",
+      "dependencies": {
+        "ember-cli-babel": "^7.20.5",
+        "ember-cli-is-package-missing": "^1.0.0",
+        "ember-cookies": "^0.5.0",
+        "silent-error": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "peerDependencies": {
+        "ember-fetch": "^8.0.1"
       }
     },
     "node_modules/ember-simple-charts": {
@@ -42092,12 +42122,11 @@
       }
     },
     "ember-cookies": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-0.5.2.tgz",
-      "integrity": "sha512-nZ7oG97kBcO9UHjO95ryABpnVx62Bhxo7lIsBJNmWvFXleILm9DGueiAynzXxuYWWPuKIeeSbYakrS1869tNTw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-1.0.0.tgz",
+      "integrity": "sha512-/kugyQInCkELQAdWMX9ud5AGiQrmkDGV16kOBSCRN3I8jCsaU2uzh8bGFyjyTSFc1cTdIO0Rwm9+ImbgHMzjpA==",
       "requires": {
-        "ember-cli-babel": "^7.1.0",
-        "ember-getowner-polyfill": "^1.1.0 || ^2.0.0"
+        "@embroider/addon-shim": "^1.7.1"
       }
     },
     "ember-could-get-used-to-this": {
@@ -45232,13 +45261,14 @@
       }
     },
     "ember-simple-auth": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ember-simple-auth/-/ember-simple-auth-5.0.0.tgz",
-      "integrity": "sha512-wGf2jTvOKo11jNmWYBIZhgMx32kvAJEMNJNCpbdx0Ak6X+4uzO8l203C5kDH0idZej/2dHgYkcVaEzl2HCVFwA==",
+      "version": "6.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/ember-simple-auth/-/ember-simple-auth-6.0.0-rc.1.tgz",
+      "integrity": "sha512-s5ts3Fl4fmsWXBQCcw8R58iwhWMejQo1Hk7Dxp9eN2V2dwtkXKUoFCtPwzgaaX+esjAouQ/q8LS5eWjpiIX4OA==",
       "requires": {
+        "ember-auto-import": "^2.4.2",
         "ember-cli-babel": "^7.20.5",
         "ember-cli-is-package-missing": "^1.0.0",
-        "ember-cookies": "^0.5.0",
+        "ember-cookies": "^1.0.0",
         "silent-error": "^1.0.0"
       }
     },
@@ -45250,6 +45280,28 @@
         "ember-cli-babel": "^6.6.0 || ^7.0.0",
         "ember-fetch": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "ember-simple-auth": "^1.6.0 || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
+      },
+      "dependencies": {
+        "ember-cookies": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-0.5.2.tgz",
+          "integrity": "sha512-nZ7oG97kBcO9UHjO95ryABpnVx62Bhxo7lIsBJNmWvFXleILm9DGueiAynzXxuYWWPuKIeeSbYakrS1869tNTw==",
+          "requires": {
+            "ember-cli-babel": "^7.1.0",
+            "ember-getowner-polyfill": "^1.1.0 || ^2.0.0"
+          }
+        },
+        "ember-simple-auth": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ember-simple-auth/-/ember-simple-auth-5.0.0.tgz",
+          "integrity": "sha512-wGf2jTvOKo11jNmWYBIZhgMx32kvAJEMNJNCpbdx0Ak6X+4uzO8l203C5kDH0idZej/2dHgYkcVaEzl2HCVFwA==",
+          "requires": {
+            "ember-cli-babel": "^7.20.5",
+            "ember-cli-is-package-missing": "^1.0.0",
+            "ember-cookies": "^0.5.0",
+            "silent-error": "^1.0.0"
+          }
+        }
       }
     },
     "ember-simple-charts": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "ember-modifier": "^4.0.0",
     "ember-moment": "^10.0.0",
     "ember-promise-helpers": "2.0.0",
+    "ember-simple-auth": "^6.0.0-rc.1",
     "ember-simple-auth-token": "^5.0.0",
     "ember-simple-charts": "^10.3.0",
     "ember-test-selectors": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "ember-modifier": "^4.0.0",
     "ember-moment": "^10.0.0",
     "ember-promise-helpers": "2.0.0",
-    "ember-simple-auth": "^6.0.0-rc.1",
     "ember-simple-auth-token": "^5.0.0",
     "ember-simple-charts": "^10.3.0",
     "ember-test-selectors": "^6.0.0",
@@ -174,9 +173,12 @@
     "tracked-built-ins": "^3.1.1",
     "webpack": "^5.78.0"
   },
+  "overrides": {
+    "ember-simple-auth": "^6.0.0-rc.1"
+  },
   "engines": {
     "node": "16.* || >= 18",
-    "npm": ">= 8"
+    "npm": ">= 8.3"
   },
   "ember": {
     "edition": "octane"

--- a/tests/dummy/config/dependency-lint.js
+++ b/tests/dummy/config/dependency-lint.js
@@ -6,5 +6,7 @@ module.exports = {
     'ember-in-element-polyfill': '*',
     'ember-get-config': '^1.0.0 || ^2.0.0',
     'ember-modifier': '3.2.7 || ^ 4.0.0',
+    'ember-simple-auth': '^5.0.0 || 6.0.0-rc.1',
+    'ember-cookies': '^0.5.2 || ^1.0.0',
   },
 };

--- a/tests/dummy/config/dependency-lint.js
+++ b/tests/dummy/config/dependency-lint.js
@@ -6,7 +6,5 @@ module.exports = {
     'ember-in-element-polyfill': '*',
     'ember-get-config': '^1.0.0 || ^2.0.0',
     'ember-modifier': '3.2.7 || ^ 4.0.0',
-    'ember-simple-auth': '^5.0.0 || 6.0.0-rc.1',
-    'ember-cookies': '^0.5.2 || ^1.0.0',
   },
 };


### PR DESCRIPTION
This release candidate has improved support for ember beta and canary releases.