### PR TITLE
Cleanup our dependabot ignore list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,36 +11,42 @@ updates:
   ignore:
   - dependency-name: "@babel/eslint-parser"
   - dependency-name: "@babel/plugin-proposal-decorators"
-  - dependency-name: broccoli-asset-rev
-  - dependency-name: concurrently
   - dependency-name: "@ember/optional-features"
+  - dependency-name: "@ember/string"
   - dependency-name: "@ember/test-helpers"
   - dependency-name: "@embroider/test-setup"
+  - dependency-name: "@glimmer/component"
+  - dependency-name: "@glimmer/tracking"
+  - dependency-name: broccoli-asset-rev
+  - dependency-name: concurrently
   - dependency-name: ember-auto-import
   - dependency-name: ember-cli
   - dependency-name: ember-cli-babel
   - dependency-name: ember-cli-dependency-checker
-  - dependency-name: ember-cli-eslint
   - dependency-name: ember-cli-htmlbars
-  - dependency-name: ember-cli-htmlbars-inline-precompile
   - dependency-name: ember-cli-inject-live-reload
   - dependency-name: ember-cli-sri
-  - dependency-name: ember-cli-template-lint
-  - dependency-name: ember-cli-uglify
-  - dependency-name: ember-disable-prototype-extensions
-  - dependency-name: ember-export-application-global
+  - dependency-name: ember-cli-terser
   - dependency-name: ember-load-initializers
+  - dependency-name: ember-page-title
   - dependency-name: ember-qunit
   - dependency-name: ember-resolver
   - dependency-name: ember-source
   - dependency-name: ember-source-channel-url
+  - dependency-name: ember-template-lint
   - dependency-name: ember-try
   - dependency-name: eslint
+  - dependency-name: eslint-config-prettier
   - dependency-name: eslint-plugin-ember
   - dependency-name: eslint-plugin-n
+  - dependency-name: eslint-plugin-prettier
+  - dependency-name: eslint-plugin-qunit
   - dependency-name: loader.js
+  - dependency-name: prettier
+  - dependency-name: qunit
   - dependency-name: qunit-dom
   - dependency-name: stylelint
+  - dependency-name: stylelint-config-standard
   - dependency-name: stylelint-prettier
   - dependency-name: webpack
 - package-ecosystem: github-actions


### PR DESCRIPTION
I synced this with the Ember 4.12 addon blueprint package.json file so we're ignoring everything that ember-cli provides us.