### PR TITLE
Replace resolve async value resource

### DIFF
--- a/addon/components/collapsed-competencies.hbs
+++ b/addon/components/collapsed-competencies.hbs
@@ -3,9 +3,9 @@
   data-test-collapsed-competencies
 >
   <div class="title" role="button" {{on "click" @expand}} data-test-title>
-    {{t "general.competencies"}} ({{this.competencies.length}})
+    {{t "general.competencies"}} ({{@subject.competencies.length}})
   </div>
-  {{#unless this.competencies}}
+  {{#if this.isLoading}}
     <LoadingSpinner />
   {{else}}
     <div class="content">
@@ -34,5 +34,5 @@
         </tbody>
       </table>
     </div>
-  {{/unless}}
+  {{/if}}
 </section>

--- a/addon/components/course-materials.js
+++ b/addon/components/course-materials.js
@@ -6,7 +6,8 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import AsyncProcess from 'ilios-common/classes/async-process';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
 
@@ -19,11 +20,33 @@ export default class CourseMaterialsComponent extends Component {
 
   typesWithUrl = ['file', 'link'];
 
-  @use courseMaterials = new ResolveAsyncValue(() => [this.args.course.learningMaterials]);
-  @use loadedCourseSessions = new ResolveAsyncValue(() => [
-    this.dataLoader.loadCourseSessions(this.args.course.id),
-  ]);
-  @use courseSessions = new ResolveAsyncValue(() => [this.args.course.sessions]);
+  @cached
+  get courseMaterialsData() {
+    return new TrackedAsyncData(this.args.course.learningMaterials);
+  }
+
+  @cached
+  get loadedCourseSessionsData() {
+    return new TrackedAsyncData(this.dataLoader.loadCourseSessions(this.args.course.id));
+  }
+
+  @cached
+  get courseSessionsData() {
+    return new TrackedAsyncData(this.args.course.sessions);
+  }
+
+  get courseMaterials() {
+    return this.courseMaterialsData.isResolved ? this.courseMaterialsData.value : null;
+  }
+
+  get loadedCourseSessions() {
+    return this.loadedCourseSessionsData.isResolved ? this.loadedCourseSessionsData.value : null;
+  }
+
+  get courseSessions() {
+    return this.courseSessionsData.isResolved ? this.courseSessionsData.value : null;
+  }
+
   get sessions() {
     if (!this.loadedCourseSessions) {
       return false;

--- a/addon/components/course-publicationcheck.js
+++ b/addon/components/course-publicationcheck.js
@@ -1,15 +1,22 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class CoursePublicationCheckComponent extends Component {
   @service router;
 
-  @use courseObjectives = new ResolveAsyncValue(() => [this.args.course.courseObjectives, []]);
+  @cached
+  get courseObjectives() {
+    return new TrackedAsyncData(this.args.course.courseObjectives);
+  }
 
+  @cached
   get showUnlinkIcon() {
-    const objectivesWithoutParents = this.courseObjectives.filter((objective) => {
+    if (!this.courseObjectives.isResolved) {
+      return false;
+    }
+    const objectivesWithoutParents = this.courseObjectives.value.filter((objective) => {
       return objective.programYearObjectives.length === 0;
     });
 

--- a/addon/components/course-visualize-objectives.js
+++ b/addon/components/course-visualize-objectives.js
@@ -1,12 +1,17 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class CourseVisualizeObjectivesComponent extends Component {
   @service iliosConfig;
 
-  @use academicYearCrossesCalendarYearBoundaries = new ResolveAsyncValue(() => [
-    this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries'),
-  ]);
+  crossesBoundaryConfig = new TrackedAsyncData(
+    this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries')
+  );
+
+  @cached
+  get academicYearCrossesCalendarYearBoundaries() {
+    return this.crossesBoundaryConfig.isResolved ? this.crossesBoundaryConfig.value : null;
+  }
 }

--- a/addon/components/course-visualize-session-types.js
+++ b/addon/components/course-visualize-session-types.js
@@ -1,12 +1,17 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class CourseVisualizeSessionTypesComponent extends Component {
   @service iliosConfig;
 
-  @use academicYearCrossesCalendarYearBoundaries = new ResolveAsyncValue(() => [
-    this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries'),
-  ]);
+  crossesBoundaryConfig = new TrackedAsyncData(
+    this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries')
+  );
+
+  @cached
+  get academicYearCrossesCalendarYearBoundaries() {
+    return this.crossesBoundaryConfig.isResolved ? this.crossesBoundaryConfig.value : null;
+  }
 }

--- a/addon/components/course-visualize-vocabularies.js
+++ b/addon/components/course-visualize-vocabularies.js
@@ -1,12 +1,17 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class CourseVisualizeVocabulariesComponent extends Component {
   @service iliosConfig;
 
-  @use academicYearCrossesCalendarYearBoundaries = new ResolveAsyncValue(() => [
-    this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries'),
-  ]);
+  crossesBoundaryConfig = new TrackedAsyncData(
+    this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries')
+  );
+
+  @cached
+  get academicYearCrossesCalendarYearBoundaries() {
+    return this.crossesBoundaryConfig.isResolved ? this.crossesBoundaryConfig.value : null;
+  }
 }

--- a/addon/components/course-visualize-vocabulary.js
+++ b/addon/components/course-visualize-vocabulary.js
@@ -1,12 +1,17 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class CourseVisualizeVocabularyComponent extends Component {
   @service iliosConfig;
 
-  @use academicYearCrossesCalendarYearBoundaries = new ResolveAsyncValue(() => [
-    this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries'),
-  ]);
+  crossesBoundaryConfig = new TrackedAsyncData(
+    this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries')
+  );
+
+  @cached
+  get academicYearCrossesCalendarYearBoundaries() {
+    return this.crossesBoundaryConfig.isResolved ? this.crossesBoundaryConfig.value : null;
+  }
 }

--- a/addon/components/course/loader.hbs
+++ b/addon/components/course/loader.hbs
@@ -1,32 +1,34 @@
-{{#if this.isLoaded}}
-  <IliosCourseDetails
-    @course={{@course}}
-    @editable={{@editable}}
-    @showDetails={{@showDetails}}
-    @setShowDetails={{@setShowDetails}}
-    @courseLeadershipDetails={{@courseLeadershipDetails}}
-    @courseObjectiveDetails={{@courseObjectiveDetails}}
-    @courseTaxonomyDetails={{@courseTaxonomyDetails}}
-    @courseCompetencyDetails={{@courseCompetencyDetails}}
-    @courseManageLeadership={{@courseManageLeadership}}
-    @setCourseLeadershipDetails={{@setCourseLeadershipDetails}}
-    @setCourseObjectiveDetails={{@setCourseObjectiveDetails}}
-    @setCourseTaxonomyDetails={{@setCourseTaxonomyDetails}}
-    @setCourseCompetencyDetails={{@setCourseCompetencyDetails}}
-    @setCourseManageLeadership={{@setCourseManageLeadership}}
-  />
-{{else}}
-  <Course::BackToCourses />
+{{#let (load this.courseLoadingPromise) as |p|}}
+  {{#if p.isResolved}}
+    <IliosCourseDetails
+      @course={{@course}}
+      @editable={{@editable}}
+      @showDetails={{@showDetails}}
+      @setShowDetails={{@setShowDetails}}
+      @courseLeadershipDetails={{@courseLeadershipDetails}}
+      @courseObjectiveDetails={{@courseObjectiveDetails}}
+      @courseTaxonomyDetails={{@courseTaxonomyDetails}}
+      @courseCompetencyDetails={{@courseCompetencyDetails}}
+      @courseManageLeadership={{@courseManageLeadership}}
+      @setCourseLeadershipDetails={{@setCourseLeadershipDetails}}
+      @setCourseObjectiveDetails={{@setCourseObjectiveDetails}}
+      @setCourseTaxonomyDetails={{@setCourseTaxonomyDetails}}
+      @setCourseCompetencyDetails={{@setCourseCompetencyDetails}}
+      @setCourseManageLeadership={{@setCourseManageLeadership}}
+    />
+  {{else}}
+    <Course::BackToCourses />
 
-  <section aria-hidden="true" class="course-loader" {{animate-loading "course" finalOpacity=".75"}}>
-    <CourseHeader @course={{@course}} @editable={{false}} />
-    <CourseOverview @course={{@course}} @editable={{false}} />
+    <section aria-hidden="true" class="course-loader" {{animate-loading "course" finalOpacity=".75"}}>
+      <CourseHeader @course={{@course}} @editable={{false}} />
+      <CourseOverview @course={{@course}} @editable={{false}} />
 
-    <div class="mock-detail-box" >
-      <span>
-        {{t "general.expandDetail"}}
-        <FaIcon @icon="square-plus" class="expand-collapse-icon" />
-      </span>
-    </div>
-  </section>
-{{/if}}
+      <div class="mock-detail-box" >
+        <span>
+          {{t "general.expandDetail"}}
+          <FaIcon @icon="square-plus" class="expand-collapse-icon" />
+        </span>
+      </div>
+    </section>
+  {{/if}}
+{{/let}}

--- a/addon/components/course/loader.js
+++ b/addon/components/course/loader.js
@@ -1,17 +1,7 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 
 export default class CourseLoaderComponent extends Component {
   @service dataLoader;
-  @service intl;
-
-  @use loadedCourse = new ResolveAsyncValue(() => [
-    this.dataLoader.loadCourse(this.args.course.id),
-  ]);
-
-  get isLoaded() {
-    return Boolean(this.loadedCourse);
-  }
+  courseLoadingPromise = this.dataLoader.loadCourse(this.args.course.id);
 }

--- a/addon/components/course/objective-list-item.js
+++ b/addon/components/course/objective-list-item.js
@@ -5,8 +5,8 @@ import { dropTask, restartableTask, timeout } from 'ember-concurrency';
 import { inject as service } from '@ember/service';
 import { validatable, Length, HtmlNotBlank } from 'ilios-common/decorators/validation';
 import { findById, mapBy } from 'ilios-common/utils/array-helpers';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 @validatable
 export default class CourseObjectiveListItemComponent extends Component {
@@ -21,8 +21,23 @@ export default class CourseObjectiveListItemComponent extends Component {
   @tracked termsBuffer = [];
   @tracked selectedVocabulary;
 
-  @use parents = new ResolveAsyncValue(() => [this.args.courseObjective.programYearObjectives]);
-  @use meshDescriptors = new ResolveAsyncValue(() => [this.args.courseObjective.meshDescriptors]);
+  @cached
+  get parentsData() {
+    return new TrackedAsyncData(this.args.courseObjective.programYearObjectives);
+  }
+
+  @cached
+  get meshDescriptorsData() {
+    return new TrackedAsyncData(this.args.courseObjective.meshDescriptors);
+  }
+
+  get parents() {
+    return this.parentsData.isResolved ? this.parentsData.value : null;
+  }
+
+  get meshDescriptors() {
+    return this.meshDescriptorsData.isResolved ? this.meshDescriptorsData.value : null;
+  }
 
   @action
   load(element, [courseObjective]) {

--- a/addon/components/course/objective-list.js
+++ b/addon/components/course/objective-list.js
@@ -5,7 +5,8 @@ import { map } from 'rsvp';
 import { inject as service } from '@ember/service';
 import { use } from 'ember-could-get-used-to-this';
 import AsyncProcess from 'ilios-common/classes/async-process';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import sortableByPosition from 'ilios-common/utils/sortable-by-position';
 import { findById } from 'ilios-common/utils/array-helpers';
 
@@ -16,7 +17,19 @@ export default class CourseObjectiveListComponent extends Component {
 
   @tracked isSorting = false;
 
-  @use courseObjectivesAsync = new ResolveAsyncValue(() => [this.args.course.courseObjectives]);
+  @cached
+  get courseObjectivesAsyncData() {
+    return new TrackedAsyncData(this.args.course.courseObjectives);
+  }
+
+  @cached
+  get courseCohortsAsyncData() {
+    return new TrackedAsyncData(this.args.course.cohorts);
+  }
+
+  get courseObjectivesAsync() {
+    return this.courseObjectivesAsyncData.isResolved ? this.courseObjectivesAsyncData.value : null;
+  }
 
   get courseObjectives() {
     if (this.load.lastSuccessful && this.courseObjectivesAsync) {
@@ -26,7 +39,9 @@ export default class CourseObjectiveListComponent extends Component {
     return undefined;
   }
 
-  @use courseCohortsAsync = new ResolveAsyncValue(() => [this.args.course.cohorts]);
+  get courseCohortsAsync() {
+    return this.courseCohortsAsyncData.isResolved ? this.courseCohortsAsyncData.value : null;
+  }
 
   get courseCohorts() {
     if (this.load.lastSuccessful && this.courseCohortsAsync) {

--- a/addon/components/dashboard/materials.js
+++ b/addon/components/dashboard/materials.js
@@ -6,7 +6,8 @@ import { isPresent } from '@ember/utils';
 import { restartableTask, timeout } from 'ember-concurrency';
 import { use } from 'ember-could-get-used-to-this';
 import AsyncProcess from 'ilios-common/classes/async-process';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import moment from 'moment';
 import { filterBy, sortBy, uniqueById } from 'ilios-common/utils/array-helpers';
 
@@ -24,9 +25,15 @@ export default class DashboardMaterialsComponent extends Component {
     this.loadMaterials.bind(this),
     this.args.showAllMaterials,
   ]);
-  @use academicYearCrossesCalendarYearBoundaries = new ResolveAsyncValue(() => [
-    this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries'),
-  ]);
+
+  crossesBoundaryConfig = new TrackedAsyncData(
+    this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries')
+  );
+
+  @cached
+  get academicYearCrossesCalendarYearBoundaries() {
+    return this.crossesBoundaryConfig.isResolved ? this.crossesBoundaryConfig.value : null;
+  }
 
   async loadMaterials() {
     const user = await this.currentUser.getModel();

--- a/addon/components/dashboard/selected-term-tree.js
+++ b/addon/components/dashboard/selected-term-tree.js
@@ -1,13 +1,17 @@
 import Component from '@glimmer/component';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class DashboardSelectedTermTreeComponent extends Component {
-  @use terms = new ResolveAsyncValue(() => [this.args.term.children]);
+  @cached
+  get childrenData() {
+    return new TrackedAsyncData(this.args.term.children);
+  }
 
   get children() {
-    return this.terms ? this.terms.slice() : [];
+    return this.childrenData.isResolved ? this.childrenData.value.slice() : [];
   }
+
   get level() {
     return this.args.level ?? 0;
   }

--- a/addon/components/detail-cohorts.js
+++ b/addon/components/detail-cohorts.js
@@ -3,14 +3,21 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { dropTask } from 'ember-concurrency';
 import { map, all } from 'rsvp';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class DetailCohortsComponent extends Component {
   @tracked isManaging = false;
   @tracked bufferedCohorts = [];
 
-  @use cohorts = new ResolveAsyncValue(() => [this.args.course.cohorts]);
+  @cached
+  get cohortsData() {
+    return new TrackedAsyncData(this.args.course.cohorts);
+  }
+
+  get cohorts() {
+    return this.cohortsData.isResolved ? this.cohortsData.value : null;
+  }
 
   manage = dropTask(async () => {
     const cohorts = await this.args.course.cohorts;

--- a/addon/components/detail-instructors.js
+++ b/addon/components/detail-instructors.js
@@ -4,8 +4,8 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { dropTask, restartableTask } from 'ember-concurrency';
 import { hash } from 'rsvp';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
-import { use } from 'ember-could-get-used-to-this';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class DetailInstructorsComponent extends Component {
   @service currentUser;
@@ -13,9 +13,33 @@ export default class DetailInstructorsComponent extends Component {
   @tracked instructorGroupBuffer = [];
   @tracked instructorBuffer = [];
   @tracked availableInstructorGroups;
-  @use ilmSession = new ResolveAsyncValue(() => [this.args.session.ilmSession]);
-  @use ilmInstructors = new ResolveAsyncValue(() => [this.ilmSession?.instructors]);
-  @use ilmInstructorGroups = new ResolveAsyncValue(() => [this.ilmSession?.instructorGroups]);
+
+  @cached
+  get ilmSessionData() {
+    return new TrackedAsyncData(this.args.session.ilmSession);
+  }
+
+  @cached
+  get ilmInstructorsData() {
+    return new TrackedAsyncData(this.ilmSession?.instructors);
+  }
+
+  @cached
+  get ilmInstructorGroupsData() {
+    return new TrackedAsyncData(this.ilmSession?.instructorGroups);
+  }
+
+  get ilmSession() {
+    return this.ilmSessionData.isResolved ? this.ilmSessionData.value : null;
+  }
+
+  get ilmInstructors() {
+    return this.ilmInstructorsData.isResolved ? this.ilmInstructorsData.value : null;
+  }
+
+  get ilmInstructorGroups() {
+    return this.ilmInstructorGroupsData.isResolved ? this.ilmInstructorGroupsData.value : null;
+  }
 
   constructor() {
     super(...arguments);

--- a/addon/components/detail-learners-and-learner-groups.js
+++ b/addon/components/detail-learners-and-learner-groups.js
@@ -5,8 +5,8 @@ import { inject as service } from '@ember/service';
 import { dropTask } from 'ember-concurrency';
 import { hash } from 'rsvp';
 import { uniqueValues } from 'ilios-common/utils/array-helpers';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
-import { use } from 'ember-could-get-used-to-this';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class DetailLearnersAndLearnerGroupsComponent extends Component {
   @service currentUser;
@@ -14,11 +14,50 @@ export default class DetailLearnersAndLearnerGroupsComponent extends Component {
   @tracked learnerGroupBuffer = [];
   @tracked learnerBuffer = [];
 
-  @use ilmSession = new ResolveAsyncValue(() => [this.args.session.ilmSession]);
-  @use course = new ResolveAsyncValue(() => [this.args.session.course]);
-  @use cohorts = new ResolveAsyncValue(() => [this.course?.cohorts]);
-  @use ilmLearners = new ResolveAsyncValue(() => [this.ilmSession?.learners]);
-  @use ilmLearnerGroups = new ResolveAsyncValue(() => [this.ilmSession?.learnerGroups]);
+  @cached
+  get ilmSessionData() {
+    return new TrackedAsyncData(this.args.session.ilmSession);
+  }
+
+  @cached
+  get courseData() {
+    return new TrackedAsyncData(this.args.session.course);
+  }
+
+  @cached
+  get cohortsData() {
+    return new TrackedAsyncData(this.course?.cohorts);
+  }
+
+  @cached
+  get ilmLearnersData() {
+    return new TrackedAsyncData(this.ilmSession?.learners);
+  }
+
+  @cached
+  get ilmLearnerGroupsData() {
+    return new TrackedAsyncData(this.ilmSession?.learnerGroups);
+  }
+
+  get ilmSession() {
+    return this.ilmSessionData.isResolved ? this.ilmSessionData.value : null;
+  }
+
+  get course() {
+    return this.courseData.isResolved ? this.courseData.value : null;
+  }
+
+  get cohorts() {
+    return this.cohortsData.isResolved ? this.cohortsData.value : null;
+  }
+
+  get ilmLearners() {
+    return this.ilmLearnersData.isResolved ? this.ilmLearnersData.value : null;
+  }
+
+  get ilmLearnerGroups() {
+    return this.ilmLearnerGroupsData.isResolved ? this.ilmLearnerGroupsData.value : null;
+  }
 
   manage = dropTask(async () => {
     const ilmSession = await this.args.session.ilmSession;

--- a/addon/components/detail-learning-materials-item.js
+++ b/addon/components/detail-learning-materials-item.js
@@ -2,21 +2,26 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { dropTask } from 'ember-concurrency';
 import AsyncProcess from 'ilios-common/classes/async-process';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import { use } from 'ember-could-get-used-to-this';
 
 export default class DetailLearningMaterialsItemComponent extends Component {
   @tracked showRemoveConfirmation = false;
 
   @use owningUser = new AsyncProcess(() => [this.getOwningUser.bind(this), this.args.lm]);
-  @use meshDescriptorsResource = new ResolveAsyncValue(() => [this.args.lm.meshDescriptors]);
 
-  get meshDescriptorsLoaded() {
-    return !!this.meshDescriptorsResource;
+  @cached
+  get meshDescriptorsData() {
+    return new TrackedAsyncData(this.args.lm.meshDescriptors);
   }
 
   get meshDescriptors() {
-    return this.meshDescriptorsResource ? this.meshDescriptorsResource.slice() : [];
+    return this.meshDescriptorsData.isResolved ? this.meshDescriptorsData.value.slice() : [];
+  }
+
+  get meshDescriptorsLoaded() {
+    return this.meshDescriptorsData.isResolved;
   }
 
   async getOwningUser(lm) {

--- a/addon/components/detail-learning-materials.js
+++ b/addon/components/detail-learning-materials.js
@@ -5,8 +5,8 @@ import { action } from '@ember/object';
 import { dropTask } from 'ember-concurrency';
 import { all } from 'rsvp';
 import scrollIntoView from 'scroll-into-view';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import { mapBy } from 'ilios-common/utils/array-helpers';
 import sortableByPosition from 'ilios-common/utils/sortable-by-position';
 
@@ -24,7 +24,10 @@ export default class DetailCohortsComponent extends Component {
   @tracked learningMaterialUserRoles;
   @tracked title;
 
-  @use lmResource = new ResolveAsyncValue(() => [this.args.subject.learningMaterials]);
+  @cached
+  get lmData() {
+    return new TrackedAsyncData(this.args.subject.learningMaterials);
+  }
 
   constructor() {
     super(...arguments);
@@ -32,11 +35,12 @@ export default class DetailCohortsComponent extends Component {
     this.learningMaterialUserRoles = this.store.peekAll('learning-material-user-role').slice();
   }
 
+  @cached
   get materials() {
-    if (!this.lmResource) {
+    if (!this.lmData.isResolved) {
       return [];
     }
-    return this.lmResource.slice().sort(sortableByPosition);
+    return this.lmData.value.slice().sort(sortableByPosition);
   }
 
   get parentMaterialIds() {

--- a/addon/components/detail-taxonomies.js
+++ b/addon/components/detail-taxonomies.js
@@ -3,8 +3,8 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { dropTask } from 'ember-concurrency';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class DetailTaxonomiesComponent extends Component {
   @service store;
@@ -12,7 +12,15 @@ export default class DetailTaxonomiesComponent extends Component {
   @service flashMessages;
   @tracked bufferedTerms = [];
   @tracked isManaging = false;
-  @use terms = new ResolveAsyncValue(() => [this.args.subject.terms]);
+
+  @cached
+  get termsData() {
+    return new TrackedAsyncData(this.args.subject.terms);
+  }
+
+  get terms() {
+    return this.termsData.isResolved ? this.termsData.value : null;
+  }
 
   get showCollapsible() {
     const terms = this.args.subject.hasMany('terms').ids();

--- a/addon/components/detail-terms-list-item.js
+++ b/addon/components/detail-terms-list-item.js
@@ -2,7 +2,8 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { use } from 'ember-could-get-used-to-this';
 import AsyncProcess from 'ilios-common/classes/async-process';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class DetailTermsListItem extends Component {
   @tracked isHovering;
@@ -12,7 +13,14 @@ export default class DetailTermsListItem extends Component {
     this.args.term.getAllParentTitles.bind(this.args.term),
   ]);
 
-  @use parent = new ResolveAsyncValue(() => [this.args.term.parent]);
+  @cached
+  get parentData() {
+    return new TrackedAsyncData(this.args.term.parent);
+  }
+
+  get parent() {
+    return this.parentData.isResolved ? this.parentData.value : null;
+  }
 
   get showTooltip() {
     return this.args?.term.description?.length && this.theElement && this.isHovering;

--- a/addon/components/learnergroup-selection-cohort-manager.hbs
+++ b/addon/components/learnergroup-selection-cohort-manager.hbs
@@ -2,7 +2,7 @@
   class="learnergroup-selection-cohort-manager"
   data-test-learnergroup-selection-cohort-manager
 >
-  {{#if this.learnerGroupsLoaded}}
+  {{#if this.learnerGroups.isResolved}}
     <h5 class="cohort-title" data-test-title-cohort-title>
       {{@cohort.programYear.program.title}}
       {{@cohort.title}}

--- a/addon/components/learnergroup-selection-cohort-manager.js
+++ b/addon/components/learnergroup-selection-cohort-manager.js
@@ -1,25 +1,24 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class LearnergroupSelectionCohortManagerComponent extends Component {
   @service intl;
 
-  @use learnerGroups = new ResolveAsyncValue(() => [this.args.cohort.learnerGroups]);
-
-  get learnerGroupsLoaded() {
-    return !!this.learnerGroups;
+  @cached
+  get learnerGroups() {
+    return new TrackedAsyncData(this.args.cohort.learnerGroups);
   }
 
   get rootLevelLearnerGroups() {
-    if (!this.learnerGroups) {
+    if (!this.learnerGroups.isResolved) {
       return [];
     }
-    return this.learnerGroups
-      .slice()
-      .filter((learnerGroup) => learnerGroup.belongsTo('parent').value() === null);
+    return this.learnerGroups.value.filter(
+      (learnerGroup) => learnerGroup.belongsTo('parent').value() === null
+    );
   }
 
   @action

--- a/addon/components/learnergroup-tree.js
+++ b/addon/components/learnergroup-tree.js
@@ -3,7 +3,8 @@ import { action } from '@ember/object';
 import { filter } from 'rsvp';
 import { inject as service } from '@ember/service';
 import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import AsyncProcess from 'ilios-common/classes/async-process';
 
 export default class LearnergroupTree extends Component {
@@ -13,7 +14,14 @@ export default class LearnergroupTree extends Component {
     return this.args.isRoot ?? true;
   }
 
-  @use children = new ResolveAsyncValue(() => [this.args.learnerGroup.children]);
+  @cached
+  get childrenData() {
+    return new TrackedAsyncData(this.args.learnerGroup.children);
+  }
+
+  get children() {
+    return this.childrenData.isResolved ? this.childrenData.value : null;
+  }
 
   @use hasUnSelectedChildren = new AsyncProcess(() => [
     this.getHasUnSelectedChildren.bind(this),

--- a/addon/components/learning-materials-sort-manager.hbs
+++ b/addon/components/learning-materials-sort-manager.hbs
@@ -2,7 +2,7 @@
   class="learning-materials-sort-manager"
   data-test-detail-learning-materials-sort-manager
 >
-  {{#if (is-array this.learningMaterials)}}
+  {{#if this.learningMaterials.isResolved}}
     <div class="actions">
       <button class="bigadd" type="button" {{on "click" (perform this.callSave)}} data-test-save>
         <FaIcon

--- a/addon/components/learning-materials-sort-manager.js
+++ b/addon/components/learning-materials-sort-manager.js
@@ -3,8 +3,8 @@ import { dropTask } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
 import sortableByPosition from 'ilios-common/utils/sortable-by-position';
 import { action } from '@ember/object';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class LearningMaterialsSortManagerComponent extends Component {
   @tracked sortableObjectList;
@@ -13,9 +13,16 @@ export default class LearningMaterialsSortManagerComponent extends Component {
   @tracked draggedBelowItem;
   @tracked sortedItems;
 
-  @use learningMaterials = new ResolveAsyncValue(() => [this.args.subject.learningMaterials]);
+  @cached
+  get learningMaterials() {
+    return new TrackedAsyncData(this.args.subject.learningMaterials);
+  }
+
   get sortedLearningMaterials() {
-    return this.learningMaterials?.slice().sort(sortableByPosition) ?? [];
+    if (!this.learningMaterials.isResolved) {
+      return [];
+    }
+    return this.learningMaterials.value.slice().sort(sortableByPosition);
   }
 
   get items() {

--- a/addon/components/mesh-descriptor-last-tree-number.js
+++ b/addon/components/mesh-descriptor-last-tree-number.js
@@ -1,14 +1,17 @@
 import Component from '@glimmer/component';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class MeshDescriptorLastTreeNumber extends Component {
-  @use trees = new ResolveAsyncValue(() => [this.args.descriptor.trees]);
+  @cached
+  get trees() {
+    return new TrackedAsyncData(this.args.descriptor.trees);
+  }
 
   get value() {
-    if (!this.trees || !this.trees.length) {
+    if (!this.trees.isResolved || !this.trees.value.length) {
       return '';
     }
-    return this.trees.toArray().reverse()[0].treeNumber;
+    return this.trees.value.slice().reverse()[0].treeNumber;
   }
 }

--- a/addon/components/new-learningmaterial.js
+++ b/addon/components/new-learningmaterial.js
@@ -12,8 +12,8 @@ import {
   IsURL,
 } from 'ilios-common/decorators/validation';
 import { ValidateIf } from 'class-validator';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import { findBy, findById } from 'ilios-common/utils/array-helpers';
 
 const DEFAULT_URL_VALUE = 'https://';
@@ -49,7 +49,12 @@ export default class NewLearningmaterialComponent extends Component {
   @ValidateIf((o) => o.isCitation) @NotBlank() @tracked citation;
   @tracked fileUploadErrorMessage = false;
 
-  @use currentUserModel = new ResolveAsyncValue(() => [this.currentUser.getModel()]);
+  userModel = new TrackedAsyncData(this.currentUser.getModel());
+
+  @cached
+  get currentUserModel() {
+    return this.userModel.isResolved ? this.userModel.value : null;
+  }
 
   get isFile() {
     return this.args.type === 'file';

--- a/addon/components/objective-list-item-terms.js
+++ b/addon/components/objective-list-item-terms.js
@@ -1,7 +1,14 @@
 import Component from '@glimmer/component';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class ObjectiveListItemTermsComponent extends Component {
-  @use terms = new ResolveAsyncValue(() => [this.args.subject.terms]);
+  @cached
+  get termsData() {
+    return new TrackedAsyncData(this.args.subject.terms);
+  }
+
+  get terms() {
+    return this.termsData.isResolved ? this.termsData.value : null;
+  }
 }

--- a/addon/components/objective-sort-manager.js
+++ b/addon/components/objective-sort-manager.js
@@ -4,8 +4,8 @@ import { dropTask } from 'ember-concurrency';
 import sortableByPosition from 'ilios-common/utils/sortable-by-position';
 import { all } from 'rsvp';
 import { action } from '@ember/object';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class ObjectiveSortManagerComponent extends Component {
   @tracked totalObjectivesToSave;
@@ -15,9 +15,16 @@ export default class ObjectiveSortManagerComponent extends Component {
   @tracked draggedBelowItem;
   @tracked sortedItems;
 
-  @use objectives = new ResolveAsyncValue(() => [this.args.subject.xObjectives]);
+  @cached
+  get objectives() {
+    return new TrackedAsyncData(this.args.subject.xObjectives);
+  }
+
   get sortedObjectives() {
-    return this.objectives?.slice().sort(sortableByPosition) ?? [];
+    if (!this.objectives.isResolved) {
+      return [];
+    }
+    return this.objectives.value.slice().sort(sortableByPosition);
   }
 
   get items() {

--- a/addon/components/offering-manager.js
+++ b/addon/components/offering-manager.js
@@ -3,8 +3,8 @@ import { action, set } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { task, timeout } from 'ember-concurrency';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class OfferingManagerComponent extends Component {
   @service intl;
@@ -12,10 +12,41 @@ export default class OfferingManagerComponent extends Component {
   @tracked showRemoveConfirmation = false;
   @tracked hoveredGroups = [];
 
-  @use learnerGroups = new ResolveAsyncValue(() => [this.args.offering.learnerGroups]);
-  @use session = new ResolveAsyncValue(() => [this.args.offering?.session]);
-  @use course = new ResolveAsyncValue(() => [this.session?.course]);
-  @use cohorts = new ResolveAsyncValue(() => [this.course?.cohorts]);
+  @cached
+  get learnerGroupsData() {
+    return new TrackedAsyncData(this.args.offering.learnerGroups);
+  }
+
+  @cached
+  get sessionData() {
+    return new TrackedAsyncData(this.args.offering?.session);
+  }
+
+  @cached
+  get courseData() {
+    return new TrackedAsyncData(this.session?.course);
+  }
+
+  @cached
+  get cohortsData() {
+    return new TrackedAsyncData(this.course?.cohorts);
+  }
+
+  get learnerGroups() {
+    return this.learnerGroupsData.isResolved ? this.learnerGroupsData.value : null;
+  }
+
+  get session() {
+    return this.sessionData.isResolved ? this.sessionData.value : null;
+  }
+
+  get course() {
+    return this.courseData.isResolved ? this.courseData.value : null;
+  }
+
+  get cohorts() {
+    return this.cohortsData.isResolved ? this.cohortsData.value : null;
+  }
 
   get cohortsLoaded() {
     return !!this.cohorts;

--- a/addon/components/print-course-session.js
+++ b/addon/components/print-course-session.js
@@ -1,11 +1,50 @@
 import Component from '@glimmer/component';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
-import { use } from 'ember-could-get-used-to-this';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class PrintCourseSessionComponent extends Component {
-  @use sessionObjectives = new ResolveAsyncValue(() => [this.args.session.sessionObjectives, []]);
-  @use learningMaterials = new ResolveAsyncValue(() => [this.args.session.learningMaterials, []]);
-  @use meshDescriptors = new ResolveAsyncValue(() => [this.args.session.meshDescriptors, []]);
-  @use offerings = new ResolveAsyncValue(() => [this.args.session.offerings, []]);
-  @use terms = new ResolveAsyncValue(() => [this.args.session.terms, []]);
+  @cached
+  get sessionObjectivesData() {
+    return new TrackedAsyncData(this.args.session.sessionObjectives);
+  }
+
+  @cached
+  get learningMaterialsData() {
+    return new TrackedAsyncData(this.args.session.learningMaterials);
+  }
+
+  @cached
+  get meshDescriptorsData() {
+    return new TrackedAsyncData(this.args.session.meshDescriptors);
+  }
+
+  @cached
+  get offeringsData() {
+    return new TrackedAsyncData(this.args.session.offerings);
+  }
+
+  @cached
+  get termsData() {
+    return new TrackedAsyncData(this.args.session.terms);
+  }
+
+  get sessionObjectives() {
+    return this.sessionObjectivesData.isResolved ? this.sessionObjectivesData.value : [];
+  }
+
+  get learningMaterials() {
+    return this.learningMaterialsData.isResolved ? this.learningMaterialsData.value : [];
+  }
+
+  get meshDescriptors() {
+    return this.meshDescriptorsData.isResolved ? this.meshDescriptorsData.value : [];
+  }
+
+  get offerings() {
+    return this.offeringsData.isResolved ? this.offeringsData.value : [];
+  }
+
+  get terms() {
+    return this.termsData.isResolved ? this.termsData.value : [];
+  }
 }

--- a/addon/components/print-course.js
+++ b/addon/components/print-course.js
@@ -3,8 +3,8 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { dropTask } from 'ember-concurrency';
 import sortableByPosition from 'ilios-common/utils/sortable-by-position';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
-import { use } from 'ember-could-get-used-to-this';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class PrintCourseComponent extends Component {
   @service store;
@@ -14,13 +14,52 @@ export default class PrintCourseComponent extends Component {
   @tracked sortDirectorsBy;
   @tracked academicYearCrossesCalendarYearBoundaries = false;
 
-  @use competencies = new ResolveAsyncValue(() => [this.args.course.competencies, []]);
-  @use directors = new ResolveAsyncValue(() => [this.args.course.directors, []]);
-  @use courseLearningMaterialsRelationship = new ResolveAsyncValue(() => [
-    this.args.course.learningMaterials,
-  ]);
-  @use sessionsRelationship = new ResolveAsyncValue(() => [this.args.course.sessions]);
-  @use meshDescriptors = new ResolveAsyncValue(() => [this.args.course.meshDescriptors, []]);
+  @cached
+  get competenciesData() {
+    return new TrackedAsyncData(this.args.course.competencies);
+  }
+
+  @cached
+  get directorsData() {
+    return new TrackedAsyncData(this.args.course.directors);
+  }
+
+  @cached
+  get courseLearningMaterialsRelationshipData() {
+    return new TrackedAsyncData(this.args.course.learningMaterials);
+  }
+
+  @cached
+  get sessionsRelationshipData() {
+    return new TrackedAsyncData(this.args.course.sessions);
+  }
+
+  @cached
+  get meshDescriptorsData() {
+    return new TrackedAsyncData(this.args.course.meshDescriptors);
+  }
+
+  get competencies() {
+    return this.competenciesData.isResolved ? this.competenciesData.value : [];
+  }
+
+  get directors() {
+    return this.directorsData.isResolved ? this.directorsData.value : [];
+  }
+
+  get courseLearningMaterialsRelationship() {
+    return this.courseLearningMaterialsRelationshipData.isResolved
+      ? this.courseLearningMaterialsRelationshipData.value
+      : null;
+  }
+
+  get sessionsRelationship() {
+    return this.sessionsRelationshipData.isResolved ? this.sessionsRelationshipData.value : null;
+  }
+
+  get meshDescriptors() {
+    return this.meshDescriptorsData.isResolved ? this.meshDescriptorsData.value : [];
+  }
 
   load = dropTask(async () => {
     this.academicYearCrossesCalendarYearBoundaries = await this.iliosConfig.itemFromConfig(

--- a/addon/components/publish-all-sessions.js
+++ b/addon/components/publish-all-sessions.js
@@ -4,8 +4,8 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { all } from 'rsvp';
 import { dropTask, timeout } from 'ember-concurrency';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
-import { use } from 'ember-could-get-used-to-this';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import { uniqueValues } from 'ilios-common/utils/array-helpers';
 
 export default class PublishAllSessionsComponent extends Component {
@@ -21,8 +21,23 @@ export default class PublishAllSessionsComponent extends Component {
   @tracked userSelectedSessionsToPublish = [];
   @tracked userSelectedSessionsToSchedule = [];
 
-  @use courseObjectives = new ResolveAsyncValue(() => [this.args.course.courseObjectives]);
-  @use sessions = new ResolveAsyncValue(() => [this.args.course.sessions, []]);
+  @cached
+  get courseObjectivesData() {
+    return new TrackedAsyncData(this.args.course.courseObjectives);
+  }
+
+  @cached
+  get sessionsData() {
+    return new TrackedAsyncData(this.args.course.sessions);
+  }
+
+  get courseObjectives() {
+    return this.courseObjectivesData.isResolved ? this.courseObjectivesData.value : null;
+  }
+
+  get sessions() {
+    return this.sessionsData.isResolved ? this.sessionsData.value : [];
+  }
 
   get publishedSessions() {
     return this.overridableSessions.filter((s) => {

--- a/addon/components/selected-instructor-group-members.js
+++ b/addon/components/selected-instructor-group-members.js
@@ -1,7 +1,14 @@
 import Component from '@glimmer/component';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
-import { use } from 'ember-could-get-used-to-this';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class SelectedInstructorGroupMembersComponent extends Component {
-  @use members = new ResolveAsyncValue(() => [this.args.instructorGroup.users, []]);
+  @cached
+  get membersData() {
+    return new TrackedAsyncData(this.args.instructorGroup.users);
+  }
+
+  get members() {
+    return this.membersData.isResolved ? this.membersData.value : [];
+  }
 }

--- a/addon/components/session-details.js
+++ b/addon/components/session-details.js
@@ -1,8 +1,23 @@
 import Component from '@glimmer/component';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
-import { use } from 'ember-could-get-used-to-this';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class SessionDetailsComponent extends Component {
-  @use course = new ResolveAsyncValue(() => [this.args.session.course]);
-  @use cohorts = new ResolveAsyncValue(() => [this.course?.cohorts]);
+  @cached
+  get courseData() {
+    return new TrackedAsyncData(this.args.session.course);
+  }
+
+  @cached
+  get cohortsData() {
+    return new TrackedAsyncData(this.course?.cohorts);
+  }
+
+  get course() {
+    return this.courseData.isResolved ? this.courseData.value : null;
+  }
+
+  get cohorts() {
+    return this.cohortsData.isResolved ? this.cohortsData.value : null;
+  }
 }

--- a/addon/components/session-offerings.js
+++ b/addon/components/session-offerings.js
@@ -1,8 +1,23 @@
 import Component from '@glimmer/component';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
-import { use } from 'ember-could-get-used-to-this';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class SessionOfferingsComponent extends Component {
-  @use course = new ResolveAsyncValue(() => [this.args.session.course]);
-  @use cohorts = new ResolveAsyncValue(() => [this.course?.cohorts]);
+  @cached
+  get courseData() {
+    return new TrackedAsyncData(this.args.session.course);
+  }
+
+  @cached
+  get cohortsData() {
+    return new TrackedAsyncData(this.course?.cohorts);
+  }
+
+  get course() {
+    return this.courseData.isResolved ? this.courseData.value : null;
+  }
+
+  get cohorts() {
+    return this.cohortsData.isResolved ? this.cohortsData.value : null;
+  }
 }

--- a/addon/components/session-overview.js
+++ b/addon/components/session-overview.js
@@ -8,8 +8,8 @@ import moment from 'moment';
 import { validatable, Length, Gte, NotBlank } from 'ilios-common/decorators/validation';
 import { hash } from 'rsvp';
 import { findById, sortBy } from 'ilios-common/utils/array-helpers';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
-import { use } from 'ember-could-get-used-to-this';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 @validatable
 export default class SessionOverview extends Component {
@@ -37,10 +37,41 @@ export default class SessionOverview extends Component {
   @tracked showSpecialEquipmentRequired = false;
   @tracked isIndependentLearning = false;
 
-  @use prerequisites = new ResolveAsyncValue(() => [this.args.session.prerequisites]);
-  @use postrequisite = new ResolveAsyncValue(() => [this.args.session.postrequisite]);
-  @use postrequisiteCourse = new ResolveAsyncValue(() => [this.postrequisite?.course]);
-  @use ilmSession = new ResolveAsyncValue(() => [this.args.session.ilmSession]);
+  @cached
+  get prerequisitesData() {
+    return new TrackedAsyncData(this.args.session.prerequisites);
+  }
+
+  @cached
+  get postrequisiteData() {
+    return new TrackedAsyncData(this.args.session.postrequisite);
+  }
+
+  @cached
+  get postrequisiteCourseData() {
+    return new TrackedAsyncData(this.postrequisite?.course);
+  }
+
+  @cached
+  get ilmSessionData() {
+    return new TrackedAsyncData(this.args.session.ilmSession);
+  }
+
+  get prerequisites() {
+    return this.prerequisitesData.isResolved ? this.prerequisitesData.value : null;
+  }
+
+  get postrequisite() {
+    return this.postrequisiteData.isResolved ? this.postrequisiteData.value : null;
+  }
+
+  get postrequisiteCourse() {
+    return this.postrequisiteCourseData.isResolved ? this.postrequisiteCourseData.value : null;
+  }
+
+  get ilmSession() {
+    return this.ilmSessionData.isResolved ? this.ilmSessionData.value : null;
+  }
 
   get filteredSessionTypes() {
     const selectedSessionTypeId = isEmpty(this.sessionType) ? -1 : this.sessionType.id;

--- a/addon/components/session-publicationcheck.js
+++ b/addon/components/session-publicationcheck.js
@@ -1,16 +1,47 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
-import { use } from 'ember-could-get-used-to-this';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class SessionPublicationCheckComponent extends Component {
   @service router;
 
-  @use course = new ResolveAsyncValue(() => [this.args.session.course]);
-  @use school = new ResolveAsyncValue(() => [this.course?.school]);
-  @use sessionTypes = new ResolveAsyncValue(() => [this.school?.sessionTypes]);
-  @use sessionObjectives = new ResolveAsyncValue(() => [this.args.session.sessionObjectives, []]);
+  @cached
+  get courseData() {
+    return new TrackedAsyncData(this.args.session.course);
+  }
+
+  @cached
+  get schoolData() {
+    return new TrackedAsyncData(this.course?.school);
+  }
+
+  @cached
+  get sessionTypesData() {
+    return new TrackedAsyncData(this.school?.sessionTypes);
+  }
+
+  @cached
+  get sessionObjectivesData() {
+    return new TrackedAsyncData(this.args.session.sessionObjectives);
+  }
+
+  get course() {
+    return this.courseData.isResolved ? this.courseData.value : null;
+  }
+
+  get school() {
+    return this.schoolData.isResolved ? this.schoolData.value : null;
+  }
+
+  get sessionTypes() {
+    return this.sessionTypesData.isResolved ? this.sessionTypesData.value : null;
+  }
+
+  get sessionObjectives() {
+    return this.sessionObjectivesData.isResolved ? this.sessionObjectivesData.value : [];
+  }
 
   get showUnlinkIcon() {
     const objectivesWithoutParents = this.sessionObjectives.filter((objective) => {

--- a/addon/components/session/objective-list-item.js
+++ b/addon/components/session/objective-list-item.js
@@ -4,8 +4,8 @@ import { action } from '@ember/object';
 import { dropTask, restartableTask, timeout } from 'ember-concurrency';
 import { inject as service } from '@ember/service';
 import { validatable, Length, HtmlNotBlank } from 'ilios-common/decorators/validation';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 @validatable
 export default class SessionObjectiveListItemComponent extends Component {
@@ -20,8 +20,23 @@ export default class SessionObjectiveListItemComponent extends Component {
   @tracked termsBuffer = [];
   @tracked selectedVocabulary;
 
-  @use parents = new ResolveAsyncValue(() => [this.args.sessionObjective.courseObjectives]);
-  @use meshDescriptors = new ResolveAsyncValue(() => [this.args.sessionObjective.meshDescriptors]);
+  @cached
+  get parentsData() {
+    return new TrackedAsyncData(this.args.sessionObjective.courseObjectives);
+  }
+
+  @cached
+  get meshDescriptorsData() {
+    return new TrackedAsyncData(this.args.sessionObjective.meshDescriptors);
+  }
+
+  get parents() {
+    return this.parentsData.isResolved ? this.parentsData.value : null;
+  }
+
+  get meshDescriptors() {
+    return this.meshDescriptorsData.isResolved ? this.meshDescriptorsData.value : null;
+  }
 
   @action
   load(element, [sessionObjective]) {

--- a/addon/components/session/objective-list.js
+++ b/addon/components/session/objective-list.js
@@ -1,14 +1,37 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class SessionObjectiveListComponent extends Component {
   @tracked isSorting = false;
 
-  @use course = new ResolveAsyncValue(() => [this.args.session.course]);
-  @use courseObjectives = new ResolveAsyncValue(() => [this.course?.courseObjectives]);
-  @use sessionObjectives = new ResolveAsyncValue(() => [this.args.session.sortedSessionObjectives]);
+  @cached
+  get courseData() {
+    return new TrackedAsyncData(this.args.session.course);
+  }
+
+  @cached
+  get courseObjectivesData() {
+    return new TrackedAsyncData(this.course?.courseObjectives);
+  }
+
+  @cached
+  get sessionObjectivesData() {
+    return new TrackedAsyncData(this.args.session.sortedSessionObjectives);
+  }
+
+  get course() {
+    return this.courseData.isResolved ? this.courseData.value : null;
+  }
+
+  get courseObjectives() {
+    return this.courseObjectivesData.isResolved ? this.courseObjectivesData.value : null;
+  }
+
+  get sessionObjectives() {
+    return this.sessionObjectivesData.isResolved ? this.sessionObjectivesData.value : null;
+  }
 
   get sessionObjectiveCount() {
     return this.sessionObjectives?.length ?? 0;

--- a/addon/components/sessions-grid-offering-table.js
+++ b/addon/components/sessions-grid-offering-table.js
@@ -1,20 +1,25 @@
 import Component from '@glimmer/component';
 import { use } from 'ember-could-get-used-to-this';
 import PermissionChecker from 'ilios-common/classes/permission-checker';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import OfferingDateBlock from 'ilios-common/utils/offering-date-block';
 import { sortBy } from 'ilios-common/utils/array-helpers';
 
 export default class SessionsGridOfferingTable extends Component {
   @use canUpdate = new PermissionChecker(() => ['canUpdateSession', this.args.session]);
-  @use offerings = new ResolveAsyncValue(() => [this.args.session.offerings]);
+
+  @cached
+  get offerings() {
+    return new TrackedAsyncData(this.args.session.offerings);
+  }
 
   get offeringBlocks() {
-    if (!this.offerings) {
+    if (!this.offerings.isResolved) {
       return [];
     }
     const dateBlocks = {};
-    this.offerings.slice().forEach((offering) => {
+    this.offerings.value.slice().forEach((offering) => {
       const key = offering.get('dateKey');
       if (!(key in dateBlocks)) {
         dateBlocks[key] = new OfferingDateBlock(key);

--- a/addon/components/sessions-grid-offering.js
+++ b/addon/components/sessions-grid-offering.js
@@ -4,18 +4,50 @@ import { action } from '@ember/object';
 import { restartableTask, dropTask, timeout } from 'ember-concurrency';
 import { validatable, Length, NotBlank } from 'ilios-common/decorators/validation';
 import scrollIntoView from 'scroll-into-view';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
-import { use } from 'ember-could-get-used-to-this';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 @validatable
 export default class SessionsGridOffering extends Component {
   @Length(1, 255) @NotBlank() @tracked room;
   @tracked isEditing = false;
   @tracked wasUpdated = false;
-  @use session = new ResolveAsyncValue(() => [this.args.offering.session]);
-  @use course = new ResolveAsyncValue(() => [this.session?.course]);
-  @use cohorts = new ResolveAsyncValue(() => [this.course?.cohorts]);
-  @use learnerGroups = new ResolveAsyncValue(() => [this.args.offering.learnerGroups]);
+
+  @cached
+  get sessionData() {
+    return new TrackedAsyncData(this.args.offering.session);
+  }
+
+  @cached
+  get courseData() {
+    return new TrackedAsyncData(this.session?.course);
+  }
+
+  @cached
+  get cohortsData() {
+    return new TrackedAsyncData(this.course?.cohorts);
+  }
+
+  @cached
+  get learnerGroupsData() {
+    return new TrackedAsyncData(this.args.offering.learnerGroups);
+  }
+
+  get session() {
+    return this.sessionData.isResolved ? this.sessionData.value : null;
+  }
+
+  get course() {
+    return this.courseData.isResolved ? this.courseData.value : null;
+  }
+
+  get cohorts() {
+    return this.cohortsData.isResolved ? this.cohortsData.value : null;
+  }
+
+  get learnerGroups() {
+    return this.learnerGroupsData.isResolved ? this.learnerGroupsData.value : null;
+  }
 
   get cohortsLoaded() {
     return !!this.cohorts;

--- a/addon/components/single-event.js
+++ b/addon/components/single-event.js
@@ -5,8 +5,8 @@ import { inject as service } from '@ember/service';
 import { isBlank, isEmpty } from '@ember/utils';
 import moment from 'moment';
 import { findById } from 'ilios-common/utils/array-helpers';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class SingleEvent extends Component {
   @service currentUser;
@@ -17,7 +17,12 @@ export default class SingleEvent extends Component {
   @tracked isSessionMaterialsListExpanded = true;
   @tracked isCourseMaterialsListExpanded = false;
 
-  @use userIsStudent = new ResolveAsyncValue(() => [this.currentUser.getIsStudent()]);
+  userIsStudentData = new TrackedAsyncData(this.currentUser.getIsStudent());
+
+  @cached
+  get userIsStudent() {
+    return this.userIsStudentData.isResolved ? this.userIsStudentData.value : false;
+  }
 
   get courseId() {
     return this.args.event.course;

--- a/addon/components/visualizer-course-instructor-session-type.js
+++ b/addon/components/visualizer-course-instructor-session-type.js
@@ -6,7 +6,8 @@ import { restartableTask, timeout } from 'ember-concurrency';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import AsyncProcess from 'ilios-common/classes/async-process';
 import { findBy, mapBy, uniqueValues } from 'ilios-common/utils/array-helpers';
 
@@ -16,7 +17,15 @@ export default class VisualizerCourseInstructorSessionType extends Component {
   @tracked tooltipContent = null;
   @tracked tooltipTitle = null;
 
-  @use sessions = new ResolveAsyncValue(() => [this.args.course.sessions]);
+  @cached
+  get sessionsData() {
+    return new TrackedAsyncData(this.args.course.sessions);
+  }
+
+  get sessions() {
+    return this.sessionsData.isResolved ? this.sessionsData.value : null;
+  }
+
   @use loadedData = new AsyncProcess(() => [this.getData.bind(this), this.sessions]);
 
   get data() {

--- a/addon/components/visualizer-course-instructor-term.js
+++ b/addon/components/visualizer-course-instructor-term.js
@@ -6,7 +6,8 @@ import { restartableTask, timeout } from 'ember-concurrency';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import AsyncProcess from 'ilios-common/classes/async-process';
 import { findBy, mapBy, uniqueValues } from 'ilios-common/utils/array-helpers';
 
@@ -16,7 +17,15 @@ export default class VisualizerCourseInstructorTerm extends Component {
   @tracked tooltipContent = null;
   @tracked tooltipTitle = null;
 
-  @use sessions = new ResolveAsyncValue(() => [this.args.course.sessions]);
+  @cached
+  get sessionsData() {
+    return new TrackedAsyncData(this.args.course.sessions);
+  }
+
+  get sessions() {
+    return this.sessionsData.isResolved ? this.sessionsData.value : null;
+  }
+
   @use loadedData = new AsyncProcess(() => [this.getData.bind(this), this.sessions]);
 
   get data() {

--- a/addon/components/visualizer-course-instructors.js
+++ b/addon/components/visualizer-course-instructors.js
@@ -8,7 +8,8 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { cleanQuery } from 'ilios-common/utils/query-utils';
 import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import AsyncProcess from 'ilios-common/classes/async-process';
 import { findBy, mapBy, uniqueValues } from 'ilios-common/utils/array-helpers';
 
@@ -18,7 +19,15 @@ export default class VisualizerCourseInstructors extends Component {
   @tracked tooltipContent = null;
   @tracked tooltipTitle = null;
 
-  @use sessions = new ResolveAsyncValue(() => [this.args.course.sessions]);
+  @cached
+  get sessionsData() {
+    return new TrackedAsyncData(this.args.course.sessions);
+  }
+
+  get sessions() {
+    return this.sessionsData.isResolved ? this.sessionsData.value : null;
+  }
+
   @use loadedData = new AsyncProcess(() => [this.getData.bind(this), this.sessions]);
 
   get chartType() {

--- a/addon/components/visualizer-course-objectives.js
+++ b/addon/components/visualizer-course-objectives.js
@@ -6,7 +6,8 @@ import { htmlSafe } from '@ember/template';
 import { filter, map } from 'rsvp';
 import { restartableTask, timeout } from 'ember-concurrency';
 import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import AsyncProcess from 'ilios-common/classes/async-process';
 import { mapBy, sortBy } from 'ilios-common/utils/array-helpers';
 
@@ -19,7 +20,15 @@ export default class VisualizerCourseObjectives extends Component {
   @tracked tooltipTitle = null;
   @tracked sortBy = 'percentage:desc';
 
-  @use courseSessions = new ResolveAsyncValue(() => [this.args.course.sessions]);
+  @cached
+  get courseSessionsData() {
+    return new TrackedAsyncData(this.args.course.sessions);
+  }
+
+  get courseSessions() {
+    return this.courseSessionsData.isResolved ? this.courseSessionsData.value : null;
+  }
+
   @use dataObjects = new AsyncProcess(() => [this.getDataObjects.bind(this), this.sessions]);
 
   get sortedAscending() {

--- a/addon/components/visualizer-course-session-type.js
+++ b/addon/components/visualizer-course-session-type.js
@@ -7,7 +7,8 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import AsyncProcess from 'ilios-common/classes/async-process';
 import { findBy, mapBy, uniqueValues } from 'ilios-common/utils/array-helpers';
 
@@ -17,8 +18,24 @@ export default class VisualizerCourseSessionType extends Component {
   @tracked tooltipContent = null;
   @tracked tooltipTitle = null;
 
-  @use sessions = new ResolveAsyncValue(() => [this.args.course.sessions, []]);
-  @use sessionTypeSessions = new ResolveAsyncValue(() => [this.args.sessionType.sessions, []]);
+  @cached
+  get sessionsData() {
+    return new TrackedAsyncData(this.args.course.sessions);
+  }
+
+  @cached
+  get sessionTypeSessionsData() {
+    return new TrackedAsyncData(this.args.sessionType.sessions);
+  }
+
+  get sessions() {
+    return this.sessionsData.isResolved ? this.sessionsData.value : [];
+  }
+
+  get sessionTypeSessions() {
+    return this.sessionTypeSessionsData.isResolved ? this.sessionTypeSessionsData.value : [];
+  }
+
   @use dataObjects = new AsyncProcess(() => [
     this.getDataObjects.bind(this),
     this.sessionsAndSessionTypeSessions,

--- a/addon/components/visualizer-course-session-types.js
+++ b/addon/components/visualizer-course-session-types.js
@@ -7,7 +7,8 @@ import { action } from '@ember/object';
 import { cleanQuery } from 'ilios-common/utils/query-utils';
 import { map } from 'rsvp';
 import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import AsyncProcess from 'ilios-common/classes/async-process';
 import { findBy, mapBy, uniqueValues } from 'ilios-common/utils/array-helpers';
 
@@ -17,7 +18,15 @@ export default class VisualizerCourseSessionTypes extends Component {
   @tracked tooltipContent = null;
   @tracked tooltipTitle = null;
 
-  @use sessions = new ResolveAsyncValue(() => [this.args.course.sessions]);
+  @cached
+  get sessionsData() {
+    return new TrackedAsyncData(this.args.course.sessions);
+  }
+
+  get sessions() {
+    return this.sessionsData.isResolved ? this.sessionsData.value : null;
+  }
+
   @use loadedData = new AsyncProcess(() => [this.getData.bind(this), this.sessions]);
 
   get chartType() {

--- a/addon/components/visualizer-course-term.js
+++ b/addon/components/visualizer-course-term.js
@@ -4,7 +4,8 @@ import { restartableTask, timeout } from 'ember-concurrency';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
 import { findBy, findById, mapBy, uniqueValues } from 'ilios-common/utils/array-helpers';
 
@@ -14,7 +15,15 @@ export default class VisualizerCourseTerm extends Component {
   @tracked tooltipContent = null;
   @tracked tooltipTitle = null;
 
-  @use sessions = new ResolveAsyncValue(() => [this.args.course.sessions]);
+  @cached
+  get sessionsData() {
+    return new TrackedAsyncData(this.args.course.sessions);
+  }
+
+  get sessions() {
+    return this.sessionsData.isResolved ? this.sessionsData.value : null;
+  }
+
   @use sessionTypes = new ResolveFlatMapBy(() => [this.sessions, 'sessionType']);
 
   get isLoaded() {

--- a/addon/components/visualizer-course-vocabularies.js
+++ b/addon/components/visualizer-course-vocabularies.js
@@ -6,7 +6,8 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import AsyncProcess from 'ilios-common/classes/async-process';
 import { findBy, mapBy } from 'ilios-common/utils/array-helpers';
 
@@ -16,7 +17,14 @@ export default class VisualizerCourseVocabularies extends Component {
   @tracked tooltipContent = null;
   @tracked tooltipTitle = null;
 
-  @use sessions = new ResolveAsyncValue(() => [this.args.course.sessions, []]);
+  @cached
+  get sessionsData() {
+    return new TrackedAsyncData(this.args.course.sessions);
+  }
+
+  get sessions() {
+    return this.sessionsData.isResolved ? this.sessionsData.value : [];
+  }
 
   @use dataObjects = new AsyncProcess(() => [this.getDataObjects.bind(this), this.sessions]);
 

--- a/addon/components/visualizer-course-vocabulary.js
+++ b/addon/components/visualizer-course-vocabulary.js
@@ -6,7 +6,8 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import AsyncProcess from 'ilios-common/classes/async-process';
 import { findBy, mapBy, uniqueValues } from 'ilios-common/utils/array-helpers';
 
@@ -16,7 +17,14 @@ export default class VisualizerCourseVocabulary extends Component {
   @tracked tooltipContent = null;
   @tracked tooltipTitle = null;
 
-  @use sessions = new ResolveAsyncValue(() => [this.args.course.sessions, []]);
+  @cached
+  get sessionsData() {
+    return new TrackedAsyncData(this.args.course.sessions);
+  }
+
+  get sessions() {
+    return this.sessionsData.isResolved ? this.sessionsData.value : [];
+  }
 
   @use dataObjects = new AsyncProcess(() => [this.getDataObjects.bind(this), this.sessions]);
 

--- a/addon/components/week-glance.js
+++ b/addon/components/week-glance.js
@@ -4,20 +4,27 @@ import { isNone } from '@ember/utils';
 import { DateTime } from 'luxon';
 import scrollIntoView from 'scroll-into-view';
 import { action } from '@ember/object';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class WeeklyGlance extends Component {
   @service userEvents;
   @service intl;
   @service localeDays;
 
-  @use weekEvents = new ResolveAsyncValue(() => [
-    this.userEvents.getEvents(
-      this.midnightAtTheStartOfTheWeekDateTime.toUnixInteger(),
-      this.midnightAtTheEndOfTheWeekDateTime.toUnixInteger()
-    ),
-  ]);
+  @cached
+  get weekEventsData() {
+    return new TrackedAsyncData(
+      this.userEvents.getEvents(
+        this.midnightAtTheStartOfTheWeekDateTime.toUnixInteger(),
+        this.midnightAtTheEndOfTheWeekDateTime.toUnixInteger()
+      )
+    );
+  }
+
+  get weekEvents() {
+    return this.weekEventsData.isResolved ? this.weekEventsData.value : null;
+  }
 
   get eventsLoaded() {
     return !isNone(this.weekEvents);

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "broccoli-funnel": "^3.0.0",
         "broccoli-merge-trees": "^4.0.0",
         "class-validator": "^0.14.0",
+        "ember-async-data": "^1.0.1",
         "ember-auto-import": "^2.6.3",
         "ember-cli-babel": "^7.26.11",
         "ember-cli-flash": "^4.0.0",
@@ -10777,6 +10778,18 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/ember-async-data": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ember-async-data/-/ember-async-data-1.0.1.tgz",
+      "integrity": "sha512-R9nBxCZ9WDPMJpuGBODs8wV1PHXUbkSbrzVmL34R4aOWbx237yLBllJghQOwfJs1+D72wdzgxg/+J3DY43xz3g==",
+      "dependencies": {
+        "@ember/test-waiters": "^3.0.0",
+        "@embroider/addon-shim": "^1.8.4"
+      },
+      "peerDependencies": {
+        "ember-source": "^4.8.4"
       }
     },
     "node_modules/ember-auto-import": {
@@ -39762,6 +39775,15 @@
       "requires": {
         "@glimmer/compiler": "^0.27.0",
         "@glimmer/syntax": "^0.27.0"
+      }
+    },
+    "ember-async-data": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ember-async-data/-/ember-async-data-1.0.1.tgz",
+      "integrity": "sha512-R9nBxCZ9WDPMJpuGBODs8wV1PHXUbkSbrzVmL34R4aOWbx237yLBllJghQOwfJs1+D72wdzgxg/+J3DY43xz3g==",
+      "requires": {
+        "@ember/test-waiters": "^3.0.0",
+        "@embroider/addon-shim": "^1.8.4"
       }
     },
     "ember-auto-import": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "broccoli-funnel": "^3.0.0",
     "broccoli-merge-trees": "^4.0.0",
     "class-validator": "^0.14.0",
+    "ember-async-data": "^1.0.1",
     "ember-auto-import": "^2.6.3",
     "ember-cli-babel": "^7.26.11",
     "ember-cli-flash": "^4.0.0",

--- a/tests/integration/components/single-event-test.js
+++ b/tests/integration/components/single-event-test.js
@@ -459,7 +459,11 @@ module('Integration | Component | ilios calendar single event', function (hooks)
   });
 
   test('no link to all materials if user is student and event is school-event', async function (assert) {
-    const MockCurrentUserService = Service.extend({ userIsStudent: true });
+    class MockCurrentUserService extends Service {
+      async getIsStudent() {
+        return true;
+      }
+    }
     this.owner.register('service:current-user', MockCurrentUserService);
     this.currentUser = this.owner.lookup('service:current-user');
     this.server.create('userevent', { isUserEvent: false, sessionTypeTitle: 'test type' });
@@ -588,6 +592,9 @@ module('Integration | Component | ilios calendar single event', function (hooks)
     assert.expect(2);
     class CurrentUserMock extends Service {
       performsNonLearnerFunction = true;
+      async getIsStudent() {
+        return false;
+      }
     }
     this.owner.register('service:currentUser', CurrentUserMock);
 
@@ -620,6 +627,9 @@ module('Integration | Component | ilios calendar single event', function (hooks)
       assert.expect(2);
       class CurrentUserMock extends Service {
         performsNonLearnerFunction = true;
+        async getIsStudent() {
+          return true;
+        }
       }
       this.owner.register('service:currentUser', CurrentUserMock);
 


### PR DESCRIPTION
Remove these resources and replace them with the TrackedAsyncData resource from ember-async data. This performs better than our version and is on the paved path for ember. The declarations are move verbose requiring a double getter, but this is an OK compromise for now. With time we may be able to refactor some of these getters out and replace them with the load template helper from this addon.