### PR TITLE
Fix authentication factory

### DIFF
--- a/addon-mirage-support/factories/authentication.js
+++ b/addon-mirage-support/factories/authentication.js
@@ -1,5 +1,5 @@
 import { Factory } from 'miragejs';
 
 export default Factory.extend({
-  username: (i) => i,
+  username: (i) => `username${i}`,
 });


### PR DESCRIPTION
Username is a string, sending an integer here resolves to null in ember data 4.12+ and breaks some tests in frontend. Making it a full string instead.