### PR TITLE
Replace ResolveAsyncValue in models

### DIFF
--- a/addon/components/course/objective-list-item.hbs
+++ b/addon/components/course/objective-list-item.hbs
@@ -115,14 +115,14 @@
   {{/if}}
   {{#if this.isManagingTerms}}
     <TaxonomyManager
-        @vocabularies={{@course.assignableVocabularies}}
-        @vocabulary={{this.selectedVocabulary}}
-        @selectedTerms={{this.termsBuffer}}
-        @add={{this.addTermToBuffer}}
-        @remove={{this.removeTermFromBuffer}}
-        @editable={{@editable}}
-        @save={{perform this.saveTerms}}
-        @cancel={{this.cancel}}
+      @vocabularies={{@course.assignableVocabularies}}
+      @vocabulary={{this.selectedVocabulary}}
+      @selectedTerms={{this.termsBuffer}}
+      @add={{this.addTermToBuffer}}
+      @remove={{this.removeTermFromBuffer}}
+      @editable={{@editable}}
+      @save={{perform this.saveTerms}}
+      @cancel={{this.cancel}}
     />
   {{/if}}
 </div>

--- a/addon/components/taxonomy-manager.js
+++ b/addon/components/taxonomy-manager.js
@@ -51,28 +51,25 @@ export default class TaxonomyManager extends Component {
     if (!this.args.vocabularies) {
       return [];
     } else {
-      return this.args.vocabularies.slice().filter((vocab) => {
+      return this.args.vocabularies.filter((vocab) => {
         return vocab.termCount > 0;
       });
     }
   }
 
   get assignableVocabularies() {
-    return this.nonEmptyVocabularies.filter((vocab) => {
-      return vocab.get('active');
-    });
+    return this.nonEmptyVocabularies.filter((vocab) => vocab.active);
   }
 
   get listableVocabularies() {
     return this.nonEmptyVocabularies.filter((vocab) => {
-      if (vocab.get('active')) {
+      if (vocab.active) {
         return true;
       }
       const terms = this.args.selectedTerms;
-      const vocabId = vocab.get('id');
       let hasTerms = false;
       terms.forEach((term) => {
-        if (term.belongsTo('vocabulary').id() === vocabId) {
+        if (term.belongsTo('vocabulary').id() === vocab.id) {
           hasTerms = true;
         }
       });
@@ -84,7 +81,7 @@ export default class TaxonomyManager extends Component {
   get selectedVocabulary() {
     if (isPresent(this.vocabId)) {
       const vocab = this.assignableVocabularies.find((v) => {
-        return v.get('id') === this.vocabId;
+        return v.id === this.vocabId;
       });
       if (vocab) {
         return vocab;

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -164,7 +164,7 @@ export default class LearnerGroup extends Model {
   }
 
   @cached
-  get _grandChildrenData() {
+  get _allDescendantsData() {
     if (!this._childrenData.isResolved) {
       return null;
     }
@@ -178,11 +178,11 @@ export default class LearnerGroup extends Model {
    * A list of all nested sub-groups of this group.
    */
   get allDescendants() {
-    if (!this._childrenData.isResolved || !this._grandChildrenData?.isResolved) {
+    if (!this._childrenData.isResolved || !this._allDescendantsData?.isResolved) {
       return [];
     }
 
-    return [...this._childrenData.value, ...this._grandChildrenData.value.flat()];
+    return [...this._childrenData.value, ...this._allDescendantsData.value.flat()];
   }
 
   async getAllDescendants() {
@@ -247,12 +247,12 @@ export default class LearnerGroup extends Model {
     if (
       this.isTopLevelGroup ||
       !this._parentData.isResolved ||
-      !this._grandparentsData.isResolved
+      !this._allAncestorsData.isResolved
     ) {
       return [];
     }
 
-    return [...mapBy(this._grandparentsData.value, 'title'), this._parentData.value.title];
+    return [...mapBy(this._allAncestorsData.value, 'title'), this._parentData.value.title];
   }
 
   get allParentsTitle() {
@@ -266,12 +266,12 @@ export default class LearnerGroup extends Model {
       return this.title.replace(/\s/g, '');
     }
 
-    if (!this._parentData.isResolved || !this._grandparentsData?.isResolved) {
+    if (!this._parentData.isResolved || !this._allAncestorsData?.isResolved) {
       return undefined;
     }
 
     return [
-      ...mapBy([...this._grandparentsData.value.reverse(), this._parentData.value], 'title'),
+      ...mapBy([...this._allAncestorsData.value.reverse(), this._parentData.value], 'title'),
       this.title,
     ]
       .join('')
@@ -285,17 +285,17 @@ export default class LearnerGroup extends Model {
   get filterTitle() {
     if (
       !this._parentData.isResolved ||
-      !this._grandparentsData?.isResolved ||
+      !this._allAncestorsData?.isResolved ||
       !this._childrenData.isResolved ||
-      !this._grandChildrenData?.isResolved
+      !this._allDescendantsData?.isResolved
     ) {
       return '';
     }
 
     const up = this.isTopLevelGroup
       ? []
-      : [this._parentData.value, ...this._grandparentsData.value];
-    const down = [...this._childrenData.value, ...this._grandChildrenData.value.flat()];
+      : [this._parentData.value, ...this._allAncestorsData.value];
+    const down = [...this._childrenData.value, ...this._allDescendantsData.value.flat()];
 
     return [...mapBy(down, 'title'), ...mapBy(up, 'title'), this.title].join('');
   }
@@ -311,7 +311,7 @@ export default class LearnerGroup extends Model {
   }
 
   @cached
-  get _grandparentsData() {
+  get _allAncestorsData() {
     if (!this._parentData.isResolved) {
       return null;
     }
@@ -323,12 +323,12 @@ export default class LearnerGroup extends Model {
     if (
       this.isTopLevelGroup ||
       !this._parentData.isResolved ||
-      !this._grandparentsData?.isResolved
+      !this._allAncestorsData?.isResolved
     ) {
       return [];
     }
 
-    return [this._parentData.value, ...this._grandparentsData.value];
+    return [this._parentData.value, ...this._allAncestorsData.value];
   }
 
   /**

--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -210,6 +210,12 @@ export default class LearnerGroup extends Model {
     return uniqueValues([...this._usersData.value, ...this._allDescendantsUsersData.value.flat()]);
   }
 
+  async getAllDescendantUsers() {
+    const users = await this.users;
+    const descendantUsers = await this._getDescendantUsers();
+    return uniqueValues([...users.slice(), ...descendantUsers]);
+  }
+
   async _getDescendantUsers() {
     const allDescendants = await this.getAllDescendants();
     const descendantsUsers = await Promise.all(mapBy(allDescendants, 'users'));

--- a/addon/models/session-type.js
+++ b/addon/models/session-type.js
@@ -1,7 +1,7 @@
 import Model, { hasMany, belongsTo, attr } from '@ember-data/model';
 import { htmlSafe } from '@ember/template';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class SessionType extends Model {
   @attr('string')
@@ -25,6 +25,11 @@ export default class SessionType extends Model {
   @hasMany('aamc-method', { async: true, inverse: 'sessionTypes' })
   aamcMethods;
 
+  @cached
+  get _aamcMethodsData() {
+    return new TrackedAsyncData(this.aamcMethods);
+  }
+
   @hasMany('session', { async: true, inverse: 'sessionType' })
   sessions;
 
@@ -40,11 +45,10 @@ export default class SessionType extends Model {
     return this.hasMany('sessions').ids().length;
   }
 
-  @use _aamcMethods = new ResolveAsyncValue(() => [this.aamcMethods]);
   get firstAamcMethod() {
-    if (!this._aamcMethods) {
+    if (!this._aamcMethodsData.isResolved) {
       return undefined;
     }
-    return this._aamcMethods.slice()[0];
+    return this._aamcMethodsData.value[0];
   }
 }

--- a/addon/models/user.js
+++ b/addon/models/user.js
@@ -1,7 +1,6 @@
 import Model, { hasMany, belongsTo, attr } from '@ember-data/model';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
-import ResolveFlatMapBy from 'ilios-common/classes/resolve-flat-map-by';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import { mapBy, uniqueValues } from 'ilios-common/utils/array-helpers';
 
 export default class User extends Model {
@@ -179,65 +178,183 @@ export default class User extends Model {
   @hasMany('user-session-material-status', { async: true, inverse: 'user' })
   sessionMaterialStatuses;
 
-  @use _roles = new ResolveAsyncValue(() => [this.roles, []]);
+  @cached
+  get _rolesData() {
+    return new TrackedAsyncData(this.roles);
+  }
+
+  @cached
+  get _cohortsData() {
+    return new TrackedAsyncData(this.cohorts);
+  }
+
+  @cached
+  get _offeringsData() {
+    return new TrackedAsyncData(this.offerings);
+  }
+
+  @cached
+  get _learnerIlmSessionsData() {
+    return new TrackedAsyncData(this.learnerIlmSessions);
+  }
+
+  @cached
+  get _directedCoursesData() {
+    return new TrackedAsyncData(this.directedCourses);
+  }
+
+  @cached
+  get _administeredCoursesData() {
+    return new TrackedAsyncData(this.administeredCourses);
+  }
+
+  @cached
+  get _administeredSessionsData() {
+    return new TrackedAsyncData(this.administeredSessions);
+  }
+
+  @cached
+  get _instructorGroupsData() {
+    return new TrackedAsyncData(this.instructorGroups);
+  }
+
+  @cached
+  get _instructedOfferingsData() {
+    return new TrackedAsyncData(this.instructedOfferings);
+  }
+
+  @cached
+  get _instructedLearnerGroupsData() {
+    return new TrackedAsyncData(this.instructedLearnerGroups);
+  }
+
+  @cached
+  get _directedProgramsData() {
+    return new TrackedAsyncData(this.directedPrograms);
+  }
+
+  @cached
+  get _programYearsData() {
+    return new TrackedAsyncData(this.programYears);
+  }
+
+  @cached
+  get _administeredCurriculumInventoryReportsData() {
+    return new TrackedAsyncData(this.administeredCurriculumInventoryReports);
+  }
+
+  @cached
+  get _directedSchoolsData() {
+    return new TrackedAsyncData(this.directedSchools);
+  }
+
+  @cached
+  get _administeredSchoolsData() {
+    return new TrackedAsyncData(this.administeredSchools);
+  }
+
+  @cached
+  get _instructorIlmSessionsData() {
+    return new TrackedAsyncData(this.instructorIlmSessions);
+  }
+
+  @cached
+  get _primaryCohortData() {
+    return new TrackedAsyncData(this.primaryCohort);
+  }
 
   get _roleTitles() {
-    return mapBy(this._roles, 'title');
+    if (!this._rolesData.isResolved) {
+      return [];
+    }
+
+    return this._rolesData.value.map((r) => r.title);
+  }
+
+  @cached
+  get _learnerGroupsData() {
+    return new TrackedAsyncData(this.learnerGroups);
   }
 
   get isStudent() {
-    return Boolean(this._roleTitles?.includes('Student'));
+    return Boolean(this._roleTitles.includes('Student'));
   }
-
-  @use _cohorts = new ResolveAsyncValue(() => [this.cohorts]);
-  @use _offerings = new ResolveAsyncValue(() => [this.offerings]);
-  @use _learnerIlmSessions = new ResolveAsyncValue(() => [this.learnerIlmSessions]);
 
   /**
    * Checks if a user is linked to any student things
    */
   get isLearner() {
-    return Boolean(
-      this._cohorts?.length || this._offerings?.length || this._learnerIlmSessions?.length
-    );
-  }
+    if (this._cohortsData.isResolved && this._cohortsData.value.length) {
+      return true;
+    }
+    if (this._offeringsData.isResolved && this._offeringsData.value.length) {
+      return true;
+    }
+    if (
+      this._learnerIlmSessionSessionsData?.isResolved &&
+      this._learnerIlmSessionSessionsData.value.length
+    ) {
+      return true;
+    }
 
-  @use _directedCourses = new ResolveAsyncValue(() => [this.directedCourses]);
-  @use _administeredCourses = new ResolveAsyncValue(() => [this.administeredCourses]);
-  @use _administeredSessions = new ResolveAsyncValue(() => [this.administeredSessions]);
-  @use _instructorGroups = new ResolveAsyncValue(() => [this.instructorGroups]);
-  @use _instructedOfferings = new ResolveAsyncValue(() => [this.instructedOfferings]);
-  @use _instructedLearnerGroups = new ResolveAsyncValue(() => [this.instructedLearnerGroups]);
-  @use _directedPrograms = new ResolveAsyncValue(() => [this.directedPrograms]);
-  @use _programYears = new ResolveAsyncValue(() => [this.programYears]);
-  @use _administeredCurriculumInventoryReports = new ResolveAsyncValue(() => [
-    this.administeredCurriculumInventoryReports,
-  ]);
-  @use _directedSchools = new ResolveAsyncValue(() => [this.directedSchools]);
-  @use _administeredSchools = new ResolveAsyncValue(() => [this.administeredSchools]);
+    return false;
+  }
 
   /**
    * Checks if a user is linked to any non-student things
    */
   get performsNonLearnerFunction() {
-    return Boolean(
-      this._directedCourses?.length ||
-        this._administeredCourses?.length ||
-        this._administeredSessions?.length ||
-        this._instructorGroups?.length ||
-        this._instructedOfferings?.length ||
-        this._instructedIlmSessions?.length ||
-        this._instructedLearnerGroups?.length ||
-        this._directedPrograms?.length ||
-        this._programYears?.length ||
-        this._administeredCurriculumInventoryReports?.length ||
-        this._directedSchools?.length ||
-        this._administeredSchools?.length
-    );
+    if (this._directedCoursesData.isResolved && this._directedCoursesData.value.length) {
+      return true;
+    }
+    if (this._administeredCoursesData.isResolved && this._administeredCoursesData.value.length) {
+      return true;
+    }
+    if (this._administeredSessionsData.isResolved && this._administeredSessionsData.value.length) {
+      return true;
+    }
+    if (this._instructorGroupsData.isResolved && this._instructorGroupsData.value.length) {
+      return true;
+    }
+    if (this._instructedOfferingsData.isResolved && this._instructedOfferingsData.value.length) {
+      return true;
+    }
+    if (
+      this._instructorIlmSessionsData.isResolved &&
+      this._instructorIlmSessionsData.value.length
+    ) {
+      return true;
+    }
+    if (
+      this._instructedLearnerGroupsData.isResolved &&
+      this._instructedLearnerGroupsData.value.length
+    ) {
+      return true;
+    }
+    if (this._directedProgramsData.isResolved && this._directedProgramsData.value.length) {
+      return true;
+    }
+    if (this._programYearsData.isResolved && this._programYearsData.value.length) {
+      return true;
+    }
+    if (
+      this._administeredCurriculumInventoryReportsData.isResolved &&
+      this._administeredCurriculumInventoryReportsData.value.length
+    ) {
+      return true;
+    }
+    if (this._directedSchoolsData.isResolved && this._directedSchoolsData.value.length) {
+      return true;
+    }
+    if (this._administeredSchoolsData.isResolved && this._administeredSchoolsData.value.length) {
+      return true;
+    }
+
+    return false;
   }
 
   get fullName() {
-    return this.displayName ? this.displayName : this.fullNameFromFirstMiddleInitialLastName;
+    return this.displayName ?? this.fullNameFromFirstMiddleInitialLastName;
   }
 
   get fullNameFromFirstMiddleInitialLastName() {
@@ -287,119 +404,214 @@ export default class User extends Model {
     );
   }
 
-  @use _instructedLearnerGroupOfferings = new ResolveFlatMapBy(() => [
-    this._instructedLearnerGroups,
-    'offerings',
-  ]);
+  @cached
+  get _instructedLearnerGroupOfferingsData() {
+    if (!this._instructedLearnerGroupsData.isResolved) {
+      return null;
+    }
+
+    return new TrackedAsyncData(
+      Promise.all(this._instructedLearnerGroupsData.value.map((t) => t.offerings))
+    );
+  }
 
   get _allInstructedOfferings() {
-    if (!this._instructedLearnerGroupOfferings || !this._instructedOfferings) {
-      return [];
-    }
-    return uniqueValues([...this._instructedLearnerGroupOfferings, ...this._instructedOfferings]);
-  }
-
-  @use _instructorIlmSessions = new ResolveAsyncValue(() => [this.instructorIlmSessions]);
-  @use _instructorIlmSessionsSessions = new ResolveFlatMapBy(() => [
-    this._instructorIlmSessions,
-    'session',
-  ]);
-
-  get _instructedIlmSessions() {
-    if (!this._instructorIlmSessions) {
-      return [];
-    }
-    return this._instructorIlmSessions.slice();
-  }
-
-  @use _instructedOfferingSessions = new ResolveFlatMapBy(() => [
-    this._allInstructedOfferings,
-    'session',
-  ]);
-  @use _instructorGroupSessions = new ResolveFlatMapBy(() => [this._instructorGroups, 'sessions']);
-
-  get allInstructedSessions() {
     if (
-      !this._instructorIlmSessionsSessions ||
-      !this._instructedOfferingSessions ||
-      !this._instructorGroupSessions
-    ) {
-      return [];
-    }
-    return uniqueValues(
-      [
-        ...this._instructorIlmSessionsSessions,
-        ...this._instructedOfferingSessions,
-        ...this._instructorGroupSessions,
-      ].filter(Boolean)
-    );
-  }
-
-  @use allInstructedCourses = new ResolveFlatMapBy(() => [this.allInstructedSessions, 'course']);
-
-  @use _offeringSessions = new ResolveFlatMapBy(() => [this._offerings, 'session']);
-  @use _learnerIlmSessionSessions = new ResolveFlatMapBy(() => [
-    this._learnerIlmSessions,
-    'session',
-  ]);
-  @use _learnerGroupOfferings = new ResolveFlatMapBy(() => [this.learnerGroups, 'offerings']);
-  @use _learnerGroupIlmSessions = new ResolveFlatMapBy(() => [this.learnerGroups, 'ilmSessions']);
-  @use _learnerGroupIlmSessionsSessions = new ResolveFlatMapBy(() => [
-    this._learnerGroupIlmSessions,
-    'session',
-  ]);
-
-  get _learnerOfferings() {
-    if (!this._learnerGroupOfferings || !this._offerings) {
-      return [];
-    }
-    return uniqueValues([...this._learnerGroupOfferings, ...this._offerings.slice()]);
-  }
-  @use _learnerOfferingSessions = new ResolveFlatMapBy(() => [this._learnerOfferings, 'session']);
-
-  get _learnerSessions() {
-    if (
-      !this._learnerOfferingSessions ||
-      !this._learnerIlmSessionSessions ||
-      !this._learnerGroupIlmSessionsSessions
-    ) {
-      return [];
-    }
-    return uniqueValues(
-      [
-        ...this._learnerOfferingSessions,
-        ...this._learnerIlmSessionSessions,
-        ...this._learnerGroupIlmSessionsSessions,
-      ].filter(Boolean)
-    );
-  }
-
-  @use _learnerCourses = new ResolveFlatMapBy(() => [this._learnerSessions, 'course']);
-
-  get allRelatedCourses() {
-    if (
-      !this._learnerCourses ||
-      !this.allInstructedCourses ||
-      !this._directedCourses ||
-      !this._administeredCourses
+      !this._instructedLearnerGroupOfferingsData?.isResolved ||
+      !this._instructorGroupOfferings?.isResolved ||
+      !this._instructedOfferingsData.isResolved
     ) {
       return [];
     }
     return uniqueValues([
-      ...this._learnerCourses,
-      ...this.allInstructedCourses,
-      ...this._directedCourses.slice(),
-      ...this._administeredCourses.slice(),
+      ...this._instructedLearnerGroupOfferingsData.value.flat(),
+      ...this._instructorGroupOfferings.value.flat(),
+      ...this._instructedOfferingsData.value,
     ]);
   }
 
-  @use _primaryCohort = new ResolveAsyncValue(() => [this.primaryCohort]);
+  @cached
+  get _allInstructedOfferingSessions() {
+    return new TrackedAsyncData(Promise.all(this._allInstructedOfferings.map((o) => o.session)));
+  }
 
-  get secondaryCohorts() {
-    if (!this._cohorts || !this._primaryCohort) {
+  @cached
+  get _instructorIlmSessionSessions() {
+    if (!this._instructorIlmSessionsData.isResolved) {
+      return null;
+    }
+
+    return new TrackedAsyncData(
+      Promise.all(this._instructorIlmSessionsData.value.map((t) => t.session))
+    );
+  }
+
+  @cached
+  get _instructorGroupIlmSessions() {
+    if (!this._instructorGroupsData.isResolved) {
+      return null;
+    }
+
+    return new TrackedAsyncData(
+      Promise.all(this._instructorGroupsData.value.map((i) => i.ilmSessions))
+    );
+  }
+
+  @cached
+  get _instructorGroupIlmSessionSessions() {
+    if (!this._instructorGroupIlmSessions?.isResolved) {
+      return null;
+    }
+
+    return new TrackedAsyncData(
+      Promise.all(this._instructorGroupIlmSessions.value.flat().map((ilm) => ilm.session))
+    );
+  }
+
+  @cached
+  get _instructorGroupOfferings() {
+    if (!this._instructorGroupsData.isResolved) {
+      return null;
+    }
+
+    return new TrackedAsyncData(
+      Promise.all(this._instructorGroupsData.value.map((g) => g.offerings))
+    );
+  }
+
+  get allInstructedSessions() {
+    if (
+      !this._instructorIlmSessionSessions?.isResolved ||
+      !this._instructorGroupIlmSessionSessions?.isResolved ||
+      !this._allInstructedOfferingSessions.isResolved
+    ) {
       return [];
     }
-    return this._cohorts.slice().filter((cohort) => cohort !== this._primaryCohort);
+    return uniqueValues(
+      [
+        ...this._instructorIlmSessionSessions.value,
+        ...this._instructorGroupIlmSessionSessions.value,
+        ...this._allInstructedOfferingSessions.value,
+      ].filter(Boolean)
+    );
+  }
+
+  @cached
+  get _allInstructedCoursesData() {
+    if (
+      !this._instructorIlmSessionSessions?.isResolved ||
+      !this._instructorGroupIlmSessionSessions?.isResolved ||
+      !this._allInstructedOfferingSessions.isResolved
+    ) {
+      return null;
+    }
+    return new TrackedAsyncData(
+      Promise.all(
+        uniqueValues(
+          [
+            ...this._instructorIlmSessionSessions.value,
+            ...this._instructorGroupIlmSessionSessions.value,
+            ...this._allInstructedOfferingSessions.value,
+          ]
+            .filter(Boolean)
+            .map((s) => s.course)
+        )
+      )
+    );
+  }
+
+  get allInstructedCourses() {
+    if (!this._allInstructedCoursesData?.isResolved) {
+      return [];
+    }
+
+    return this._allInstructedCoursesData.value;
+  }
+
+  @cached
+  get _learnerIlmSessionSessionsData() {
+    if (!this._learnerIlmSessionsData.isResolved) {
+      return [];
+    }
+    return new TrackedAsyncData(
+      Promise.all(this._learnerIlmSessionsData.value.map((i) => i.session))
+    );
+  }
+
+  @cached
+  get _learnerGroupOfferingsData() {
+    if (!this._learnerGroupsData.isResolved) {
+      return null;
+    }
+    return new TrackedAsyncData(Promise.all(this._learnerGroupsData.value.map((l) => l.offerings)));
+  }
+
+  @cached
+  get _learnerGroupIlmSessionsData() {
+    if (!this._learnerGroupsData.isResolved) {
+      return null;
+    }
+    return new TrackedAsyncData(
+      Promise.all(this._learnerGroupsData.value.map((l) => l.ilmSessions))
+    );
+  }
+
+  @cached
+  get _learnerSessionsData() {
+    if (
+      !this._offeringsData.isResolved ||
+      !this._learnerIlmSessionsData.isResolved ||
+      !this._learnerGroupOfferingsData?.isResolved ||
+      !this._learnerGroupIlmSessionsData.isResolved
+    ) {
+      return null;
+    }
+    const offerings = this._offeringsData.value;
+    const learnerIlmSessions = this._learnerIlmSessionsData.value;
+    const learnerGroupOfferings = this._learnerGroupOfferingsData.value.flat();
+    const ilmSessions = this._learnerGroupIlmSessionsData.value.flat();
+
+    return new TrackedAsyncData(
+      Promise.all(
+        [...offerings, ...learnerIlmSessions, ...learnerGroupOfferings, ...ilmSessions].map(
+          (obj) => obj.session
+        )
+      )
+    );
+  }
+
+  @cached
+  get _learnerCoursesData() {
+    if (!this._learnerSessionsData?.isResolved) {
+      return null;
+    }
+
+    return new TrackedAsyncData(Promise.all(this._learnerSessionsData.value.map((s) => s.course)));
+  }
+
+  get allRelatedCourses() {
+    if (
+      !this._learnerCoursesData?.isResolved ||
+      !this._allInstructedCoursesData?.isResolved ||
+      !this._directedCoursesData.isResolved ||
+      !this._administeredCoursesData.isResolved
+    ) {
+      return [];
+    }
+
+    return uniqueValues([
+      ...this._learnerCoursesData.value,
+      ...this._allInstructedCoursesData.value,
+      ...this._directedCoursesData.value,
+      ...this._administeredCoursesData.value,
+    ]);
+  }
+
+  get secondaryCohorts() {
+    if (!this._cohortsData.isResolved || !this._primaryCohortData.isResolved) {
+      return [];
+    }
+    return this._cohortsData.value.filter((cohort) => cohort !== this._primaryCohortData.value);
   }
 
   /**

--- a/tests/integration/components/course/objective-list-item-test.js
+++ b/tests/integration/components/course/objective-list-item-test.js
@@ -14,17 +14,20 @@ module('Integration | Component | course/objective-list-item', function (hooks) 
 
   test('it renders and is accessible', async function (assert) {
     assert.expect(6);
-    const course = this.server.create('course');
+    const school = this.server.create('school');
+    const course = this.server.create('course', { school });
     const courseObjective = this.server.create('courseObjective', { course });
-    const courseObjectiveModel = await this.owner
-      .lookup('service:store')
-      .findRecord('courseObjective', courseObjective.id);
+    const store = this.owner.lookup('service:store');
+    const courseModel = await store.findRecord('course', course.id);
+    const courseObjectiveModel = await store.findRecord('courseObjective', courseObjective.id);
+    this.set('course', courseModel);
     this.set('courseObjective', courseObjectiveModel);
     await render(
       hbs`<Course::ObjectiveListItem
         @courseObjective={{this.courseObjective}}
         @editable={{true}}
         @cohortObjectives={{(array)}}
+        @course={{this.course}}
       />
 `
     );
@@ -38,17 +41,20 @@ module('Integration | Component | course/objective-list-item', function (hooks) 
   });
 
   test('can change title', async function (assert) {
-    const course = this.server.create('course');
+    const school = this.server.create('school');
+    const course = this.server.create('course', { school });
     const courseObjective = this.server.create('courseObjective', { course });
-    const courseObjectiveModel = await this.owner
-      .lookup('service:store')
-      .findRecord('courseObjective', courseObjective.id);
+    const store = this.owner.lookup('service:store');
+    const courseModel = await store.findRecord('course', course.id);
+    const courseObjectiveModel = await store.findRecord('courseObjective', courseObjective.id);
+    this.set('course', courseModel);
     this.set('courseObjective', courseObjectiveModel);
     await render(
       hbs`<Course::ObjectiveListItem
         @courseObjective={{this.courseObjective}}
         @editable={{true}}
         @cohortObjectives={{(array)}}
+        @course={{this.course}}
       />
 `
     );
@@ -62,11 +68,13 @@ module('Integration | Component | course/objective-list-item', function (hooks) 
 
   test('can manage parents', async function (assert) {
     assert.expect(1);
-    const course = this.server.create('course');
+    const school = this.server.create('school');
+    const course = this.server.create('course', { school });
     const courseObjective = this.server.create('courseObjective', { course });
-    const courseObjectiveModel = await this.owner
-      .lookup('service:store')
-      .findRecord('courseObjective', courseObjective.id);
+    const store = this.owner.lookup('service:store');
+    const courseModel = await store.findRecord('course', course.id);
+    const courseObjectiveModel = await store.findRecord('courseObjective', courseObjective.id);
+    this.set('course', courseModel);
     this.set('courseObjective', courseObjectiveModel);
     await render(
       hbs`<Course::ObjectiveListItem
@@ -82,17 +90,20 @@ module('Integration | Component | course/objective-list-item', function (hooks) 
   });
 
   test('can manage descriptors', async function (assert) {
-    const course = this.server.create('course');
+    const school = this.server.create('school');
+    const course = this.server.create('course', { school });
     const courseObjective = this.server.create('courseObjective', { course });
-    const courseObjectiveModel = await this.owner
-      .lookup('service:store')
-      .findRecord('courseObjective', courseObjective.id);
+    const store = this.owner.lookup('service:store');
+    const courseModel = await store.findRecord('course', course.id);
+    const courseObjectiveModel = await store.findRecord('courseObjective', courseObjective.id);
+    this.set('course', courseModel);
     this.set('courseObjective', courseObjectiveModel);
     await render(
       hbs`<Course::ObjectiveListItem
         @courseObjective={{this.courseObjective}}
         @editable={{true}}
         @cohortObjectives={{(array)}}
+        @course={{this.course}}
       />
 `
     );
@@ -102,17 +113,20 @@ module('Integration | Component | course/objective-list-item', function (hooks) 
 
   test('can manage terms', async function (assert) {
     assert.expect(2);
-    const course = this.server.create('course');
+    const school = this.server.create('school');
+    const course = this.server.create('course', { school });
     const courseObjective = this.server.create('courseObjective', { course });
-    const courseObjectiveModel = await this.owner
-      .lookup('service:store')
-      .findRecord('courseObjective', courseObjective.id);
+    const store = this.owner.lookup('service:store');
+    const courseModel = await store.findRecord('course', course.id);
+    const courseObjectiveModel = await store.findRecord('courseObjective', courseObjective.id);
     this.set('courseObjective', courseObjectiveModel);
+    this.set('course', courseModel);
     await render(
       hbs`<Course::ObjectiveListItem
         @courseObjective={{this.courseObjective}}
         @editable={{true}}
         @cohortObjectives={{(array)}}
+        @course={{this.course}}
       />
 `
     );
@@ -122,17 +136,20 @@ module('Integration | Component | course/objective-list-item', function (hooks) 
   });
 
   test('can trigger removal', async function (assert) {
-    const course = this.server.create('course');
+    const school = this.server.create('school');
+    const course = this.server.create('course', { school });
     const courseObjective = this.server.create('courseObjective', { course });
-    const courseObjectiveModel = await this.owner
-      .lookup('service:store')
-      .findRecord('courseObjective', courseObjective.id);
+    const store = this.owner.lookup('service:store');
+    const courseModel = await store.findRecord('course', course.id);
+    const courseObjectiveModel = await store.findRecord('courseObjective', courseObjective.id);
+    this.set('course', courseModel);
     this.set('courseObjective', courseObjectiveModel);
     await render(
       hbs`<Course::ObjectiveListItem
         @courseObjective={{this.courseObjective}}
         @editable={{true}}
         @cohortObjectives={{(array)}}
+        @course={{this.course}}
       />
 `
     );

--- a/tests/integration/components/session/objective-list-item-test.js
+++ b/tests/integration/components/session/objective-list-item-test.js
@@ -14,19 +14,23 @@ module('Integration | Component | session/objective-list-item', function (hooks)
 
   test('it renders and is accessible', async function (assert) {
     assert.expect(6);
-    const session = this.server.create('session');
+    const school = this.server.create('school');
+    const course = this.server.create('course', { school });
+    const session = this.server.create('session', { course });
     const sessionObjective = this.server.create('sessionObjective', {
       session,
     });
-    const sessionObjectiveModel = await this.owner
-      .lookup('service:store')
-      .findRecord('session-objective', sessionObjective.id);
+    const store = await this.owner.lookup('service:store');
+    const sessionModel = await store.findRecord('session', session.id);
+    const sessionObjectiveModel = await store.findRecord('session-objective', sessionObjective.id);
     this.set('sessionObjective', sessionObjectiveModel);
+    this.set('sessionModel', sessionModel);
     await render(
       hbs`<Session::ObjectiveListItem
         @sessionObjective={{this.sessionObjective}}
         @editable={{true}}
         @courseObjectives={{(array)}}
+        @session={{this.sessionModel}}
       />
 `
     );
@@ -44,15 +48,17 @@ module('Integration | Component | session/objective-list-item', function (hooks)
     const sessionObjective = this.server.create('sessionObjective', {
       session,
     });
-    const sessionObjectiveModel = await this.owner
-      .lookup('service:store')
-      .findRecord('session-objective', sessionObjective.id);
+    const store = await this.owner.lookup('service:store');
+    const sessionModel = await store.findRecord('session', session.id);
+    const sessionObjectiveModel = await store.findRecord('session-objective', sessionObjective.id);
     this.set('sessionObjective', sessionObjectiveModel);
+    this.set('sessionModel', sessionModel);
     await render(
       hbs`<Session::ObjectiveListItem
         @sessionObjective={{this.sessionObjective}}
         @editable={{true}}
         @courseObjectives={{(array)}}
+        @session={{this.sessionModel}}
       />
 `
     );
@@ -66,19 +72,23 @@ module('Integration | Component | session/objective-list-item', function (hooks)
 
   test('can manage parents', async function (assert) {
     assert.expect(1);
-    const session = this.server.create('session');
+    const school = this.server.create('school');
+    const course = this.server.create('course', { school });
+    const session = this.server.create('session', { course });
     const sessionObjective = this.server.create('sessionObjective', {
       session,
     });
-    const sessionObjectiveModel = await this.owner
-      .lookup('service:store')
-      .findRecord('session-objective', sessionObjective.id);
+    const store = await this.owner.lookup('service:store');
+    const sessionModel = await store.findRecord('session', session.id);
+    const sessionObjectiveModel = await store.findRecord('session-objective', sessionObjective.id);
     this.set('sessionObjective', sessionObjectiveModel);
+    this.set('sessionModel', sessionModel);
     await render(
       hbs`<Session::ObjectiveListItem
         @sessionObjective={{this.sessionObjective}}
         @editable={{true}}
         @courseObjectives={{(array)}}
+        @session={{this.sessionModel}}
       />
 `
     );
@@ -91,15 +101,17 @@ module('Integration | Component | session/objective-list-item', function (hooks)
     const sessionObjective = this.server.create('sessionObjective', {
       session,
     });
-    const sessionObjectiveModel = await this.owner
-      .lookup('service:store')
-      .findRecord('session-objective', sessionObjective.id);
+    const store = await this.owner.lookup('service:store');
+    const sessionModel = await store.findRecord('session', session.id);
+    const sessionObjectiveModel = await store.findRecord('session-objective', sessionObjective.id);
     this.set('sessionObjective', sessionObjectiveModel);
+    this.set('sessionModel', sessionModel);
     await render(
       hbs`<Session::ObjectiveListItem
         @sessionObjective={{this.sessionObjective}}
         @editable={{true}}
         @courseObjectives={{(array)}}
+        @session={{this.sessionModel}}
       />
 `
     );
@@ -109,19 +121,23 @@ module('Integration | Component | session/objective-list-item', function (hooks)
 
   test('can manage terms', async function (assert) {
     assert.expect(2);
-    const session = this.server.create('session');
+    const school = this.server.create('school');
+    const course = this.server.create('course', { school });
+    const session = this.server.create('session', { course });
     const sessionObjective = this.server.create('sessionObjective', {
       session,
     });
-    const sessionObjectiveModel = await this.owner
-      .lookup('service:store')
-      .findRecord('session-objective', sessionObjective.id);
+    const store = await this.owner.lookup('service:store');
+    const sessionModel = await store.findRecord('session', session.id);
+    const sessionObjectiveModel = await store.findRecord('session-objective', sessionObjective.id);
     this.set('sessionObjective', sessionObjectiveModel);
+    this.set('sessionModel', sessionModel);
     await render(
       hbs`<Session::ObjectiveListItem
         @sessionObjective={{this.sessionObjective}}
         @editable={{true}}
         @courseObjectives={{(array)}}
+        @session={{this.sessionModel}}
       />
 `
     );
@@ -135,15 +151,17 @@ module('Integration | Component | session/objective-list-item', function (hooks)
     const sessionObjective = this.server.create('sessionObjective', {
       session,
     });
-    const sessionObjectiveModel = await this.owner
-      .lookup('service:store')
-      .findRecord('session-objective', sessionObjective.id);
+    const store = await this.owner.lookup('service:store');
+    const sessionModel = await store.findRecord('session', session.id);
+    const sessionObjectiveModel = await store.findRecord('session-objective', sessionObjective.id);
     this.set('sessionObjective', sessionObjectiveModel);
+    this.set('sessionModel', sessionModel);
     await render(
       hbs`<Session::ObjectiveListItem
         @sessionObjective={{this.sessionObjective}}
         @editable={{true}}
         @courseObjectives={{(array)}}
+        @session={{this.sessionModel}}
       />
 `
     );

--- a/tests/unit/models/learner-group-test.js
+++ b/tests/unit/models/learner-group-test.js
@@ -106,6 +106,43 @@ module('Unit | Model | LearnerGroup', function (hooks) {
     assert.ok(allDescendantUsers.includes(user5));
   });
 
+  test('check getAllDescendantUsers on empty group', async function (assert) {
+    assert.expect(1);
+    const learnerGroup = this.owner.lookup('service:store').createRecord('learner-group');
+    const allDescendantUsers = await learnerGroup.getAllDescendantUsers();
+    assert.strictEqual(allDescendantUsers.length, 0);
+  });
+
+  test('check getAllDescendantUsers on populated group with sub-groups', async function (assert) {
+    assert.expect(6);
+    const store = this.owner.lookup('service:store');
+    const learnerGroup = store.createRecord('learner-group');
+
+    const user1 = store.createRecord('user');
+    const user2 = store.createRecord('user');
+    const user3 = store.createRecord('user');
+    const user4 = store.createRecord('user');
+    const user5 = store.createRecord('user');
+    const subGroup1 = store.createRecord('learner-group', { users: [user2] });
+    const subSubGroup1 = store.createRecord('learner-group', {
+      users: [user3],
+    });
+    const subGroup2 = store.createRecord('learner-group', {
+      users: [user5],
+      children: [subSubGroup1],
+    });
+    learnerGroup.get('users').pushObjects([user1, user2, user3, user4, user5]);
+    learnerGroup.get('children').pushObjects([subGroup1, subGroup2]);
+
+    const allDescendantUsers = await learnerGroup.getAllDescendantUsers();
+    assert.strictEqual(allDescendantUsers.length, 5);
+    assert.ok(allDescendantUsers.includes(user1));
+    assert.ok(allDescendantUsers.includes(user2));
+    assert.ok(allDescendantUsers.includes(user3));
+    assert.ok(allDescendantUsers.includes(user4));
+    assert.ok(allDescendantUsers.includes(user5));
+  });
+
   test('check empty allDescendants', async function (assert) {
     assert.expect(1);
     const learnerGroup = this.owner.lookup('service:store').createRecord('learner-group');

--- a/tests/unit/models/program-test.js
+++ b/tests/unit/models/program-test.js
@@ -39,10 +39,10 @@ module('Unit | Model | Program', function (hooks) {
       cohort: cohort2,
     });
     model.programYears.pushObjects([programYear1, programYear2]);
-    await waitForResource(model, '_cohorts');
-    assert.strictEqual(model.cohorts.length, 2);
-    assert.ok(model.cohorts.includes(cohort1));
-    assert.ok(model.cohorts.includes(cohort2));
+    const cohorts = await waitForResource(model, 'cohorts');
+    assert.strictEqual(cohorts.length, 2);
+    assert.ok(cohorts.includes(cohort1));
+    assert.ok(cohorts.includes(cohort2));
   });
 
   test('courses', async function (assert) {
@@ -63,10 +63,10 @@ module('Unit | Model | Program', function (hooks) {
       cohort: cohort2,
     });
     model.programYears.pushObjects([programYear1, programYear2]);
-    await waitForResource(model, '_courses');
-    assert.strictEqual(model.courses.length, 3);
-    assert.ok(model.courses.includes(course1));
-    assert.ok(model.courses.includes(course2));
-    assert.ok(model.courses.includes(course3));
+    const courses = await waitForResource(model, 'courses');
+    assert.strictEqual(courses.length, 3);
+    assert.ok(courses.includes(course1));
+    assert.ok(courses.includes(course2));
+    assert.ok(courses.includes(course3));
   });
 });

--- a/tests/unit/models/user-test.js
+++ b/tests/unit/models/user-test.js
@@ -335,22 +335,25 @@ module('Unit | Model | User', function (hooks) {
     const session1 = store.createRecord('session', {
       course: course1,
     });
+    const session2 = store.createRecord('session', {
+      course: course1,
+    });
     const ilm1 = store.createRecord('ilmSession', {
       session: session1,
     });
     const ilm2 = store.createRecord('ilmSession', {
-      session: session1,
+      session: session2,
     });
     store.createRecord('learnerGroup', {
       ilmSessions: [ilm1, ilm2],
       users: [model],
     });
     const course2 = store.createRecord('course');
-    const session2 = store.createRecord('session', {
+    const session3 = store.createRecord('session', {
       course: course2,
     });
     const ilm3 = store.createRecord('ilmSession', {
-      session: session2,
+      session: session3,
     });
     store.createRecord('learnerGroup', {
       ilmSessions: [ilm3],


### PR DESCRIPTION
The TrackedAsyncData provides a better way to manage asynchronous state, however it is more verbose and in order to be auto tracked it requires each step in an async getter chain to be explicitly coded. I focused on the testable output of the non-private getters for this change and I think I've replaced our original resources with these new getters. Long term we probably need to remove many of the public getters on models because doing things this way where we can't know exactly where in an async chain a change may happen makes for some verbose and difficult to read code.