### PR TITLE
Replace autodetected mirage models

### DIFF
--- a/addon-mirage-support/models/aamc-method.js
+++ b/addon-mirage-support/models/aamc-method.js
@@ -1,0 +1,5 @@
+import { Model, hasMany } from 'miragejs';
+
+export default Model.extend({
+  sessionTypes: hasMany('session-type', { inverse: 'aamcMethods' }),
+});

--- a/addon-mirage-support/models/aamc-pcrs.js
+++ b/addon-mirage-support/models/aamc-pcrs.js
@@ -1,0 +1,5 @@
+import { Model, hasMany } from 'miragejs';
+
+export default Model.extend({
+  competencies: hasMany('competency', { async: true, inverse: 'aamcPcrses' }),
+});

--- a/addon-mirage-support/models/aamc-pcrs.js
+++ b/addon-mirage-support/models/aamc-pcrs.js
@@ -1,5 +1,5 @@
 import { Model, hasMany } from 'miragejs';
 
 export default Model.extend({
-  competencies: hasMany('competency', { async: true, inverse: 'aamcPcrses' }),
+  competencies: hasMany('competency', { inverse: 'aamcPcrses' }),
 });

--- a/addon-mirage-support/models/aamc-resource-type.js
+++ b/addon-mirage-support/models/aamc-resource-type.js
@@ -1,0 +1,5 @@
+import { Model, hasMany } from 'miragejs';
+
+export default Model.extend({
+  competencies: hasMany('term', { async: true, inverse: 'aamcResourceTypes' }),
+});

--- a/addon-mirage-support/models/academic-year.js
+++ b/addon-mirage-support/models/academic-year.js
@@ -1,0 +1,3 @@
+import { Model } from 'miragejs';
+
+export default Model.extend({});

--- a/addon-mirage-support/models/assessment-option.js
+++ b/addon-mirage-support/models/assessment-option.js
@@ -1,5 +1,5 @@
 import { Model, hasMany } from 'miragejs';
 
 export default Model.extend({
-  competencies: hasMany('term', { inverse: 'aamcResourceTypes' }),
+  sessionTypes: hasMany('session-type', { inverse: 'assessmentOption' }),
 });

--- a/addon-mirage-support/models/authentication.js
+++ b/addon-mirage-support/models/authentication.js
@@ -1,0 +1,5 @@
+import { Model, belongsTo } from 'miragejs';
+
+export default Model.extend({
+  user: belongsTo('user', { inverse: 'authentication' }),
+});

--- a/addon-mirage-support/models/cohort.js
+++ b/addon-mirage-support/models/cohort.js
@@ -1,0 +1,8 @@
+import { Model, belongsTo, hasMany } from 'miragejs';
+
+export default Model.extend({
+  programYear: belongsTo('program-year', { inverse: 'cohort' }),
+  courses: hasMany('course', { inverse: 'cohorts' }),
+  learnerGroups: hasMany('learner-group', { inverse: 'cohort' }),
+  users: hasMany('user', { inverse: 'cohorts' }),
+});

--- a/addon-mirage-support/models/competency.js
+++ b/addon-mirage-support/models/competency.js
@@ -6,5 +6,5 @@ export default Model.extend({
   children: hasMany('competency', { inverse: 'parent' }),
   aamcPcrses: hasMany('aamc-pcrs', { inverse: 'competencies' }),
   programYears: hasMany('program-year', { inverse: 'competencies' }),
-  programYearObjectives: hasMany('program-year-objectives', { inverse: 'competency' }),
+  programYearObjectives: hasMany('program-year-objective', { inverse: 'competency' }),
 });

--- a/addon-mirage-support/models/competency.js
+++ b/addon-mirage-support/models/competency.js
@@ -1,0 +1,10 @@
+import { Model, belongsTo, hasMany } from 'miragejs';
+
+export default Model.extend({
+  school: belongsTo('school', { inverse: 'competencies' }),
+  parent: belongsTo('competency', { inverse: 'children' }),
+  children: hasMany('competency', { inverse: 'parent' }),
+  aamcPcrses: hasMany('aamc-pcrs', { inverse: 'competencies' }),
+  programYears: hasMany('program-year', { inverse: 'competencies' }),
+  programYearObjectives: hasMany('program-year-objectives', { inverse: 'competency' }),
+});

--- a/addon-mirage-support/models/course-clerkship-type.js
+++ b/addon-mirage-support/models/course-clerkship-type.js
@@ -1,5 +1,5 @@
 import { Model, hasMany } from 'miragejs';
 
 export default Model.extend({
-  competencies: hasMany('term', { inverse: 'aamcResourceTypes' }),
+  courses: hasMany('course', { inverse: 'clerkshipType' }),
 });

--- a/addon-mirage-support/models/course-learning-material.js
+++ b/addon-mirage-support/models/course-learning-material.js
@@ -1,0 +1,7 @@
+import { Model, belongsTo, hasMany } from 'miragejs';
+
+export default Model.extend({
+  course: belongsTo('course', { inverse: 'learningMaterials' }),
+  learningMaterial: belongsTo('learning-material', { inverse: 'courseLearningMaterials' }),
+  meshDescriptors: hasMany('mesh-descriptors', { inverse: 'courseLearningMaterials' }),
+});

--- a/addon-mirage-support/models/course-objective.js
+++ b/addon-mirage-support/models/course-objective.js
@@ -1,0 +1,11 @@
+import { Model, belongsTo, hasMany } from 'miragejs';
+
+export default Model.extend({
+  course: belongsTo('course', { inverse: 'courseObjectives' }),
+  terms: hasMany('term', { inverse: 'courseObjectives' }),
+  meshDescriptors: hasMany('mesh-descriptor', { inverse: 'courseObjectives' }),
+  ancestor: belongsTo('course-objective', { inverse: 'descendants' }),
+  descendants: hasMany('course-objective', { inverse: 'ancestor' }),
+  sessionObjectives: hasMany('session-objective', { inverse: 'courseObjectives' }),
+  programYearObjectives: hasMany('program-year-objective', { inverse: 'courseObjectives' }),
+});

--- a/addon-mirage-support/models/course.js
+++ b/addon-mirage-support/models/course.js
@@ -1,0 +1,17 @@
+import { Model, belongsTo, hasMany } from 'miragejs';
+
+export default Model.extend({
+  clerkshipType: belongsTo('course-clerkship-type', { inverse: 'courses' }),
+  school: belongsTo('school', { inverse: 'courses' }),
+  directors: hasMany('user', { inverse: 'directedCourses' }),
+  administrators: hasMany('user', { inverse: 'administeredCourses' }),
+  studentAdvisors: hasMany('user', { inverse: 'studentAdvisedCourses' }),
+  cohorts: hasMany('cohort', { inverse: 'courses' }),
+  courseObjectives: hasMany('course-objective', { inverse: 'course' }),
+  meshDescriptors: hasMany('mesh-descriptor', { inverse: 'courses' }),
+  learningMaterials: hasMany('course-learning-material', { inverse: 'course' }),
+  sessions: hasMany('session', { inverse: 'course' }),
+  ancestor: belongsTo('course', { inverse: 'descendants' }),
+  descendants: hasMany('course', { inverse: 'ancestor' }),
+  terms: hasMany('term', { inverse: 'courses' }),
+});

--- a/addon-mirage-support/models/curriculum-inventory-academic-level.js
+++ b/addon-mirage-support/models/curriculum-inventory-academic-level.js
@@ -1,0 +1,11 @@
+import { Model, belongsTo, hasMany } from 'miragejs';
+
+export default Model.extend({
+  report: belongsTo('curriculum-inventory-report', { inverse: 'academicLevels' }),
+  startingSequenceBlocks: hasMany('curriculum-inventory-sequence-block', {
+    inverse: 'startingAcademicLevel',
+  }),
+  endingSequenceBlocks: hasMany('curriculum-inventory-sequence-block', {
+    inverse: 'endingAcademicLevel',
+  }),
+});

--- a/addon-mirage-support/models/curriculum-inventory-export.js
+++ b/addon-mirage-support/models/curriculum-inventory-export.js
@@ -1,0 +1,6 @@
+import { Model, belongsTo } from 'miragejs';
+
+export default Model.extend({
+  report: belongsTo('curriculum-inventory-report', { inverse: 'export' }),
+  createdBy: belongsTo('user', { inverse: null }),
+});

--- a/addon-mirage-support/models/curriculum-inventory-institution.js
+++ b/addon-mirage-support/models/curriculum-inventory-institution.js
@@ -1,0 +1,5 @@
+import { Model, belongsTo } from 'miragejs';
+
+export default Model.extend({
+  school: belongsTo('school', { inverse: 'curriculumInventoryInstitution' }),
+});

--- a/addon-mirage-support/models/curriculum-inventory-report.js
+++ b/addon-mirage-support/models/curriculum-inventory-report.js
@@ -1,0 +1,14 @@
+import { Model, belongsTo, hasMany } from 'miragejs';
+
+export default Model.extend({
+  export: belongsTo('curriculum-inventory-export', { inverse: 'report' }),
+  sequence: belongsTo('curriculum-inventory-sequence', { inverse: 'report' }),
+  sequenceBlocks: hasMany('curriculum-inventory-sequence-block', {
+    inverse: 'report',
+  }),
+  program: belongsTo('program', { inverse: 'curriculumInventoryReports' }),
+  academicLevels: hasMany('curriculum-inventory-academic-level', {
+    inverse: 'report',
+  }),
+  administrators: hasMany('user', { inverse: 'administeredCurriculumInventoryReports' }),
+});

--- a/addon-mirage-support/models/curriculum-inventory-sequence-block.js
+++ b/addon-mirage-support/models/curriculum-inventory-sequence-block.js
@@ -1,0 +1,18 @@
+import { Model, belongsTo, hasMany } from 'miragejs';
+
+export default Model.extend({
+  startingAcademicLevel: belongsTo('curriculum-inventory-academic-level', {
+    inverse: 'startingSequenceBlocks',
+  }),
+  endingAcademicLevel: belongsTo('curriculum-inventory-academic-level', {
+    inverse: 'endingSequenceBlocks',
+  }),
+  parent: belongsTo('curriculum-inventory-sequence-block', { inverse: 'children' }),
+  children: hasMany('curriculum-inventory-sequence-block', { inverse: 'parent' }),
+  report: belongsTo('curriculum-inventory-report', {
+    inverse: 'sequenceBlocks',
+  }),
+  sessions: hasMany('session', { inverse: null }),
+  excludedSessions: hasMany('session', { inverse: null }),
+  course: belongsTo('course', { inverse: null }),
+});

--- a/addon-mirage-support/models/curriculum-inventory-sequence.js
+++ b/addon-mirage-support/models/curriculum-inventory-sequence.js
@@ -1,0 +1,5 @@
+import { Model, belongsTo } from 'miragejs';
+
+export default Model.extend({
+  report: belongsTo('curriculum-inventory-report', { inverse: 'sequence' }),
+});

--- a/addon-mirage-support/models/ilm-session.js
+++ b/addon-mirage-support/models/ilm-session.js
@@ -1,0 +1,9 @@
+import { Model, belongsTo, hasMany } from 'miragejs';
+
+export default Model.extend({
+  session: belongsTo('session', { inverse: 'ilmSession' }),
+  learnerGroups: hasMany('learner-group', { inverse: 'ilmSessions' }),
+  instructorGroups: hasMany('instructor-group', { inverse: 'ilmSessions' }),
+  instructors: hasMany('user', { inverse: 'instructorIlmSessions' }),
+  learners: hasMany('user', { inverse: 'learnerIlmSessions' }),
+});

--- a/addon-mirage-support/models/ingestion-exception.js
+++ b/addon-mirage-support/models/ingestion-exception.js
@@ -1,0 +1,5 @@
+import { Model, belongsTo } from 'miragejs';
+
+export default Model.extend({
+  user: belongsTo('user', { inverse: 'ingestionExceptions' }),
+});

--- a/addon-mirage-support/models/instructor-group.js
+++ b/addon-mirage-support/models/instructor-group.js
@@ -1,0 +1,9 @@
+import { Model, belongsTo, hasMany } from 'miragejs';
+
+export default Model.extend({
+  school: belongsTo('school', { inverse: 'instructorGroups' }),
+  learnerGroups: hasMany('learner-group', { inverse: 'instructorGroups' }),
+  ilmSessions: hasMany('ilm-session', { inverse: 'instructorGroups' }),
+  users: hasMany('user', { inverse: 'instructorGroups' }),
+  offerings: hasMany('offering', { inverse: 'instructorGroups' }),
+});

--- a/addon-mirage-support/models/learner-group.js
+++ b/addon-mirage-support/models/learner-group.js
@@ -1,0 +1,14 @@
+import { Model, belongsTo, hasMany } from 'miragejs';
+
+export default Model.extend({
+  cohort: belongsTo('cohort', { inverse: 'learnerGroups' }),
+  parent: belongsTo('learner-group', { inverse: 'children' }),
+  children: hasMany('learner-group', { inverse: 'parent' }),
+  ilmSessions: hasMany('ilm-session', { inverse: 'learnerGroups' }),
+  offerings: hasMany('offering', { inverse: 'learnerGroups' }),
+  instructorGroups: hasMany('instructor-group', { inverse: 'learnerGroups' }),
+  users: hasMany('user', { inverse: 'learnerGroups' }),
+  instructors: hasMany('user', { inverse: 'instructedLearnerGroups' }),
+  ancestor: belongsTo('learner-group', { inverse: 'descendants' }),
+  descendants: hasMany('learner-group', { inverse: 'ancestor' }),
+});

--- a/addon-mirage-support/models/learning-material-status.js
+++ b/addon-mirage-support/models/learning-material-status.js
@@ -1,0 +1,3 @@
+import { Model } from 'miragejs';
+
+export default Model.extend({});

--- a/addon-mirage-support/models/learning-material-user-role.js
+++ b/addon-mirage-support/models/learning-material-user-role.js
@@ -1,0 +1,3 @@
+import { Model } from 'miragejs';
+
+export default Model.extend({});

--- a/addon-mirage-support/models/learning-material.js
+++ b/addon-mirage-support/models/learning-material.js
@@ -5,5 +5,5 @@ export default Model.extend({
   status: belongsTo('learning-material-status', { inverse: null }),
   owningUser: belongsTo('user', { inverse: null }),
   sessionLearningMaterials: hasMany('session-learning-material', { inverse: 'learningMaterial' }),
-  courseLearningMaterial: hasMany('course-learning-material', { inverse: 'learningMaterial' }),
+  courseLearningMaterials: hasMany('course-learning-material', { inverse: 'learningMaterial' }),
 });

--- a/addon-mirage-support/models/learning-material.js
+++ b/addon-mirage-support/models/learning-material.js
@@ -1,0 +1,9 @@
+import { Model, belongsTo, hasMany } from 'miragejs';
+
+export default Model.extend({
+  userRole: belongsTo('learning-material-user-role', { inverse: null }),
+  status: belongsTo('learning-material-status', { inverse: null }),
+  owningUser: belongsTo('user', { inverse: null }),
+  sessionLearningMaterials: hasMany('session-learning-material', { inverse: 'learningMaterial' }),
+  courseLearningMaterial: hasMany('course-learning-material', { inverse: 'learningMaterial' }),
+});

--- a/addon-mirage-support/models/mesh-concept.js
+++ b/addon-mirage-support/models/mesh-concept.js
@@ -1,0 +1,6 @@
+import { Model, hasMany } from 'miragejs';
+
+export default Model.extend({
+  terms: hasMany('mesh-term', { inverse: 'concepts' }),
+  descriptors: hasMany('mesh-descriptor', { inverse: 'concepts' }),
+});

--- a/addon-mirage-support/models/mesh-descriptor.js
+++ b/addon-mirage-support/models/mesh-descriptor.js
@@ -1,0 +1,15 @@
+import { Model, belongsTo, hasMany } from 'miragejs';
+
+export default Model.extend({
+  courses: hasMany('course', { inverse: 'meshDescriptors' }),
+  sessions: hasMany('session', { inverse: 'meshDescriptors' }),
+  concepts: hasMany('mesh-concept', { inverse: 'descriptors' }),
+  qualifiers: hasMany('mesh-qualifier', { inverse: 'descriptors' }),
+  trees: hasMany('mesh-tree', { inverse: 'descriptors' }),
+  sessionLearningMaterials: hasMany('session-learning-material', { inverse: 'meshDescriptors' }),
+  courseLearningMaterials: hasMany('course-learning-material', { inverse: 'meshDescriptors' }),
+  previousIndexing: belongsTo('mesh-previous-indexing', { inverse: 'descriptor' }),
+  sessionObjectives: hasMany('session-objective', { inverse: 'meshDescriptors' }),
+  courseObjectives: hasMany('course-objective', { inverse: 'meshDescriptors' }),
+  programYearObjectives: hasMany('program-year-objective', { inverse: 'meshDescriptors' }),
+});

--- a/addon-mirage-support/models/mesh-descriptor.js
+++ b/addon-mirage-support/models/mesh-descriptor.js
@@ -5,7 +5,7 @@ export default Model.extend({
   sessions: hasMany('session', { inverse: 'meshDescriptors' }),
   concepts: hasMany('mesh-concept', { inverse: 'descriptors' }),
   qualifiers: hasMany('mesh-qualifier', { inverse: 'descriptors' }),
-  trees: hasMany('mesh-tree', { inverse: 'descriptors' }),
+  trees: hasMany('mesh-tree', { inverse: 'descriptor' }),
   sessionLearningMaterials: hasMany('session-learning-material', { inverse: 'meshDescriptors' }),
   courseLearningMaterials: hasMany('course-learning-material', { inverse: 'meshDescriptors' }),
   previousIndexing: belongsTo('mesh-previous-indexing', { inverse: 'descriptor' }),

--- a/addon-mirage-support/models/mesh-previous-indexing.js
+++ b/addon-mirage-support/models/mesh-previous-indexing.js
@@ -1,0 +1,5 @@
+import { Model, belongsTo } from 'miragejs';
+
+export default Model.extend({
+  descriptor: belongsTo('mesh-descriptor', { inverse: 'previousIndexing' }),
+});

--- a/addon-mirage-support/models/mesh-qualifier.js
+++ b/addon-mirage-support/models/mesh-qualifier.js
@@ -1,0 +1,5 @@
+import { Model, hasMany } from 'miragejs';
+
+export default Model.extend({
+  descriptors: hasMany('mesh-descriptor', { inverse: 'meshQualifier' }),
+});

--- a/addon-mirage-support/models/mesh-term.js
+++ b/addon-mirage-support/models/mesh-term.js
@@ -1,0 +1,5 @@
+import { Model, hasMany } from 'miragejs';
+
+export default Model.extend({
+  concepts: hasMany('mesh-concept', { inverse: 'meshTerms' }),
+});

--- a/addon-mirage-support/models/mesh-tree.js
+++ b/addon-mirage-support/models/mesh-tree.js
@@ -1,0 +1,5 @@
+import { Model, belongsTo } from 'miragejs';
+
+export default Model.extend({
+  descriptor: belongsTo('mesh-descriptor', { inverse: 'trees' }),
+});

--- a/addon-mirage-support/models/offering.js
+++ b/addon-mirage-support/models/offering.js
@@ -1,0 +1,9 @@
+import { Model, belongsTo, hasMany } from 'miragejs';
+
+export default Model.extend({
+  session: belongsTo('session', { inverse: 'offerings' }),
+  learnerGroups: hasMany('learner-group', { inverse: 'offerings' }),
+  instructorGroups: hasMany('instructor-group', { inverse: 'offerings' }),
+  learners: hasMany('user', { inverse: 'offerings' }),
+  instructors: hasMany('user', { inverse: 'instructedOfferings' }),
+});

--- a/addon-mirage-support/models/pending-user-update.js
+++ b/addon-mirage-support/models/pending-user-update.js
@@ -1,0 +1,5 @@
+import { Model, belongsTo } from 'miragejs';
+
+export default Model.extend({
+  user: belongsTo('user', { inverse: 'pendingUserUpdates' }),
+});

--- a/addon-mirage-support/models/program-year-objective.js
+++ b/addon-mirage-support/models/program-year-objective.js
@@ -1,0 +1,10 @@
+import { Model, belongsTo, hasMany } from 'miragejs';
+
+export default Model.extend({
+  competency: belongsTo('competency', { inverse: 'programYearObjectives' }),
+  programYear: belongsTo('program-year', { inverse: 'programYearObjectives' }),
+  terms: hasMany('mesh-descriptor', { inverse: 'programYearObjectives' }),
+  ancestor: belongsTo('program-year-objective', { inverse: 'descendants' }),
+  descendants: hasMany('program-year-objective', { inverse: 'ancestor' }),
+  courseObjectives: hasMany('course-objective', { inverse: 'programYearObjectives' }),
+});

--- a/addon-mirage-support/models/program-year-objective.js
+++ b/addon-mirage-support/models/program-year-objective.js
@@ -3,7 +3,8 @@ import { Model, belongsTo, hasMany } from 'miragejs';
 export default Model.extend({
   competency: belongsTo('competency', { inverse: 'programYearObjectives' }),
   programYear: belongsTo('program-year', { inverse: 'programYearObjectives' }),
-  terms: hasMany('mesh-descriptor', { inverse: 'programYearObjectives' }),
+  terms: hasMany('term', { inverse: 'programYearObjectives' }),
+  meshDescriptors: hasMany('mesh-descriptor', { inverse: 'programYearObjectives' }),
   ancestor: belongsTo('program-year-objective', { inverse: 'descendants' }),
   descendants: hasMany('program-year-objective', { inverse: 'ancestor' }),
   courseObjectives: hasMany('course-objective', { inverse: 'programYearObjectives' }),

--- a/addon-mirage-support/models/program-year.js
+++ b/addon-mirage-support/models/program-year.js
@@ -1,0 +1,10 @@
+import { Model, belongsTo, hasMany } from 'miragejs';
+
+export default Model.extend({
+  program: belongsTo('program', { inverse: 'programYears' }),
+  cohort: belongsTo('cohort', { inverse: 'programYear' }),
+  directors: hasMany('user', { inverse: 'programYears' }),
+  competencies: hasMany('competency', { inverse: 'programYears' }),
+  programYearObjectives: hasMany('program-year-objective', { inverse: 'programYear' }),
+  terms: hasMany('term', { inverse: 'programYears' }),
+});

--- a/addon-mirage-support/models/program.js
+++ b/addon-mirage-support/models/program.js
@@ -1,0 +1,8 @@
+import { Model, belongsTo, hasMany } from 'miragejs';
+
+export default Model.extend({
+  school: belongsTo('school', { inverse: 'programs' }),
+  programYears: hasMany('program-year', { inverse: 'program' }),
+  directors: hasMany('user', { inverse: 'directedPrograms' }),
+  curriculumInventoryReports: hasMany('curriculum-inventory-report', { inverse: 'program' }),
+});

--- a/addon-mirage-support/models/report.js
+++ b/addon-mirage-support/models/report.js
@@ -1,0 +1,6 @@
+import { Model, belongsTo } from 'miragejs';
+
+export default Model.extend({
+  user: belongsTo('user', { inverse: 'reports' }),
+  school: belongsTo('school', { inverse: null }),
+});

--- a/addon-mirage-support/models/school-config.js
+++ b/addon-mirage-support/models/school-config.js
@@ -1,0 +1,5 @@
+import { Model, belongsTo } from 'miragejs';
+
+export default Model.extend({
+  school: belongsTo('school', { inverse: 'configurations' }),
+});

--- a/addon-mirage-support/models/school.js
+++ b/addon-mirage-support/models/school.js
@@ -10,7 +10,7 @@ export default Model.extend({
     inverse: 'school',
   }),
   sessionTypes: hasMany('session-type', { inverse: 'school' }),
-  directors: hasMany('user', { inverse: 'school' }),
+  directors: hasMany('user', { inverse: 'directedSchools' }),
   administrators: hasMany('user', { inverse: 'administeredSchools' }),
   configurations: hasMany('school-config', { inverse: 'school' }),
 });

--- a/addon-mirage-support/models/school.js
+++ b/addon-mirage-support/models/school.js
@@ -1,0 +1,16 @@
+import { Model, belongsTo, hasMany } from 'miragejs';
+
+export default Model.extend({
+  competencies: hasMany('competency', { inverse: 'school' }),
+  courses: hasMany('course', { inverse: 'school' }),
+  programs: hasMany('program', { inverse: 'school' }),
+  vocabularies: hasMany('vocabulary', { inverse: 'school' }),
+  instructorGroups: hasMany('instructor-group', { inverse: 'school' }),
+  curriculumInventoryInstitution: belongsTo('curriculum-inventory-institution', {
+    inverse: 'school',
+  }),
+  sessionTypes: hasMany('session-type', { inverse: 'school' }),
+  directors: hasMany('user', { inverse: 'school' }),
+  administrators: hasMany('user', { inverse: 'school' }),
+  configurations: hasMany('school-config', { inverse: 'school' }),
+});

--- a/addon-mirage-support/models/school.js
+++ b/addon-mirage-support/models/school.js
@@ -11,6 +11,6 @@ export default Model.extend({
   }),
   sessionTypes: hasMany('session-type', { inverse: 'school' }),
   directors: hasMany('user', { inverse: 'school' }),
-  administrators: hasMany('user', { inverse: 'school' }),
+  administrators: hasMany('user', { inverse: 'administeredSchools' }),
   configurations: hasMany('school-config', { inverse: 'school' }),
 });

--- a/addon-mirage-support/models/session-learning-material.js
+++ b/addon-mirage-support/models/session-learning-material.js
@@ -2,6 +2,6 @@ import { Model, belongsTo, hasMany } from 'miragejs';
 
 export default Model.extend({
   session: belongsTo('session', { inverse: 'learningMaterials' }),
-  terms: belongsTo('learning-material', { inverse: 'sessionLearningMaterials' }),
+  learningMaterial: belongsTo('learning-material', { inverse: 'sessionLearningMaterials' }),
   meshDescriptors: hasMany('mesh-descriptor', { inverse: 'sessionLearningMaterials' }),
 });

--- a/addon-mirage-support/models/session-learning-material.js
+++ b/addon-mirage-support/models/session-learning-material.js
@@ -1,0 +1,7 @@
+import { Model, belongsTo, hasMany } from 'miragejs';
+
+export default Model.extend({
+  session: belongsTo('session', { inverse: 'learningMaterials' }),
+  terms: belongsTo('learning-material', { inverse: 'sessionLearningMaterials' }),
+  meshDescriptors: hasMany('mesh-descriptor', { inverse: 'sessionLearningMaterials' }),
+});

--- a/addon-mirage-support/models/session-objective.js
+++ b/addon-mirage-support/models/session-objective.js
@@ -2,7 +2,7 @@ import { Model, belongsTo, hasMany } from 'miragejs';
 
 export default Model.extend({
   session: belongsTo('session', { inverse: 'sessionObjectives' }),
-  terms: hasMany('session', { inverse: 'sessionObjectives' }),
+  terms: hasMany('term', { inverse: 'sessionObjectives' }),
   meshDescriptors: hasMany('mesh-descriptor', { inverse: 'sessionObjectives' }),
   ancestor: belongsTo('session-objective', { inverse: 'descendants' }),
   descendants: hasMany('session-objective', { inverse: 'ancestor' }),

--- a/addon-mirage-support/models/session-objective.js
+++ b/addon-mirage-support/models/session-objective.js
@@ -1,0 +1,10 @@
+import { Model, belongsTo, hasMany } from 'miragejs';
+
+export default Model.extend({
+  session: belongsTo('session', { inverse: 'sessionObjectives' }),
+  terms: hasMany('session', { inverse: 'sessionObjectives' }),
+  meshDescriptors: hasMany('mesh-descriptor', { inverse: 'sessionObjectives' }),
+  ancestor: belongsTo('session-objective', { inverse: 'descendants' }),
+  descendants: hasMany('session-objective', { inverse: 'ancestor' }),
+  courseObjectives: hasMany('course-objective', { inverse: 'sessionObjectives' }),
+});

--- a/addon-mirage-support/models/session-type.js
+++ b/addon-mirage-support/models/session-type.js
@@ -1,0 +1,8 @@
+import { Model, belongsTo, hasMany } from 'miragejs';
+
+export default Model.extend({
+  assessmentOption: belongsTo('assessment-option', { inverse: 'sessionTypes' }),
+  school: belongsTo('school', { inverse: 'sessionTypes' }),
+  aamcMethods: hasMany('aamc-method', { inverse: 'sessionTypes' }),
+  sessions: hasMany('session', { inverse: 'sessionType' }),
+});

--- a/addon-mirage-support/models/session.js
+++ b/addon-mirage-support/models/session.js
@@ -1,0 +1,24 @@
+import { Model, belongsTo, hasMany } from 'miragejs';
+
+export default Model.extend({
+  sessionType: belongsTo('session-type', { inverse: 'sessions' }),
+  course: belongsTo('course', { inverse: 'sessions' }),
+  ilmSession: belongsTo('ilm-session', { inverse: 'session' }),
+  sessionObjectives: hasMany('session-objective', { inverse: 'session' }),
+  meshDescriptors: hasMany('mesh-descriptor', { inverse: 'sessions' }),
+  learningMaterials: hasMany('session-learning-material', { inverse: 'session' }),
+  offerings: hasMany('offering', { inverse: 'session' }),
+  administrators: hasMany('user', {
+    inverse: 'administeredSessions',
+  }),
+  studentAdvisors: hasMany('user', {
+    inverse: 'studentAdvisedSessions',
+  }),
+  postrequisite: belongsTo('session', {
+    inverse: 'prerequisites',
+  }),
+  prerequisites: hasMany('session', {
+    inverse: 'postrequisite',
+  }),
+  terms: hasMany('term', { inverse: 'sessions' }),
+});

--- a/addon-mirage-support/models/term.js
+++ b/addon-mirage-support/models/term.js
@@ -1,0 +1,14 @@
+import { Model, belongsTo, hasMany } from 'miragejs';
+
+export default Model.extend({
+  vocabulary: belongsTo('vocabulary', { inverse: 'terms' }),
+  parent: belongsTo('term', { inverse: 'children' }),
+  children: hasMany('term', { inverse: 'parent' }),
+  programYears: hasMany('program-year', { inverse: 'terms' }),
+  sessions: hasMany('session', { inverse: 'terms' }),
+  courses: hasMany('course', { inverse: 'terms' }),
+  aamcResourceTypes: hasMany('aamc-resource-type', { inverse: 'terms' }),
+  courseObjectives: hasMany('course-objective', { inverse: 'terms' }),
+  programYearObjectives: hasMany('program-year-objective', { inverse: 'terms' }),
+  sessionObjectives: hasMany('session-objective', { inverse: 'terms' }),
+});

--- a/addon-mirage-support/models/user-role.js
+++ b/addon-mirage-support/models/user-role.js
@@ -1,0 +1,3 @@
+import { Model } from 'miragejs';
+
+export default Model.extend({});

--- a/addon-mirage-support/models/user-session-material-status.js
+++ b/addon-mirage-support/models/user-session-material-status.js
@@ -1,0 +1,6 @@
+import { Model, belongsTo } from 'miragejs';
+
+export default Model.extend({
+  user: belongsTo('user', { inverse: 'sessionMaterialStatuses' }),
+  material: belongsTo('session-learning-material', { inverse: null }),
+});

--- a/addon-mirage-support/models/user.js
+++ b/addon-mirage-support/models/user.js
@@ -1,7 +1,7 @@
 import { Model, belongsTo, hasMany } from 'miragejs';
 
 export default Model.extend({
-  reports: belongsTo('report', { inverse: 'user' }),
+  reports: hasMany('report', { inverse: 'user' }),
   school: belongsTo('school', { inverse: null }),
   authentication: belongsTo('authentication', { inverse: 'user' }),
   directedCourses: hasMany('course', { inverse: 'directors' }),
@@ -9,6 +9,7 @@ export default Model.extend({
   studentAdvisedCourses: hasMany('course', { inverse: 'studentAdvisors' }),
   studentAdvisedSessions: hasMany('session', { inverse: 'studentAdvisors' }),
   learnerGroups: hasMany('learner-group', { inverse: 'users' }),
+  instructedLearnerGroups: hasMany('learner-group', { inverse: 'instructors' }),
   instructorGroups: hasMany('instructor-group', { inverse: 'users' }),
   instructorIlmSessions: hasMany('ilm-session', { inverse: 'instructors' }),
   learnerIlmSessions: hasMany('ilm-session', { inverse: 'learners' }),

--- a/addon-mirage-support/models/user.js
+++ b/addon-mirage-support/models/user.js
@@ -15,7 +15,7 @@ export default Model.extend({
   offerings: hasMany('offering', { inverse: 'learners' }),
   instructedOfferings: hasMany('offering', { inverse: 'instructors' }),
   programYears: hasMany('program-year', { inverse: 'directors' }),
-  roles: hasMany('user-year', { inverse: null }),
+  roles: hasMany('user-role', { inverse: null }),
   directedSchools: hasMany('school', { inverse: 'directors' }),
   administeredSchools: hasMany('school', { inverse: 'administrators' }),
   administeredSessions: hasMany('session', { inverse: 'administrators' }),

--- a/addon-mirage-support/models/user.js
+++ b/addon-mirage-support/models/user.js
@@ -1,0 +1,30 @@
+import { Model, belongsTo, hasMany } from 'miragejs';
+
+export default Model.extend({
+  reports: belongsTo('report', { inverse: 'user' }),
+  school: belongsTo('school', { inverse: null }),
+  authentication: belongsTo('authentication', { inverse: 'user' }),
+  directedCourses: hasMany('course', { inverse: 'directors' }),
+  administeredCourses: hasMany('course', { inverse: 'administrators' }),
+  studentAdvisedCourses: hasMany('course', { inverse: 'studentAdvisors' }),
+  studentAdvisedSessions: hasMany('session', { inverse: 'studentAdvisors' }),
+  learnerGroups: hasMany('learner-group', { inverse: 'users' }),
+  instructorGroups: hasMany('instructor-group', { inverse: 'users' }),
+  instructorIlmSessions: hasMany('ilm-session', { inverse: 'instructors' }),
+  learnerIlmSessions: hasMany('ilm-session', { inverse: 'learners' }),
+  offerings: hasMany('offering', { inverse: 'learners' }),
+  instructedOfferings: hasMany('offering', { inverse: 'instructors' }),
+  programYears: hasMany('program-year', { inverse: 'directors' }),
+  roles: hasMany('user-year', { inverse: null }),
+  directedSchools: hasMany('school', { inverse: 'directors' }),
+  administeredSchools: hasMany('school', { inverse: 'administrators' }),
+  administeredSessions: hasMany('session', { inverse: 'administrators' }),
+  directedPrograms: hasMany('program', { inverse: 'directors' }),
+  cohorts: hasMany('cohort', { inverse: 'users' }),
+  primaryCohort: belongsTo('cohort', { inverse: null }),
+  pendingUserUpdates: hasMany('pending-user-update', { inverse: 'user' }),
+  administeredCurriculumInventoryReports: hasMany('curriculum-inventory-report', {
+    inverse: 'administrators',
+  }),
+  sessionMaterialStatuses: hasMany('user-session-material-status', { inverse: 'user' }),
+});

--- a/addon-mirage-support/models/vocabulary.js
+++ b/addon-mirage-support/models/vocabulary.js
@@ -1,0 +1,6 @@
+import { Model, belongsTo, hasMany } from 'miragejs';
+
+export default Model.extend({
+  school: belongsTo('school', { inverse: 'vocabularies' }),
+  terms: hasMany('term', { inverse: 'vocabulary' }),
+});

--- a/addon/models/competency.js
+++ b/addon/models/competency.js
@@ -21,7 +21,7 @@ export default class CompetencyModel extends Model {
   @hasMany('program-year', { async: true, inverse: 'competencies' })
   programYears;
 
-  @hasMany('program-year-objectives', { async: true, inverse: 'competency' })
+  @hasMany('program-year-objective', { async: true, inverse: 'competency' })
   programYearObjectives;
 
   get childCount() {

--- a/tests/dummy/mirage/config.js
+++ b/tests/dummy/mirage/config.js
@@ -1,6 +1,5 @@
 import commonRoutes from './routes';
 import ENV from 'dummy/config/environment';
-import { discoverEmberDataModels } from 'ember-cli-mirage';
 import { createServer } from 'miragejs';
 
 const { apiVersion } = ENV;
@@ -8,7 +7,6 @@ const { apiVersion } = ENV;
 export default function (config) {
   let finalConfig = {
     ...config,
-    models: { ...discoverEmberDataModels(), ...config.models },
     routes() {
       this.namespace = '/';
       commonRoutes(this);


### PR DESCRIPTION
The auto detector for mirage will not work anymore in ember-data v5. Instead we can just manually build our models and keep them up to date.