### PR TITLE
Freeze some test dates

### DIFF
--- a/addon-mirage-support/factories/course.js
+++ b/addon-mirage-support/factories/course.js
@@ -1,11 +1,14 @@
 import { DateTime } from 'luxon';
 import { Factory } from 'miragejs';
 
+const june24th2025 = { year: 2005, month: 6, day: 24, hour: 8 };
+const startDate = DateTime.fromObject(june24th2025).toJSDate();
+const endDate = DateTime.fromObject(june24th2025).plus({ weeks: 7 }).toJSDate();
 export default Factory.extend({
   title: (i) => `course ${i}`,
   year: 2013,
   level: 1,
-  startDate: () => DateTime.fromObject({ hour: 8 }).toJSDate(),
-  endDate: () => DateTime.fromObject({ hour: 8 }).plus({ weeks: 7 }).toJSDate(),
+  startDate,
+  endDate,
   archived: false,
 });

--- a/addon-mirage-support/factories/session.js
+++ b/addon-mirage-support/factories/session.js
@@ -1,4 +1,5 @@
 import { Factory } from 'miragejs';
+import { DateTime } from 'luxon';
 
 export default Factory.extend({
   title: (i) => `session ${i}`,
@@ -6,4 +7,5 @@ export default Factory.extend({
   attireRequired: false,
   equipmentRequired: false,
   supplemental: false,
+  updatedAt: DateTime.fromObject({ month: 2, day: 4, hour: 6, minute: 8 }).toJSDate(),
 });

--- a/tests/acceptance/course/session/offerings-test.js
+++ b/tests/acceptance/course/session/offerings-test.js
@@ -4,10 +4,17 @@ import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/session';
 import percySnapshot from '@percy/ember';
+import { freezeDateAt, unfreezeDate } from 'ilios-common';
 
 module('Acceptance | Session - Offerings', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
+    freezeDateAt(
+      DateTime.fromObject({
+        month: 12,
+        day: 11,
+      }).toJSDate()
+    );
     this.school = this.server.create('school');
     this.user = await setupAuthentication({ school: this.school });
     const program = this.server.create('program', { school: this.school });
@@ -74,6 +81,10 @@ module('Acceptance | Session - Offerings', function (hooks) {
       endDate: this.today.plus({ days: 3, hours: 1 }).toJSDate(),
       url: 'https://example.edu/',
     });
+  });
+
+  hooks.afterEach(() => {
+    unfreezeDate();
   });
 
   test('basics', async function (assert) {

--- a/tests/acceptance/course/session/publish-test.js
+++ b/tests/acceptance/course/session/publish-test.js
@@ -5,11 +5,18 @@ import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/session';
 import percySnapshot from '@percy/ember';
+import { freezeDateAt, unfreezeDate } from 'ilios-common';
 
 module('Acceptance | Session - Publish', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(async function () {
+    freezeDateAt(
+      DateTime.fromObject({
+        month: 3,
+        day: 15,
+      }).toJSDate()
+    );
     const school = this.server.create('school');
     await setupAuthentication({ school, administeredSchools: [school] });
     this.course = this.server.create('course', { school });
@@ -48,6 +55,10 @@ module('Acceptance | Session - Publish', function (hooks) {
       startDate: DateTime.now().toJSDate(),
       endDate: DateTime.now().plus({ hours: 6 }).toJSDate(),
     });
+  });
+
+  hooks.afterEach(() => {
+    unfreezeDate();
   });
 
   test('check published session', async function (assert) {

--- a/tests/acceptance/course/sessionlist-test.js
+++ b/tests/acceptance/course/sessionlist-test.js
@@ -5,13 +5,19 @@ import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/sessions';
 import sessionPage from 'ilios-common/page-objects/session';
-
-const today = DateTime.fromObject({ hour: 8 });
+import { freezeDateAt, unfreezeDate } from 'ilios-common';
 import percySnapshot from '@percy/ember';
 
 module('Acceptance | Course - Session List', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
+    freezeDateAt(
+      DateTime.fromObject({
+        month: 4,
+        day: 1,
+      }).toJSDate()
+    );
+    this.today = DateTime.fromObject({ hour: 8 });
     this.school = this.server.create('school');
     this.user = await setupAuthentication({ school: this.school });
     this.sessionType = this.server.create('sessionType', {
@@ -56,8 +62,8 @@ module('Acceptance | Course - Session List', function (hooks) {
     });
     this.server.create('offering', {
       session: this.session1,
-      startDate: today.toJSDate(),
-      endDate: today.plus({ hour: 1 }).toJSDate(),
+      startDate: this.today.toJSDate(),
+      endDate: this.today.plus({ hour: 1 }).toJSDate(),
       learners: [learner1],
       learnerGroups: [learnerGroup1, learnerGroup2],
       instructors: [instructor1],
@@ -65,14 +71,18 @@ module('Acceptance | Course - Session List', function (hooks) {
     });
     this.server.create('offering', {
       session: this.session1,
-      startDate: today.plus({ day: 1, hour: 1 }).toJSDate(),
-      endDate: today.plus({ day: 1, hour: 4 }).toJSDate(),
+      startDate: this.today.plus({ day: 1, hour: 1 }).toJSDate(),
+      endDate: this.today.plus({ day: 1, hour: 4 }).toJSDate(),
     });
     this.server.create('offering', {
       session: this.session1,
-      startDate: today.plus({ day: 2 }).toJSDate(),
-      endDate: today.plus({ day: 3 }).toJSDate(),
+      startDate: this.today.plus({ day: 2 }).toJSDate(),
+      endDate: this.today.plus({ day: 3 }).toJSDate(),
     });
+  });
+
+  hooks.afterEach(() => {
+    unfreezeDate();
   });
 
   test('session list', async function (assert) {
@@ -89,7 +99,7 @@ module('Acceptance | Course - Session List', function (hooks) {
     assert.strictEqual(sessions[0].row.termCount, '0');
     assert.strictEqual(
       sessions[0].row.firstOffering,
-      this.intl.formatDate(today.toJSDate(), {
+      this.intl.formatDate(this.today.toJSDate(), {
         month: 'numeric',
         day: 'numeric',
         year: 'numeric',
@@ -340,7 +350,7 @@ module('Acceptance | Course - Session List', function (hooks) {
     assert.strictEqual(sessions.length, 4);
     assert.strictEqual(
       sessions[0].row.firstOffering,
-      this.intl.formatDate(today.toJSDate(), {
+      this.intl.formatDate(this.today.toJSDate(), {
         month: 'numeric',
         day: 'numeric',
         year: 'numeric',
@@ -420,7 +430,7 @@ module('Acceptance | Course - Session List', function (hooks) {
     assert.strictEqual(sessions.length, 4);
     assert.strictEqual(
       sessions[0].row.firstOffering,
-      this.intl.formatDate(today.toJSDate(), {
+      this.intl.formatDate(this.today.toJSDate(), {
         month: 'numeric',
         day: 'numeric',
         year: 'numeric',

--- a/tests/acceptance/dashboard/calendar-test.js
+++ b/tests/acceptance/dashboard/calendar-test.js
@@ -246,6 +246,13 @@ module('Acceptance | Dashboard Calendar', function (hooks) {
 
   test('load day calendar', async function (assert) {
     assert.expect(3);
+    freezeDateAt(
+      DateTime.fromObject({
+        year: 2025,
+        month: 6,
+        day: 24,
+      }).toJSDate()
+    );
     const today = DateTime.fromObject({ hour: 8, minute: 8, second: 8 });
     const tomorow = today.plus({ day: 1 });
     const yesterday = today.minus({ day: 1 });
@@ -870,14 +877,14 @@ module('Acceptance | Dashboard Calendar', function (hooks) {
 
   test('test tooltip', async function (assert) {
     assert.expect(1);
-    const today = DateTime.fromObject({ hour: 8, minute: 8, second: 8 });
+    const november11th = DateTime.fromObject({ month: 11, day: 11, hour: 8, minute: 8, second: 8 });
     this.server.create('userevent', {
       user: this.user.id,
-      startDate: today.toJSDate(),
-      endDate: today.plus({ hour: 1 }).toJSDate(),
+      startDate: november11th.toJSDate(),
+      endDate: november11th.plus({ hour: 1 }).toJSDate(),
       offering: 1,
     });
-    await page.visit({ show: 'calendar', view: 'week' });
+    await page.visit({ show: 'calendar', view: 'week', date: november11th.toFormat('yyyy-LL-dd') });
     await triggerEvent('[data-test-weekly-calendar-event]', 'mouseover');
     await percySnapshot(assert);
     assert.dom('[data-test-ilios-calendar-event-tooltip]').exists();

--- a/tests/acceptance/dashboard/materials-test.js
+++ b/tests/acceptance/dashboard/materials-test.js
@@ -5,11 +5,18 @@ import { setupApplicationTest } from 'dummy/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import page from 'ilios-common/page-objects/dashboard-materials';
 import percySnapshot from '@percy/ember';
+import { freezeDateAt, unfreezeDate } from 'ilios-common';
 
 module('Acceptance | Dashboard Materials', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(async function () {
+    freezeDateAt(
+      DateTime.fromObject({
+        month: 11,
+        day: 5,
+      }).toJSDate()
+    );
     this.school = this.server.create('school');
     this.user = await setupAuthentication({ school: this.school });
 
@@ -133,6 +140,10 @@ module('Acceptance | Dashboard Materials', function (hooks) {
     this.currentMaterials = currentMaterials;
     this.allMaterials = [...currentMaterials, ...notCurrentMaterials];
     this.courses = courses;
+  });
+
+  hooks.afterEach(() => {
+    unfreezeDate();
   });
 
   test('it renders with materials in show-current mode', async function (assert) {


### PR DESCRIPTION
In order to make our percy tests more stable I'm freezing several dates and providing default dates to the course and session factories.