### PR TITLE
add some space between title and session type in session grid.

### DIFF
--- a/app/styles/ilios-common/components/sessions-grid-row.scss
+++ b/app/styles/ilios-common/components/sessions-grid-row.scss
@@ -15,4 +15,8 @@
       margin-right: 0.25rem;
     }
   }
+
+  .session-grid-title {
+    padding-right: 0.5rem;
+  }
 }


### PR DESCRIPTION
![image](https://github.com/ilios/common/assets/1410427/a250e5e0-e62a-4432-a1e5-7b2371885b08)

fixes https://github.com/ilios/ilios/issues/4733