### PR TITLE
Skip updating eslint-plugin-n

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,7 +37,7 @@ updates:
   - dependency-name: ember-try
   - dependency-name: eslint
   - dependency-name: eslint-plugin-ember
-  - dependency-name: eslint-plugin-node
+  - dependency-name: eslint-plugin-n
   - dependency-name: loader.js
   - dependency-name: qunit-dom
   - dependency-name: stylelint


### PR DESCRIPTION
Package name changed in the ember-cli blueprint, we still don't want to update it.