### PR TITLE
prevent overlap by giving sticky header a higher z-index.

### DIFF
--- a/app/styles/ilios-common/components/sessions-grid-header.scss
+++ b/app/styles/ilios-common/components/sessions-grid-header.scss
@@ -10,6 +10,7 @@
   font-weight: normal;
   position: sticky;
   top: 0;
+  z-index: 1;
 
   .sortable-heading {
     padding: 0.5rem 0;


### PR DESCRIPTION
fixes https://github.com/ilios/ilios/issues/4119