### PR TITLE
Unlock embroider tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "@ember/optional-features": "^2.0.0",
         "@ember/string": "^3.0.1",
         "@ember/test-helpers": "^2.9.3",
-        "@embroider/test-setup": "^2.1.1",
+        "@embroider/test-setup": "^3.0.0",
         "@ilios/ember-template-lint-plugin": "^3.0.0",
         "@percy/cli": "^1.24.0",
         "@percy/ember": "^4.2.0",
@@ -139,6 +139,7 @@
         "class-validator": "^0.14.0",
         "ember-source": "~4.11.0",
         "flatpickr": "^4.0.0",
+        "froala-editor": "^4.0.13",
         "luxon": "^3.0.1",
         "miragejs": "^0.1.45",
         "mockdate": "^3.0.5",
@@ -2454,11 +2455,11 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@embroider/addon-shim": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/@embroider/addon-shim/-/addon-shim-1.8.4.tgz",
-      "integrity": "sha512-sFhfWC0vI18KxVenmswQ/ShIvBg4juL8ubI+Q3NTSdkCTeaPQ/DIOUF6oR5DCQ8eO/TkIaw+kdG3FkTY6yNJqA==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@embroider/addon-shim/-/addon-shim-1.8.5.tgz",
+      "integrity": "sha512-pDgpdTsC9i/+5hHziygK5VIZc64OG8bupiqL0OxJp+bnINURalHMbu5B3Gikq/a0QIvMPzDFWzKxIZCBpeiHkg==",
       "dependencies": {
-        "@embroider/shared-internals": "^2.0.0",
+        "@embroider/shared-internals": "^2.1.0",
         "broccoli-funnel": "^3.0.8",
         "semver": "^7.3.8"
       },
@@ -2497,11 +2498,11 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@embroider/macros": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.10.0.tgz",
-      "integrity": "sha512-LMbfQGk/a+f6xtvAv5fq/wf2LRxETnbgSCLUf/z6ebzmuskOUxrke+uP55chF/loWrARi9g6erFQ7RDOUoBMSg==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.11.0.tgz",
+      "integrity": "sha512-P/WSB+PqKSja5qXjYvhLyUM0ivcDoI9kkqs+R0GNujfVhS0EIIAMHfD9uHDBbhzFit39pT0QJqgcXGE2rprCPA==",
       "dependencies": {
-        "@embroider/shared-internals": "2.0.0",
+        "@embroider/shared-internals": "2.1.0",
         "assert-never": "^1.2.1",
         "babel-import-util": "^1.1.0",
         "ember-cli-babel": "^7.26.6",
@@ -2512,6 +2513,14 @@
       },
       "engines": {
         "node": "12.* || 14.* || >= 16"
+      },
+      "peerDependencies": {
+        "@glint/template": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@glint/template": {
+          "optional": true
+        }
       }
     },
     "node_modules/@embroider/macros/node_modules/lru-cache": {
@@ -2545,9 +2554,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@embroider/shared-internals": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.0.0.tgz",
-      "integrity": "sha512-qZ2/xky9mWm5YC6noOa6AiAwgISEQ78YTZNv4SNu2PFgEK/H+Ha/3ddngzGSsnXkVnIHZyxIBzhxETonQYHY9g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.1.0.tgz",
+      "integrity": "sha512-9hKbMxW7wDWt1BqdpnLZ5W6ETrmAg9HnfBwf1IDkT+8he5nOdTD0PNtruMjm7V0Tb9p9hI7O+UXSa8ZnX1BQXg==",
       "dependencies": {
         "babel-import-util": "^1.1.0",
         "ember-rfc176-data": "^0.3.17",
@@ -2593,9 +2602,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@embroider/test-setup": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@embroider/test-setup/-/test-setup-2.1.1.tgz",
-      "integrity": "sha512-t81a2z2OEFAOZVbV7wkgiDuCyZ3ajD7J7J+keaTfNSRiXoQgeFFASEECYq1TCsH8m/R+xHMRiY59apF2FIeFhw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@embroider/test-setup/-/test-setup-3.0.1.tgz",
+      "integrity": "sha512-t7R2f10iZDSNw3ovWAPM63GRQTu63uihpVh6CvHev5XkLt8B7tdxcxGyO6RbdF5Hu+pbsUu8sD0kAlR1gopmxg==",
       "dev": true,
       "dependencies": {
         "lodash": "^4.17.21",
@@ -2603,14 +2612,30 @@
       },
       "engines": {
         "node": "12.* || 14.* || >= 16"
+      },
+      "peerDependencies": {
+        "@embroider/compat": "^3.0.0",
+        "@embroider/core": "^3.0.0",
+        "@embroider/webpack": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@embroider/compat": {
+          "optional": true
+        },
+        "@embroider/core": {
+          "optional": true
+        },
+        "@embroider/webpack": {
+          "optional": true
+        }
       }
     },
     "node_modules/@embroider/util": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@embroider/util/-/util-1.10.0.tgz",
-      "integrity": "sha512-utAFKoq6ajI27jyqjvX3PiGL4m+ZyGVlVNbSbE/nOqi2llRyAkh5ltH1WkIK7jhdwQFJouo1NpOSj9J3/HDa3A==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@embroider/util/-/util-1.11.0.tgz",
+      "integrity": "sha512-v6Jdjl87jzsAtYgU/xkx+7CykoC06E6qd3j8ULe8jC8hVXKkjWR7Nks5D5V970/fravGd/FMOT3tVIF3Dj5yaw==",
       "dependencies": {
-        "@embroider/macros": "^1.10.0",
+        "@embroider/macros": "^1.11.0",
         "broccoli-funnel": "^3.0.5",
         "ember-cli-babel": "^7.26.11"
       },
@@ -2618,10 +2643,14 @@
         "node": "14.* || >= 16"
       },
       "peerDependencies": {
-        "@glint/template": "^1.0.0-beta.1",
+        "@glint/environment-ember-loose": "^1.0.0",
+        "@glint/template": "^1.0.0",
         "ember-source": "*"
       },
       "peerDependenciesMeta": {
+        "@glint/environment-ember-loose": {
+          "optional": true
+        },
         "@glint/template": {
           "optional": true
         }
@@ -3775,9 +3804,9 @@
       }
     },
     "node_modules/@percy/sdk-utils": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@percy/sdk-utils/-/sdk-utils-1.24.0.tgz",
-      "integrity": "sha512-kfYxX0rHP5N2Da6HyfjRCVaeNahAO9XV5WD4SKWKKjdKVkV/Z5/XjVgSKlTBLSYxnWDzYJJ4UHZV43Mw+facMA==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@percy/sdk-utils/-/sdk-utils-1.24.1.tgz",
+      "integrity": "sha512-8yiziR0/5+1soNmD3IWqVrgF8gPRRqkTQRCLN2l5Wue53a6BOMzrx9gkUp1WFeEEHCA9z0lVnE5eMRYcCkaXgA==",
       "dev": true,
       "engines": {
         "node": ">=14"
@@ -4022,9 +4051,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.1.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.1.5.tgz",
-      "integrity": "sha512-IvGD1CD/nego63ySR7vrAKEX3AJTcmrAN2kn+/sDNLi1Ff5kBzDeEdqWDplK+0HAEoLYej137Sk0cUU8OLOlMg=="
+      "version": "20.2.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.1.tgz",
+      "integrity": "sha512-DqJociPbZP1lbZ5SQPk4oag6W7AyaGMO6gSfRwq3PWl4PXTwJpRQJhDq4W0kzrg3w6tJ1SwlvGZ5uKFHY13LIg=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -8423,9 +8452,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001487",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001487.tgz",
-      "integrity": "sha512-83564Z3yWGqXsh2vaH/mhXfEM0wX+NlBCm1jYHOb97TrTWJEmPTccZgeLTPBUUb0PNVo+oomb7wkimZBIERClA==",
+      "version": "1.0.30001488",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001488.tgz",
+      "integrity": "sha512-NORIQuuL4xGpIy6iCCQGN4iFjlBXtfKWIenlUuyZJumLRIindLb7wXM+GO8erEhb7vXfcnf4BAg2PrSDN5TNLQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -10410,9 +10439,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.396",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.396.tgz",
-      "integrity": "sha512-pqKTdqp/c5vsrc0xUPYXTDBo9ixZuGY8es4ZOjjd6HD6bFYbu5QA09VoW3fkY4LF1T0zYk86lN6bZnNlBuOpdQ=="
+      "version": "1.4.399",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.399.tgz",
+      "integrity": "sha512-+V1aNvVgoWNWYIbMOiQ1n5fRIaY4SlQ/uRlrsCjLrUwr/3OvQgiX2f5vdav4oArVT9TnttJKcPCqjwPNyZqw/A=="
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
@@ -22292,9 +22321,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
-      "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
+      "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -27080,9 +27109,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.21.8",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.21.8.tgz",
-      "integrity": "sha512-SSFV2T2fWtQ/vvBip85u2Nr0GNKireabH9d7nXswBg+XSH+jbVDSYptRAEbCEsquhs503rpPA9POYAp0/Jhasw==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.22.0.tgz",
+      "integrity": "sha512-imsigcWor5Y/dC0rz2q0bBt9PabcL3TORry2hAa6O6BuMvY71bqHyfReAz5qyAqiQATD1m70qdntqBfBQjVWpQ==",
       "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -28679,9 +28708,9 @@
       "dev": true
     },
     "node_modules/stylelint": {
-      "version": "15.6.1",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-15.6.1.tgz",
-      "integrity": "sha512-d8icFBlVl93Elf3Z5ABQNOCe4nx69is3D/NZhDLAie1eyYnpxfeKe7pCfqzT5W4F8vxHCLSDfV8nKNJzogvV2Q==",
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-15.6.2.tgz",
+      "integrity": "sha512-fjQWwcdUye4DU+0oIxNGwawIPC5DvG5kdObY5Sg4rc87untze3gC/5g/ikePqVjrAsBUZjwMN+pZsAYbDO6ArQ==",
       "dev": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^2.1.1",
@@ -29247,9 +29276,9 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.8.tgz",
-      "integrity": "sha512-WiHL3ElchZMsK27P8uIUh4604IgJyAW47LVXGbEoB21DbQcZ+OuMpGjVYnEUaqcWM6dO8uS2qUbA7LSCWqvsbg==",
+      "version": "5.3.9",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.9.tgz",
+      "integrity": "sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.17",
         "jest-worker": "^27.4.5",
@@ -29941,9 +29970,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.1.tgz",
+      "integrity": "sha512-KaI6gPil5m9vF7DKaoXxx1ia9fxS4qG5YveErRRVknPDXXriu5M8h48YRjB6h5ZUOKuAKlSJYb0GaDe8I39fRw=="
     },
     "node_modules/tty-browserify": {
       "version": "0.0.0",
@@ -30880,9 +30909,9 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/webpack": {
-      "version": "5.82.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.82.1.tgz",
-      "integrity": "sha512-C6uiGQJ+Gt4RyHXXYt+v9f+SN1v83x68URwgxNQ98cvH8kxiuywWGP4XeNZ1paOzZ63aY3cTciCEQJNFUljlLw==",
+      "version": "5.83.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.83.1.tgz",
+      "integrity": "sha512-TNsG9jDScbNuB+Lb/3+vYolPplCS3bbEaJf+Bj0Gw4DhP3ioAflBb1flcRt9zsWITyvOhM96wMQNRWlSX52DgA==",
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.0",
@@ -32909,11 +32938,11 @@
       }
     },
     "@embroider/addon-shim": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/@embroider/addon-shim/-/addon-shim-1.8.4.tgz",
-      "integrity": "sha512-sFhfWC0vI18KxVenmswQ/ShIvBg4juL8ubI+Q3NTSdkCTeaPQ/DIOUF6oR5DCQ8eO/TkIaw+kdG3FkTY6yNJqA==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@embroider/addon-shim/-/addon-shim-1.8.5.tgz",
+      "integrity": "sha512-pDgpdTsC9i/+5hHziygK5VIZc64OG8bupiqL0OxJp+bnINURalHMbu5B3Gikq/a0QIvMPzDFWzKxIZCBpeiHkg==",
       "requires": {
-        "@embroider/shared-internals": "^2.0.0",
+        "@embroider/shared-internals": "^2.1.0",
         "broccoli-funnel": "^3.0.8",
         "semver": "^7.3.8"
       },
@@ -32942,11 +32971,11 @@
       }
     },
     "@embroider/macros": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.10.0.tgz",
-      "integrity": "sha512-LMbfQGk/a+f6xtvAv5fq/wf2LRxETnbgSCLUf/z6ebzmuskOUxrke+uP55chF/loWrARi9g6erFQ7RDOUoBMSg==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.11.0.tgz",
+      "integrity": "sha512-P/WSB+PqKSja5qXjYvhLyUM0ivcDoI9kkqs+R0GNujfVhS0EIIAMHfD9uHDBbhzFit39pT0QJqgcXGE2rprCPA==",
       "requires": {
-        "@embroider/shared-internals": "2.0.0",
+        "@embroider/shared-internals": "2.1.0",
         "assert-never": "^1.2.1",
         "babel-import-util": "^1.1.0",
         "ember-cli-babel": "^7.26.6",
@@ -32980,9 +33009,9 @@
       }
     },
     "@embroider/shared-internals": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.0.0.tgz",
-      "integrity": "sha512-qZ2/xky9mWm5YC6noOa6AiAwgISEQ78YTZNv4SNu2PFgEK/H+Ha/3ddngzGSsnXkVnIHZyxIBzhxETonQYHY9g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.1.0.tgz",
+      "integrity": "sha512-9hKbMxW7wDWt1BqdpnLZ5W6ETrmAg9HnfBwf1IDkT+8he5nOdTD0PNtruMjm7V0Tb9p9hI7O+UXSa8ZnX1BQXg==",
       "requires": {
         "babel-import-util": "^1.1.0",
         "ember-rfc176-data": "^0.3.17",
@@ -33018,9 +33047,9 @@
       }
     },
     "@embroider/test-setup": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@embroider/test-setup/-/test-setup-2.1.1.tgz",
-      "integrity": "sha512-t81a2z2OEFAOZVbV7wkgiDuCyZ3ajD7J7J+keaTfNSRiXoQgeFFASEECYq1TCsH8m/R+xHMRiY59apF2FIeFhw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@embroider/test-setup/-/test-setup-3.0.1.tgz",
+      "integrity": "sha512-t7R2f10iZDSNw3ovWAPM63GRQTu63uihpVh6CvHev5XkLt8B7tdxcxGyO6RbdF5Hu+pbsUu8sD0kAlR1gopmxg==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.21",
@@ -33028,11 +33057,11 @@
       }
     },
     "@embroider/util": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@embroider/util/-/util-1.10.0.tgz",
-      "integrity": "sha512-utAFKoq6ajI27jyqjvX3PiGL4m+ZyGVlVNbSbE/nOqi2llRyAkh5ltH1WkIK7jhdwQFJouo1NpOSj9J3/HDa3A==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@embroider/util/-/util-1.11.0.tgz",
+      "integrity": "sha512-v6Jdjl87jzsAtYgU/xkx+7CykoC06E6qd3j8ULe8jC8hVXKkjWR7Nks5D5V970/fravGd/FMOT3tVIF3Dj5yaw==",
       "requires": {
-        "@embroider/macros": "^1.10.0",
+        "@embroider/macros": "^1.11.0",
         "broccoli-funnel": "^3.0.5",
         "ember-cli-babel": "^7.26.11"
       }
@@ -33985,9 +34014,9 @@
       "dev": true
     },
     "@percy/sdk-utils": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@percy/sdk-utils/-/sdk-utils-1.24.0.tgz",
-      "integrity": "sha512-kfYxX0rHP5N2Da6HyfjRCVaeNahAO9XV5WD4SKWKKjdKVkV/Z5/XjVgSKlTBLSYxnWDzYJJ4UHZV43Mw+facMA==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@percy/sdk-utils/-/sdk-utils-1.24.1.tgz",
+      "integrity": "sha512-8yiziR0/5+1soNmD3IWqVrgF8gPRRqkTQRCLN2l5Wue53a6BOMzrx9gkUp1WFeEEHCA9z0lVnE5eMRYcCkaXgA==",
       "dev": true
     },
     "@popperjs/core": {
@@ -34217,9 +34246,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "20.1.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.1.5.tgz",
-      "integrity": "sha512-IvGD1CD/nego63ySR7vrAKEX3AJTcmrAN2kn+/sDNLi1Ff5kBzDeEdqWDplK+0HAEoLYej137Sk0cUU8OLOlMg=="
+      "version": "20.2.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.1.tgz",
+      "integrity": "sha512-DqJociPbZP1lbZ5SQPk4oag6W7AyaGMO6gSfRwq3PWl4PXTwJpRQJhDq4W0kzrg3w6tJ1SwlvGZ5uKFHY13LIg=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -37974,9 +38003,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001487",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001487.tgz",
-      "integrity": "sha512-83564Z3yWGqXsh2vaH/mhXfEM0wX+NlBCm1jYHOb97TrTWJEmPTccZgeLTPBUUb0PNVo+oomb7wkimZBIERClA=="
+      "version": "1.0.30001488",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001488.tgz",
+      "integrity": "sha512-NORIQuuL4xGpIy6iCCQGN4iFjlBXtfKWIenlUuyZJumLRIindLb7wXM+GO8erEhb7vXfcnf4BAg2PrSDN5TNLQ=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -39528,9 +39557,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.396",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.396.tgz",
-      "integrity": "sha512-pqKTdqp/c5vsrc0xUPYXTDBo9ixZuGY8es4ZOjjd6HD6bFYbu5QA09VoW3fkY4LF1T0zYk86lN6bZnNlBuOpdQ=="
+      "version": "1.4.399",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.399.tgz",
+      "integrity": "sha512-+V1aNvVgoWNWYIbMOiQ1n5fRIaY4SlQ/uRlrsCjLrUwr/3OvQgiX2f5vdav4oArVT9TnttJKcPCqjwPNyZqw/A=="
     },
     "elliptic": {
       "version": "6.5.4",
@@ -48921,9 +48950,9 @@
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
     },
     "is-core-module": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
-      "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
+      "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
       "requires": {
         "has": "^1.0.3"
       }
@@ -52684,9 +52713,9 @@
       }
     },
     "rollup": {
-      "version": "3.21.8",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.21.8.tgz",
-      "integrity": "sha512-SSFV2T2fWtQ/vvBip85u2Nr0GNKireabH9d7nXswBg+XSH+jbVDSYptRAEbCEsquhs503rpPA9POYAp0/Jhasw==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.22.0.tgz",
+      "integrity": "sha512-imsigcWor5Y/dC0rz2q0bBt9PabcL3TORry2hAa6O6BuMvY71bqHyfReAz5qyAqiQATD1m70qdntqBfBQjVWpQ==",
       "peer": true,
       "requires": {
         "fsevents": "~2.3.2"
@@ -53970,9 +53999,9 @@
       "dev": true
     },
     "stylelint": {
-      "version": "15.6.1",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-15.6.1.tgz",
-      "integrity": "sha512-d8icFBlVl93Elf3Z5ABQNOCe4nx69is3D/NZhDLAie1eyYnpxfeKe7pCfqzT5W4F8vxHCLSDfV8nKNJzogvV2Q==",
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-15.6.2.tgz",
+      "integrity": "sha512-fjQWwcdUye4DU+0oIxNGwawIPC5DvG5kdObY5Sg4rc87untze3gC/5g/ikePqVjrAsBUZjwMN+pZsAYbDO6ArQ==",
       "dev": true,
       "requires": {
         "@csstools/css-parser-algorithms": "^2.1.1",
@@ -54419,9 +54448,9 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.8.tgz",
-      "integrity": "sha512-WiHL3ElchZMsK27P8uIUh4604IgJyAW47LVXGbEoB21DbQcZ+OuMpGjVYnEUaqcWM6dO8uS2qUbA7LSCWqvsbg==",
+      "version": "5.3.9",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.9.tgz",
+      "integrity": "sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==",
       "requires": {
         "@jridgewell/trace-mapping": "^0.3.17",
         "jest-worker": "^27.4.5",
@@ -54959,9 +54988,9 @@
       "integrity": "sha512-WZGXGstmCWgeevgTL54hrCuw1dyMQIzWy7ZfqRJfSmJZBwklI15egmQytFP6bPidmw3M8d5yEowl1niq4vmqZw=="
     },
     "tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.1.tgz",
+      "integrity": "sha512-KaI6gPil5m9vF7DKaoXxx1ia9fxS4qG5YveErRRVknPDXXriu5M8h48YRjB6h5ZUOKuAKlSJYb0GaDe8I39fRw=="
     },
     "tty-browserify": {
       "version": "0.0.0",
@@ -55724,9 +55753,9 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "webpack": {
-      "version": "5.82.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.82.1.tgz",
-      "integrity": "sha512-C6uiGQJ+Gt4RyHXXYt+v9f+SN1v83x68URwgxNQ98cvH8kxiuywWGP4XeNZ1paOzZ63aY3cTciCEQJNFUljlLw==",
+      "version": "5.83.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.83.1.tgz",
+      "integrity": "sha512-TNsG9jDScbNuB+Lb/3+vYolPplCS3bbEaJf+Bj0Gw4DhP3ioAflBb1flcRt9zsWITyvOhM96wMQNRWlSX52DgA==",
       "requires": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5255,9 +5255,9 @@
       }
     },
     "node_modules/babel-plugin-ember-template-compilation": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-ember-template-compilation/-/babel-plugin-ember-template-compilation-2.0.2.tgz",
-      "integrity": "sha512-/sQJbmOqfNfaEYrIayy8qpfi6GhsoMeBVR3IiihOTHaKFN9+EdTzED8fhUqfshBPu5Qz6zhPkY1aMJ3k/mAuxw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-ember-template-compilation/-/babel-plugin-ember-template-compilation-2.0.3.tgz",
+      "integrity": "sha512-SIetZD/uCLnzIBTJtzYGc2Q55TPqM5WyjuOgW+Is1W3SZVljlY3JD5Add29hDMs//OvXBWoXfOopQxkfG4/pIA==",
       "dependencies": {
         "babel-import-util": "^1.3.0"
       },
@@ -10439,9 +10439,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.399",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.399.tgz",
-      "integrity": "sha512-+V1aNvVgoWNWYIbMOiQ1n5fRIaY4SlQ/uRlrsCjLrUwr/3OvQgiX2f5vdav4oArVT9TnttJKcPCqjwPNyZqw/A=="
+      "version": "1.4.401",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.401.tgz",
+      "integrity": "sha512-AswqHsYyEbfSn0x87n31Na/xttUqEAg7NUjpiyxC20MaWKLyadOYHMzyLdF78N1iw+FK8/2KHLpZxRdyRILgtA=="
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
@@ -20014,9 +20014,9 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-diff": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "dev": true
     },
     "node_modules/fast-glob": {
@@ -23909,9 +23909,9 @@
       }
     },
     "node_modules/mini-css-extract-plugin": {
-      "version": "2.7.5",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.7.5.tgz",
-      "integrity": "sha512-9HaR++0mlgom81s95vvNjxkg52n2b5s//3ZTI1EtzFb98awsLSivs2LMsVqnQ3ay0PVhqWcGNyDaTE961FOcjQ==",
+      "version": "2.7.6",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.7.6.tgz",
+      "integrity": "sha512-Qk7HcgaPkGG6eD77mLvZS1nmxlao3j+9PkrT9Uc7HAE1id3F41+DdBRYRYkbyfNRGzm8/YWtzhw7nVPmwhqTQw==",
       "dependencies": {
         "schema-utils": "^4.0.0"
       },
@@ -25821,9 +25821,9 @@
       }
     },
     "node_modules/postcss-modules-local-by-default": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz",
-      "integrity": "sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.1.tgz",
+      "integrity": "sha512-Zr/dB+IlXaEqdoslLHhhqecwj73vc3rDmOpsBNBEVk7P2aqAlz+Ijy0fFbU5Ie9PtreDOIgGa9MsLWakVGl+fA==",
       "dependencies": {
         "icss-utils": "^5.0.0",
         "postcss-selector-parser": "^6.0.2",
@@ -29970,9 +29970,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.1.tgz",
-      "integrity": "sha512-KaI6gPil5m9vF7DKaoXxx1ia9fxS4qG5YveErRRVknPDXXriu5M8h48YRjB6h5ZUOKuAKlSJYb0GaDe8I39fRw=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "node_modules/tty-browserify": {
       "version": "0.0.0",
@@ -35266,9 +35266,9 @@
       }
     },
     "babel-plugin-ember-template-compilation": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-ember-template-compilation/-/babel-plugin-ember-template-compilation-2.0.2.tgz",
-      "integrity": "sha512-/sQJbmOqfNfaEYrIayy8qpfi6GhsoMeBVR3IiihOTHaKFN9+EdTzED8fhUqfshBPu5Qz6zhPkY1aMJ3k/mAuxw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-ember-template-compilation/-/babel-plugin-ember-template-compilation-2.0.3.tgz",
+      "integrity": "sha512-SIetZD/uCLnzIBTJtzYGc2Q55TPqM5WyjuOgW+Is1W3SZVljlY3JD5Add29hDMs//OvXBWoXfOopQxkfG4/pIA==",
       "requires": {
         "babel-import-util": "^1.3.0"
       }
@@ -39557,9 +39557,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.399",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.399.tgz",
-      "integrity": "sha512-+V1aNvVgoWNWYIbMOiQ1n5fRIaY4SlQ/uRlrsCjLrUwr/3OvQgiX2f5vdav4oArVT9TnttJKcPCqjwPNyZqw/A=="
+      "version": "1.4.401",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.401.tgz",
+      "integrity": "sha512-AswqHsYyEbfSn0x87n31Na/xttUqEAg7NUjpiyxC20MaWKLyadOYHMzyLdF78N1iw+FK8/2KHLpZxRdyRILgtA=="
     },
     "elliptic": {
       "version": "6.5.4",
@@ -47096,9 +47096,9 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-diff": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "dev": true
     },
     "fast-glob": {
@@ -50233,9 +50233,9 @@
       "dev": true
     },
     "mini-css-extract-plugin": {
-      "version": "2.7.5",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.7.5.tgz",
-      "integrity": "sha512-9HaR++0mlgom81s95vvNjxkg52n2b5s//3ZTI1EtzFb98awsLSivs2LMsVqnQ3ay0PVhqWcGNyDaTE961FOcjQ==",
+      "version": "2.7.6",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.7.6.tgz",
+      "integrity": "sha512-Qk7HcgaPkGG6eD77mLvZS1nmxlao3j+9PkrT9Uc7HAE1id3F41+DdBRYRYkbyfNRGzm8/YWtzhw7nVPmwhqTQw==",
       "requires": {
         "schema-utils": "^4.0.0"
       },
@@ -51727,9 +51727,9 @@
       "requires": {}
     },
     "postcss-modules-local-by-default": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz",
-      "integrity": "sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.1.tgz",
+      "integrity": "sha512-Zr/dB+IlXaEqdoslLHhhqecwj73vc3rDmOpsBNBEVk7P2aqAlz+Ijy0fFbU5Ie9PtreDOIgGa9MsLWakVGl+fA==",
       "requires": {
         "icss-utils": "^5.0.0",
         "postcss-selector-parser": "^6.0.2",
@@ -54988,9 +54988,9 @@
       "integrity": "sha512-WZGXGstmCWgeevgTL54hrCuw1dyMQIzWy7ZfqRJfSmJZBwklI15egmQytFP6bPidmw3M8d5yEowl1niq4vmqZw=="
     },
     "tslib": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.1.tgz",
-      "integrity": "sha512-KaI6gPil5m9vF7DKaoXxx1ia9fxS4qG5YveErRRVknPDXXriu5M8h48YRjB6h5ZUOKuAKlSJYb0GaDe8I39fRw=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "tty-browserify": {
       "version": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "@ember/optional-features": "^2.0.0",
     "@ember/string": "^3.0.1",
     "@ember/test-helpers": "^2.9.3",
-    "@embroider/test-setup": "^2.1.1",
+    "@embroider/test-setup": "^3.0.0",
     "@ilios/ember-template-lint-plugin": "^3.0.0",
     "@percy/cli": "^1.24.0",
     "@percy/ember": "^4.2.0",

--- a/tests/dummy/config/ember-try.js
+++ b/tests/dummy/config/ember-try.js
@@ -46,24 +46,8 @@ module.exports = async function () {
           },
         },
       },
-      embroiderSafe({
-        npm: {
-          devDependencies: {
-            '@embroider/core': '^1.9.0',
-            '@embroider/webpack': '^1.8.3',
-            '@embroider/compat': '^1.9.0',
-          },
-        },
-      }),
-      embroiderOptimized({
-        npm: {
-          devDependencies: {
-            '@embroider/core': '^1.9.0',
-            '@embroider/webpack': '^1.8.3',
-            '@embroider/compat': '^1.9.0',
-          },
-        },
-      }),
+      embroiderSafe(),
+      embroiderOptimized(),
     ],
     buildManagerOptions() {
       return ['--force'];


### PR DESCRIPTION
We pinned these at v1 because v2 of embroider had issues with our usage of await in templates. That has been resolved in embroider v3 and we can unlock these now and test with the latest version.