### PR TITLE
Replace removeObject with splice

### DIFF
--- a/addon/models/course-objective.js
+++ b/addon/models/course-objective.js
@@ -106,7 +106,7 @@ export default class CourseObjective extends Model {
       if (programYearsToRemove.includes(programYear)) {
         programYearObjectives.splice(programYearObjectives.indexOf(programYear), 1);
         const courseObjectives = await programYearObjective.courseObjectives;
-        courseObjectives.removeObject(this);
+        courseObjectives.splice(courseObjectives.indexOf(this), 1);
       }
     }
     await this.save();

--- a/tests/unit/models/session-type-test.js
+++ b/tests/unit/models/session-type-test.js
@@ -43,7 +43,7 @@ module('Unit | Model | SessionType', function (hooks) {
     const aamcMethod2 = this.store.createRecord('aamc-method', { sessionTypes: [model] });
     firstAamcMethod = await waitForResource(model, 'firstAamcMethod');
     assert.strictEqual(firstAamcMethod, aamcMethod1);
-    model.aamcMethods.splice(model.aamcMethods.indexOf(aamcMethod1), 1);
+    (await model.aamcMethods).splice(model.aamcMethods.indexOf(aamcMethod1), 1);
 
     firstAamcMethod = await waitForResource(model, 'firstAamcMethod');
     assert.strictEqual(firstAamcMethod, aamcMethod2);

--- a/tests/unit/models/session-type-test.js
+++ b/tests/unit/models/session-type-test.js
@@ -43,7 +43,8 @@ module('Unit | Model | SessionType', function (hooks) {
     const aamcMethod2 = this.store.createRecord('aamc-method', { sessionTypes: [model] });
     firstAamcMethod = await waitForResource(model, 'firstAamcMethod');
     assert.strictEqual(firstAamcMethod, aamcMethod1);
-    model.aamcMethods.removeObject(aamcMethod1);
+    model.aamcMethods.splice(model.aamcMethods.indexOf(aamcMethod1), 1);
+
     firstAamcMethod = await waitForResource(model, 'firstAamcMethod');
     assert.strictEqual(firstAamcMethod, aamcMethod2);
   });


### PR DESCRIPTION
The removeObject method on ember data arrays is deprecated and will be removed.