### PR TITLE
Replace service import definition

### DIFF
--- a/addon/adapters/ilios.js
+++ b/addon/adapters/ilios.js
@@ -1,5 +1,5 @@
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { pluralize } from 'ember-inflector';
 import { camelize } from '@ember/string';
 

--- a/addon/authenticators/ilios-jwt.js
+++ b/addon/authenticators/ilios-jwt.js
@@ -1,5 +1,5 @@
 import { get } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import JwtTokenAuthenticator from 'ember-simple-auth-token/authenticators/jwt';
 
 export default class IliosJWT extends JwtTokenAuthenticator {

--- a/addon/classes/permission-checker.js
+++ b/addon/classes/permission-checker.js
@@ -1,5 +1,5 @@
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { Resource } from 'ember-could-get-used-to-this';
 
 export default class PermissionCheckerResource extends Resource {

--- a/addon/components/api-version-notice.js
+++ b/addon/components/api-version-notice.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { dropTask, timeout } from 'ember-concurrency';
 
 export default class ApiVersionNoticeComponent extends Component {

--- a/addon/components/back-link.js
+++ b/addon/components/back-link.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class BackLinkComponent extends Component {

--- a/addon/components/collapsed-competencies.js
+++ b/addon/components/collapsed-competencies.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { findById } from 'ilios-common/utils/array-helpers';
 import { TrackedAsyncData } from 'ember-async-data';
 import { cached } from '@glimmer/tracking';

--- a/addon/components/course-header.js
+++ b/addon/components/course-header.js
@@ -3,7 +3,7 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { restartableTask } from 'ember-concurrency';
 import { validatable, Length, NotBlank } from 'ilios-common/decorators/validation';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 @validatable
 export default class CourseHeaderComponent extends Component {

--- a/addon/components/course-materials.js
+++ b/addon/components/course-materials.js
@@ -4,7 +4,7 @@ import { map } from 'rsvp';
 import { cleanQuery } from 'ilios-common/utils/query-utils';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { use } from 'ember-could-get-used-to-this';
 import { TrackedAsyncData } from 'ember-async-data';
 import { cached } from '@glimmer/tracking';

--- a/addon/components/course-overview.js
+++ b/addon/components/course-overview.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { restartableTask } from 'ember-concurrency';

--- a/addon/components/course-publicationcheck.js
+++ b/addon/components/course-publicationcheck.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { TrackedAsyncData } from 'ember-async-data';
 import { cached } from '@glimmer/tracking';
 

--- a/addon/components/course-rollover.js
+++ b/addon/components/course-rollover.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { validatable, Length, NotBlank } from 'ilios-common/decorators/validation';

--- a/addon/components/course-sessions.js
+++ b/addon/components/course-sessions.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { task, restartableTask, timeout } from 'ember-concurrency';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';

--- a/addon/components/course-summary-header.js
+++ b/addon/components/course-summary-header.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { restartableTask } from 'ember-concurrency';
 

--- a/addon/components/course-visualizations.js
+++ b/addon/components/course-visualizations.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { restartableTask } from 'ember-concurrency';
 
 export default class CourseVisualizationsComponent extends Component {

--- a/addon/components/course-visualize-instructor.js
+++ b/addon/components/course-visualize-instructor.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { map, filter } from 'rsvp';
 import { use } from 'ember-could-get-used-to-this';
 import { TrackedAsyncData } from 'ember-async-data';

--- a/addon/components/course-visualize-instructors.js
+++ b/addon/components/course-visualize-instructors.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { restartableTask } from 'ember-concurrency';
 
 export default class CourseVisualizeInstructorsComponent extends Component {

--- a/addon/components/course-visualize-objectives.js
+++ b/addon/components/course-visualize-objectives.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { TrackedAsyncData } from 'ember-async-data';
 import { cached } from '@glimmer/tracking';
 

--- a/addon/components/course-visualize-session-type.js
+++ b/addon/components/course-visualize-session-type.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { restartableTask } from 'ember-concurrency';
 
 export default class CourseVisualizeSessionTypeComponent extends Component {

--- a/addon/components/course-visualize-session-types.js
+++ b/addon/components/course-visualize-session-types.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { TrackedAsyncData } from 'ember-async-data';
 import { cached } from '@glimmer/tracking';
 

--- a/addon/components/course-visualize-term.js
+++ b/addon/components/course-visualize-term.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { restartableTask } from 'ember-concurrency';
 
 export default class CourseVisualizeTermComponent extends Component {

--- a/addon/components/course-visualize-vocabularies.js
+++ b/addon/components/course-visualize-vocabularies.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { TrackedAsyncData } from 'ember-async-data';
 import { cached } from '@glimmer/tracking';
 

--- a/addon/components/course-visualize-vocabulary.js
+++ b/addon/components/course-visualize-vocabulary.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { TrackedAsyncData } from 'ember-async-data';
 import { cached } from '@glimmer/tracking';
 

--- a/addon/components/course/loader.js
+++ b/addon/components/course/loader.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class CourseLoaderComponent extends Component {
   @service dataLoader;

--- a/addon/components/course/objective-list-item.js
+++ b/addon/components/course/objective-list-item.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { dropTask, restartableTask, timeout } from 'ember-concurrency';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { validatable, Length, HtmlNotBlank } from 'ilios-common/decorators/validation';
 import { findById, mapBy } from 'ilios-common/utils/array-helpers';
 import { TrackedAsyncData } from 'ember-async-data';

--- a/addon/components/course/objective-list.js
+++ b/addon/components/course/objective-list.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { restartableTask } from 'ember-concurrency';
 import { map } from 'rsvp';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { use } from 'ember-could-get-used-to-this';
 import AsyncProcess from 'ilios-common/classes/async-process';
 import { TrackedAsyncData } from 'ember-async-data';

--- a/addon/components/course/objectives.js
+++ b/addon/components/course/objectives.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { dropTask, restartableTask } from 'ember-concurrency';
 import { action } from '@ember/object';

--- a/addon/components/course/publication-menu.js
+++ b/addon/components/course/publication-menu.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 

--- a/addon/components/course/rollover-date-picker.js
+++ b/addon/components/course/rollover-date-picker.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { dropTask } from 'ember-concurrency';
 import flatpickr from 'flatpickr';
 import { tracked } from '@glimmer/tracking';

--- a/addon/components/daily-calendar-event.js
+++ b/addon/components/daily-calendar-event.js
@@ -3,7 +3,7 @@ import moment from 'moment';
 import colorChange from 'ilios-common/utils/color-change';
 import { htmlSafe } from '@ember/template';
 import calendarEventTooltip from 'ilios-common/utils/calendar-event-tooltip';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class DailyCalendarEventComponent extends Component {
   @service intl;

--- a/addon/components/daily-calendar.js
+++ b/addon/components/daily-calendar.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { restartableTask, timeout } from 'ember-concurrency';
 import { action, set } from '@ember/object';
 import { sortBy } from 'ilios-common/utils/array-helpers';

--- a/addon/components/dashboard/calendar-filters.js
+++ b/addon/components/dashboard/calendar-filters.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { mapBy, sortBy } from 'ilios-common/utils/array-helpers';
 import { use } from 'ember-could-get-used-to-this';
 import AsyncProcess from 'ilios-common/classes/async-process';

--- a/addon/components/dashboard/calendar.js
+++ b/addon/components/dashboard/calendar.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { dropTask, restartableTask } from 'ember-concurrency';

--- a/addon/components/dashboard/courses-calendar-filter.js
+++ b/addon/components/dashboard/courses-calendar-filter.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { restartableTask } from 'ember-concurrency';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import moment from 'moment';
 import { findBy, sortBy } from 'ilios-common/utils/array-helpers';
 

--- a/addon/components/dashboard/filter-tags.js
+++ b/addon/components/dashboard/filter-tags.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { restartableTask } from 'ember-concurrency';
 import { all, map } from 'rsvp';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { findById } from 'ilios-common/utils/array-helpers';
 
 export default class DashboardFilterTagsComponent extends Component {

--- a/addon/components/dashboard/materials.js
+++ b/addon/components/dashboard/materials.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { isPresent } from '@ember/utils';
 import { restartableTask, timeout } from 'ember-concurrency';
 import { use } from 'ember-could-get-used-to-this';

--- a/addon/components/date-picker.js
+++ b/addon/components/date-picker.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { dropTask, restartableTask, waitForProperty } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
 import flatpickr from 'flatpickr';

--- a/addon/components/detail-cohort-list.js
+++ b/addon/components/detail-cohort-list.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { restartableTask } from 'ember-concurrency';
 import { map } from 'rsvp';

--- a/addon/components/detail-cohort-manager.js
+++ b/addon/components/detail-cohort-manager.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { map, filter } from 'rsvp';
 import { mapBy } from 'ilios-common/utils/array-helpers';

--- a/addon/components/detail-instructors.js
+++ b/addon/components/detail-instructors.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { dropTask, restartableTask } from 'ember-concurrency';
 import { hash } from 'rsvp';
 import { TrackedAsyncData } from 'ember-async-data';

--- a/addon/components/detail-learners-and-learner-groups.js
+++ b/addon/components/detail-learners-and-learner-groups.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { dropTask } from 'ember-concurrency';
 import { hash } from 'rsvp';
 import { uniqueValues } from 'ilios-common/utils/array-helpers';

--- a/addon/components/detail-learning-materials.js
+++ b/addon/components/detail-learning-materials.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { dropTask } from 'ember-concurrency';

--- a/addon/components/detail-mesh.js
+++ b/addon/components/detail-mesh.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { dropTask, restartableTask } from 'ember-concurrency';
 import { action } from '@ember/object';

--- a/addon/components/detail-taxonomies.js
+++ b/addon/components/detail-taxonomies.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { dropTask } from 'ember-concurrency';
 import { TrackedAsyncData } from 'ember-async-data';
 import { cached } from '@glimmer/tracking';

--- a/addon/components/html-editor.js
+++ b/addon/components/html-editor.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { restartableTask } from 'ember-concurrency';
 import { loadFroalaEditor } from 'ilios-common/utils/load-froala-editor';

--- a/addon/components/ilios-calendar-day.js
+++ b/addon/components/ilios-calendar-day.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { DateTime } from 'luxon';
 import { deprecate } from '@ember/debug';
 

--- a/addon/components/ilios-calendar-event-month.js
+++ b/addon/components/ilios-calendar-event-month.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { htmlSafe } from '@ember/template';
 import moment from 'moment';

--- a/addon/components/ilios-course-details.js
+++ b/addon/components/ilios-course-details.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import scrollIntoView from 'scroll-into-view';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class IliosCourseDetailsComponent extends Component {
   @service router;

--- a/addon/components/leadership-search.js
+++ b/addon/components/leadership-search.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { dropTask, restartableTask, timeout } from 'ember-concurrency';
 import { cleanQuery } from 'ilios-common/utils/query-utils';
 import { tracked } from '@glimmer/tracking';

--- a/addon/components/learnergroup-selection-cohort-manager.js
+++ b/addon/components/learnergroup-selection-cohort-manager.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { TrackedAsyncData } from 'ember-async-data';
 import { cached } from '@glimmer/tracking';
 

--- a/addon/components/learnergroup-tree.js
+++ b/addon/components/learnergroup-tree.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { filter } from 'rsvp';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { use } from 'ember-could-get-used-to-this';
 import { TrackedAsyncData } from 'ember-async-data';
 import { cached } from '@glimmer/tracking';

--- a/addon/components/learning-material-uploader.js
+++ b/addon/components/learning-material-uploader.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { dropTask } from 'ember-concurrency';
 import readableFileSize from 'ilios-common/utils/readable-file-size';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class LearningMaterialUploaderComponent extends Component {

--- a/addon/components/learningmaterial-manager.js
+++ b/addon/components/learningmaterial-manager.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { dropTask, restartableTask } from 'ember-concurrency';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { DateTime } from 'luxon';

--- a/addon/components/learningmaterial-search.js
+++ b/addon/components/learningmaterial-search.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { dropTask, enqueueTask, restartableTask } from 'ember-concurrency';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 

--- a/addon/components/mesh-manager.js
+++ b/addon/components/mesh-manager.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { dropTask, restartableTask, timeout } from 'ember-concurrency';
 import { action } from '@ember/object';

--- a/addon/components/monthly-calendar.js
+++ b/addon/components/monthly-calendar.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { sortBy } from 'ilios-common/utils/array-helpers';
 import { DateTime } from 'luxon';
 import { deprecate } from '@ember/debug';

--- a/addon/components/new-learningmaterial.js
+++ b/addon/components/new-learningmaterial.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { dropTask } from 'ember-concurrency';

--- a/addon/components/new-offering.js
+++ b/addon/components/new-offering.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import scrollIntoView from 'scroll-into-view';

--- a/addon/components/new-session.js
+++ b/addon/components/new-session.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { dropTask } from 'ember-concurrency';

--- a/addon/components/offering-form.js
+++ b/addon/components/offering-form.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { isEmpty, isPresent } from '@ember/utils';
 import { hash, map } from 'rsvp';
 import moment from 'moment-timezone';

--- a/addon/components/offering-manager.js
+++ b/addon/components/offering-manager.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { action, set } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { task, timeout } from 'ember-concurrency';
 import { TrackedAsyncData } from 'ember-async-data';

--- a/addon/components/print-course.js
+++ b/addon/components/print-course.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { dropTask } from 'ember-concurrency';

--- a/addon/components/publish-all-sessions.js
+++ b/addon/components/publish-all-sessions.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { all } from 'rsvp';

--- a/addon/components/search-box.js
+++ b/addon/components/search-box.js
@@ -3,7 +3,7 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { isNone } from '@ember/utils';
 import { restartableTask, timeout } from 'ember-concurrency';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 const DEBOUNCE_TIMEOUT = 250;
 
 export default class SearchBox extends Component {

--- a/addon/components/session-copy.js
+++ b/addon/components/session-copy.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { hash, all, filter } from 'rsvp';
 import { dropTask, restartableTask, timeout } from 'ember-concurrency';
 import { action } from '@ember/object';

--- a/addon/components/session-offerings-list.js
+++ b/addon/components/session-offerings-list.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import OfferingDateBlock from 'ilios-common/utils/offering-date-block';
 import { tracked } from '@glimmer/tracking';

--- a/addon/components/session-overview.js
+++ b/addon/components/session-overview.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { isEmpty } from '@ember/utils';
 import { task, restartableTask, dropTask } from 'ember-concurrency';
 import moment from 'moment';

--- a/addon/components/session-publicationcheck.js
+++ b/addon/components/session-publicationcheck.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { TrackedAsyncData } from 'ember-async-data';
 import { cached } from '@glimmer/tracking';

--- a/addon/components/session/objective-list-item.js
+++ b/addon/components/session/objective-list-item.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { dropTask, restartableTask, timeout } from 'ember-concurrency';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { validatable, Length, HtmlNotBlank } from 'ilios-common/decorators/validation';
 import { TrackedAsyncData } from 'ember-async-data';
 import { cached } from '@glimmer/tracking';

--- a/addon/components/session/objectives.js
+++ b/addon/components/session/objectives.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { dropTask, restartableTask } from 'ember-concurrency';
 import { action } from '@ember/object';

--- a/addon/components/session/publication-menu.js
+++ b/addon/components/session/publication-menu.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 

--- a/addon/components/sessions-grid.js
+++ b/addon/components/sessions-grid.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { isEmpty } from '@ember/utils';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { next } from '@ember/runloop';
 import { use } from 'ember-could-get-used-to-this';
 import { dropTask } from 'ember-concurrency';

--- a/addon/components/single-event.js
+++ b/addon/components/single-event.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { isEmpty } from '@ember/utils';
 import moment from 'moment';
 import { findById } from 'ilios-common/utils/array-helpers';

--- a/addon/components/taxonomy-manager.js
+++ b/addon/components/taxonomy-manager.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { isPresent } from '@ember/utils';
 import { restartableTask, timeout } from 'ember-concurrency';
 import { filter } from 'rsvp';

--- a/addon/components/user-material-status.js
+++ b/addon/components/user-material-status.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { TrackedAsyncData } from 'ember-async-data';
 import { cached } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { restartableTask, timeout } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
 

--- a/addon/components/user-search.js
+++ b/addon/components/user-search.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';

--- a/addon/components/visualizer-course-instructor-session-type.js
+++ b/addon/components/visualizer-course-instructor-session-type.js
@@ -3,7 +3,7 @@ import { filter, map } from 'rsvp';
 import { isEmpty } from '@ember/utils';
 import { htmlSafe } from '@ember/template';
 import { restartableTask, timeout } from 'ember-concurrency';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { use } from 'ember-could-get-used-to-this';
 import { TrackedAsyncData } from 'ember-async-data';

--- a/addon/components/visualizer-course-instructor-term.js
+++ b/addon/components/visualizer-course-instructor-term.js
@@ -3,7 +3,7 @@ import { filter, map } from 'rsvp';
 import { isEmpty } from '@ember/utils';
 import { htmlSafe } from '@ember/template';
 import { restartableTask, timeout } from 'ember-concurrency';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { use } from 'ember-could-get-used-to-this';
 import { TrackedAsyncData } from 'ember-async-data';

--- a/addon/components/visualizer-course-instructors.js
+++ b/addon/components/visualizer-course-instructors.js
@@ -3,7 +3,7 @@ import { isEmpty } from '@ember/utils';
 import { htmlSafe } from '@ember/template';
 import { restartableTask, timeout } from 'ember-concurrency';
 import { map } from 'rsvp';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { cleanQuery } from 'ilios-common/utils/query-utils';

--- a/addon/components/visualizer-course-objectives.js
+++ b/addon/components/visualizer-course-objectives.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { htmlSafe } from '@ember/template';
 import { filter, map } from 'rsvp';
 import { restartableTask, timeout } from 'ember-concurrency';

--- a/addon/components/visualizer-course-session-type.js
+++ b/addon/components/visualizer-course-session-type.js
@@ -3,7 +3,7 @@ import { map } from 'rsvp';
 import { isEmpty } from '@ember/utils';
 import { htmlSafe } from '@ember/template';
 import { restartableTask, timeout } from 'ember-concurrency';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 import { use } from 'ember-could-get-used-to-this';

--- a/addon/components/visualizer-course-session-types.js
+++ b/addon/components/visualizer-course-session-types.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { htmlSafe } from '@ember/template';
 import { restartableTask, timeout } from 'ember-concurrency';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { cleanQuery } from 'ilios-common/utils/query-utils';

--- a/addon/components/visualizer-course-term.js
+++ b/addon/components/visualizer-course-term.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { htmlSafe } from '@ember/template';
 import { restartableTask, timeout } from 'ember-concurrency';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { use } from 'ember-could-get-used-to-this';
 import { TrackedAsyncData } from 'ember-async-data';

--- a/addon/components/visualizer-course-vocabularies.js
+++ b/addon/components/visualizer-course-vocabularies.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { all, map } from 'rsvp';
 import { htmlSafe } from '@ember/template';
 import { restartableTask, timeout } from 'ember-concurrency';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { use } from 'ember-could-get-used-to-this';

--- a/addon/components/visualizer-course-vocabulary.js
+++ b/addon/components/visualizer-course-vocabulary.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { filter, map } from 'rsvp';
 import { htmlSafe } from '@ember/template';
 import { restartableTask, timeout } from 'ember-concurrency';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { use } from 'ember-could-get-used-to-this';

--- a/addon/components/week-glance.js
+++ b/addon/components/week-glance.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { isNone } from '@ember/utils';
 import { DateTime } from 'luxon';

--- a/addon/components/weekly-calendar-event.js
+++ b/addon/components/weekly-calendar-event.js
@@ -3,7 +3,7 @@ import { DateTime } from 'luxon';
 import colorChange from 'ilios-common/utils/color-change';
 import { htmlSafe } from '@ember/template';
 import calendarEventTooltip from 'ilios-common/utils/calendar-event-tooltip';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { deprecate } from '@ember/debug';
 
 export default class WeeklyCalendarEventComponent extends Component {

--- a/addon/components/weekly-calendar.js
+++ b/addon/components/weekly-calendar.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { restartableTask, timeout } from 'ember-concurrency';
 import { action, set } from '@ember/object';
 import { DateTime } from 'luxon';

--- a/addon/controllers/course/publishall.js
+++ b/addon/controllers/course/publishall.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class CoursePublishallController extends Controller {
   @service router;

--- a/addon/controllers/course/rollover.js
+++ b/addon/controllers/course/rollover.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class CourseRolloverController extends Controller {
   @service router;

--- a/addon/controllers/dashboard/calendar.js
+++ b/addon/controllers/dashboard/calendar.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import moment from 'moment';
 import { findById } from 'ilios-common/utils/array-helpers';

--- a/addon/controllers/print-course.js
+++ b/addon/controllers/print-course.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class PrintCourseController extends Controller {
   @service currentUser;

--- a/addon/controllers/session/copy.js
+++ b/addon/controllers/session/copy.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class SessionCopyController extends Controller {
   @service router;

--- a/addon/modifiers/animate-loading.js
+++ b/addon/modifiers/animate-loading.js
@@ -1,5 +1,5 @@
 import Modifier from 'ember-modifier';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { registerDestructor } from '@ember/destroyable';
 
 export default class AnimateLoadingModifier extends Modifier {

--- a/addon/routes/course-materials.js
+++ b/addon/routes/course-materials.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { all } from 'rsvp';
 import { mapBy } from 'ilios-common/utils/array-helpers';
 

--- a/addon/routes/course-visualizations.js
+++ b/addon/routes/course-visualizations.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { all } from 'rsvp';
 import { mapBy } from 'ilios-common/utils/array-helpers';

--- a/addon/routes/course-visualize-instructor.js
+++ b/addon/routes/course-visualize-instructor.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { all, map } from 'rsvp';
 

--- a/addon/routes/course-visualize-instructors.js
+++ b/addon/routes/course-visualize-instructors.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { all, map } from 'rsvp';
 

--- a/addon/routes/course-visualize-objectives.js
+++ b/addon/routes/course-visualize-objectives.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { all, map } from 'rsvp';
 

--- a/addon/routes/course-visualize-session-type.js
+++ b/addon/routes/course-visualize-session-type.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { all, map } from 'rsvp';
 

--- a/addon/routes/course-visualize-session-types.js
+++ b/addon/routes/course-visualize-session-types.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { map } from 'rsvp';
 

--- a/addon/routes/course-visualize-term.js
+++ b/addon/routes/course-visualize-term.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { all, map } from 'rsvp';
 

--- a/addon/routes/course-visualize-vocabularies.js
+++ b/addon/routes/course-visualize-vocabularies.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { all, map } from 'rsvp';
 

--- a/addon/routes/course-visualize-vocabulary.js
+++ b/addon/routes/course-visualize-vocabulary.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { all, map } from 'rsvp';
 

--- a/addon/routes/course.js
+++ b/addon/routes/course.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { loadFroalaEditor } from 'ilios-common/utils/load-froala-editor';
 

--- a/addon/routes/course/index.js
+++ b/addon/routes/course/index.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { action } from '@ember/object';
 

--- a/addon/routes/course/publication-check.js
+++ b/addon/routes/course/publication-check.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class CoursePublicationCheckRoute extends Route {

--- a/addon/routes/course/publishall.js
+++ b/addon/routes/course/publishall.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class CoursePublishallRoute extends Route {

--- a/addon/routes/course/rollover.js
+++ b/addon/routes/course/rollover.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class CourseRolloverRoute extends Route {

--- a/addon/routes/dashboard.js
+++ b/addon/routes/dashboard.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class DashboardRoute extends Route {
   @service router;

--- a/addon/routes/dashboard/index.js
+++ b/addon/routes/dashboard/index.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class DashboardIndexRoute extends Route {
   @service router;

--- a/addon/routes/events.js
+++ b/addon/routes/events.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class EventsRoute extends Route {

--- a/addon/routes/print-course.js
+++ b/addon/routes/print-course.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class PrintCourseRoute extends Route {

--- a/addon/routes/session.js
+++ b/addon/routes/session.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { findById } from 'ilios-common/utils/array-helpers';
 

--- a/addon/routes/session/copy.js
+++ b/addon/routes/session/copy.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class SessionCopyRoute extends Route {

--- a/addon/routes/session/index.js
+++ b/addon/routes/session/index.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class SessionIndexRoute extends Route {

--- a/addon/routes/session/publication-check.js
+++ b/addon/routes/session/publication-check.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class SessionPublicationCheckRoute extends Route {

--- a/addon/routes/weeklyevents.js
+++ b/addon/routes/weeklyevents.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class WeeklyeventsRoute extends Route {

--- a/addon/services/data-loader.js
+++ b/addon/services/data-loader.js
@@ -1,5 +1,5 @@
 import Service from '@ember/service';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class DataLoaderService extends Service {
   @service store;

--- a/addon/services/fetch.js
+++ b/addon/services/fetch.js
@@ -1,5 +1,5 @@
 import Service from '@ember/service';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import fetch from 'fetch';
 import queryString from 'query-string';
 

--- a/addon/services/locale-days.js
+++ b/addon/services/locale-days.js
@@ -1,5 +1,5 @@
 import Service from '@ember/service';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { DateTime } from 'luxon';
 
 export default class LocaleDaysService extends Service {

--- a/addon/services/school-events.js
+++ b/addon/services/school-events.js
@@ -1,5 +1,5 @@
 import EventsBase from 'ilios-common/classes/events-base';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import moment from 'moment';
 import { sortBy } from 'ilios-common/utils/array-helpers';
 

--- a/addon/services/user-events.js
+++ b/addon/services/user-events.js
@@ -1,5 +1,5 @@
 import EventsBase from 'ilios-common/classes/events-base';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import moment from 'moment';
 import { sortBy } from 'ilios-common/utils/array-helpers';
 

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ApplicationController extends Controller {
   @service session;

--- a/tests/dummy/app/controllers/login.js
+++ b/tests/dummy/app/controllers/login.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { dropTask } from 'ember-concurrency';
 

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { loadPolyfills } from 'ilios-common/utils/load-polyfills';
 

--- a/tests/dummy/app/routes/dashboard.js
+++ b/tests/dummy/app/routes/dashboard.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { hash } from 'rsvp';
 

--- a/tests/dummy/app/routes/dashboard/calendar.js
+++ b/tests/dummy/app/routes/dashboard/calendar.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { hash } from 'rsvp';
 

--- a/tests/dummy/app/routes/index.js
+++ b/tests/dummy/app/routes/index.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class IndexRoute extends Route {

--- a/tests/dummy/app/routes/login.js
+++ b/tests/dummy/app/routes/login.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class LoginRoute extends Route {

--- a/tests/dummy/app/routes/logout.js
+++ b/tests/dummy/app/routes/logout.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class LogoutRoute extends Route {


### PR DESCRIPTION
In Ember 4.1 this little bit of annoyance was cleaned up and we can now import the service in a better way.