### PR TITLE
Limit or remove calls to toArray

### DIFF
--- a/addon/components/detail-instructors.js
+++ b/addon/components/detail-instructors.js
@@ -83,14 +83,14 @@ export default class DetailInstructorsComponent extends Component {
     if (!this.ilmInstructors) {
       return [];
     }
-    return this.ilmInstructors.toArray();
+    return this.ilmInstructors.slice();
   }
 
   get selectedIlmInstructorGroups() {
     if (!this.ilmInstructorGroups) {
       return [];
     }
-    return this.ilmInstructorGroups.toArray();
+    return this.ilmInstructorGroups.slice();
   }
 
   get instructorGroupCount() {

--- a/addon/components/detail-learners-and-learner-groups.js
+++ b/addon/components/detail-learners-and-learner-groups.js
@@ -97,14 +97,14 @@ export default class DetailLearnersAndLearnerGroupsComponent extends Component {
     if (!this.ilmLearners) {
       return [];
     }
-    return this.ilmLearners.toArray();
+    return this.ilmLearners.slice();
   }
 
   get selectedIlmLearnerGroups() {
     if (!this.ilmLearnerGroups) {
       return [];
     }
-    return this.ilmLearnerGroups.toArray();
+    return this.ilmLearnerGroups.slice();
   }
 
   @action

--- a/addon/helpers/sort-by.js
+++ b/addon/helpers/sort-by.js
@@ -111,7 +111,12 @@ class SortBy {
   constructor(...args) {
     let [array] = args;
     if (typeof array.toArray === 'function') {
-      array = array.toArray();
+      if (typeof array.slice === 'function') {
+        //for ember data toArray still exists but is deprecated, we want slice if it's there
+        array = array.slice();
+      } else {
+        array = array.toArray();
+      }
     }
 
     this.array = [...array];


### PR DESCRIPTION
This method is still present on ember-data relationships, but is deprecated and we shouldn't call it.