### PR TITLE
Remove Calls to Deprecated Async Computeds

### DIFF
--- a/addon/components/detail-cohort-list.hbs
+++ b/addon/components/detail-cohort-list.hbs
@@ -32,7 +32,7 @@
                 {{#if cohort.title}}
                   {{cohort.title}}
                 {{else}}
-                  {{t "general.classOf" year=cohort.classOfYear}}
+                  {{t "general.classOf" year=cohort.programYear.classOfYear}}
                 {{/if}}
               </td>
             </tr>

--- a/addon/components/detail-cohort-list.js
+++ b/addon/components/detail-cohort-list.js
@@ -21,8 +21,9 @@ export default class DetailCohortListComponent extends Component {
       const schoolTitle = school.title;
       let displayTitle = cohort.title;
       if (!displayTitle) {
-        const classOfYear = await cohort.classOfYear;
-        displayTitle = this.intl.t('general.classOf', { year: classOfYear });
+        const programYear = await cohort.programYear;
+        const year = await programYear.getClassOfYear();
+        displayTitle = this.intl.t('general.classOf', { year });
       }
 
       return {

--- a/addon/components/offering-form.js
+++ b/addon/components/offering-form.js
@@ -300,7 +300,11 @@ export default class OfferingForm extends Component {
     if (isEmpty(cohorts)) {
       associatedSchools = [];
     } else {
-      const cohortSchools = await map(cohorts.slice(), (cohort) => cohort.school);
+      const cohortSchools = await map(cohorts.slice(), async (cohort) => {
+        const programYear = await cohort.programYear;
+        const program = await programYear.program;
+        return program.school;
+      });
       associatedSchools = uniqueValues(cohortSchools);
     }
     const allInstructorGroups = await map(associatedSchools, (school) => school.instructorGroups);

--- a/addon/models/course.js
+++ b/addon/models/course.js
@@ -120,7 +120,14 @@ export default class Course extends Model {
     return uniqueValues(this.allTreeCompetencies ?? []).filter(Boolean);
   }
 
-  @use competencyDomains = new ResolveAsyncValue(() => [mapBy(this.competencies, 'domain')]);
+  @use competencyDomains = new AsyncProcess(() => [
+    this._getCompetencyDomains.bind(this),
+    this.competencies,
+  ]);
+
+  async _getCompetencyDomains(competencies) {
+    return map(competencies, (c) => c.getDomain());
+  }
 
   @use domainsWithSubcompetencies = new AsyncProcess(() => [
     this._getDomainProxies.bind(this),

--- a/addon/models/curriculum-inventory-sequence-block.js
+++ b/addon/models/curriculum-inventory-sequence-block.js
@@ -116,7 +116,7 @@ export default class CurriculumInventorySequenceBlock extends Model {
     if (!parent) {
       return [];
     }
-    const parentsAncestors = (await parent.allParents).slice();
+    const parentsAncestors = (await parent.getAllParents()).slice();
     return [parent, ...parentsAncestors];
   }
 


### PR DESCRIPTION
These are scheduled for remove, hopefully very soon, this should clean house in common only leaving a few tests which can be removed when the properties are removed from the models.