### PR TITLE
rm back-link from event details page.

### DIFF
--- a/addon-test-support/ilios-common/page-objects/components/back-link.js
+++ b/addon-test-support/ilios-common/page-objects/components/back-link.js
@@ -1,0 +1,8 @@
+import { create } from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-back-link]',
+};
+
+export default definition;
+export const component = create(definition);

--- a/addon-test-support/ilios-common/page-objects/events.js
+++ b/addon-test-support/ilios-common/page-objects/events.js
@@ -1,0 +1,9 @@
+import { create, visitable } from 'ember-cli-page-object';
+import backLink from './components/back-link';
+import event from './components/single-event';
+
+export default create({
+  visit: visitable('/events/:slug'),
+  backLink,
+  event,
+});

--- a/addon-test-support/ilios-common/page-objects/weeklyevents.js
+++ b/addon-test-support/ilios-common/page-objects/weeklyevents.js
@@ -1,0 +1,9 @@
+import { create, visitable } from 'ember-cli-page-object';
+import backLink from './components/back-link';
+import weeklyEvents from './components/weekly-events';
+
+export default create({
+  visit: visitable('/weeklyevents'),
+  backLink,
+  weeklyEvents,
+});

--- a/addon/components/back-link.hbs
+++ b/addon/components/back-link.hbs
@@ -2,6 +2,7 @@
   title={{t "general.returnToPreviousPage"}}
   class="back-link"
   href="#"
+  data-test-back-link
   {{on "click" (prevent-default this.back)}}
 >
   <FaIcon @icon="angles-left" /> {{t "general.back"}}

--- a/addon/controllers/events.js
+++ b/addon/controllers/events.js
@@ -1,9 +1,8 @@
 import Controller from '@ember/controller';
-import { getOwner } from '@ember/application';
+import { getConfig } from '@embroider/macros';
 
 export default class EventsController extends Controller {
   get showBackLink() {
-    const appConfig = getOwner(this).resolveRegistration('config:environment');
-    return !!appConfig.showHistoryBackLink;
+    return !!getConfig('showHistoryBackLink');
   }
 }

--- a/addon/controllers/events.js
+++ b/addon/controllers/events.js
@@ -1,0 +1,9 @@
+import Controller from '@ember/controller';
+import { getOwner } from '@ember/application';
+
+export default class EventsController extends Controller {
+  get showBackLink() {
+    const appConfig = getOwner(this).resolveRegistration('config:environment');
+    return !!appConfig.showHistoryBackLink;
+  }
+}

--- a/addon/controllers/weeklyevents.js
+++ b/addon/controllers/weeklyevents.js
@@ -1,7 +1,7 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { getOwner } from '@ember/application';
+import { getConfig } from '@embroider/macros';
 import moment from 'moment';
 
 export default class WeeklyeventsController extends Controller {
@@ -19,8 +19,7 @@ export default class WeeklyeventsController extends Controller {
   }
 
   get showBackLink() {
-    const appConfig = getOwner(this).resolveRegistration('config:environment');
-    return !!appConfig.showHistoryBackLink;
+    return !!getConfig('showHistoryBackLink');
   }
 
   @action

--- a/addon/controllers/weeklyevents.js
+++ b/addon/controllers/weeklyevents.js
@@ -1,6 +1,7 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { getOwner } from '@ember/application';
 import moment from 'moment';
 
 export default class WeeklyeventsController extends Controller {
@@ -15,6 +16,11 @@ export default class WeeklyeventsController extends Controller {
 
   get expandedWeeks() {
     return this.expandedString.split('-');
+  }
+
+  get showBackLink() {
+    const appConfig = getOwner(this).resolveRegistration('config:environment');
+    return !!appConfig.showHistoryBackLink;
   }
 
   @action

--- a/addon/templates/events.hbs
+++ b/addon/templates/events.hbs
@@ -1,1 +1,4 @@
+{{#if this.showBackLink}}
+  <BackLink />
+{{/if}}
 <SingleEvent @event={{this.model}} />

--- a/addon/templates/events.hbs
+++ b/addon/templates/events.hbs
@@ -1,1 +1,1 @@
-<BackLink /><SingleEvent @event={{this.model}} />
+<SingleEvent @event={{this.model}} />

--- a/addon/templates/weeklyevents.hbs
+++ b/addon/templates/weeklyevents.hbs
@@ -1,4 +1,6 @@
-<BackLink />
+{{#if this.showBackLink}}
+  <BackLink />
+{{/if}}
 <WeeklyEvents
   @year={{this.year}}
   @expandedWeeks={{this.expandedWeeks}}

--- a/app/controllers/events.js
+++ b/app/controllers/events.js
@@ -1,0 +1,1 @@
+export { default } from 'ilios-common/controllers/events';

--- a/config/environment.js
+++ b/config/environment.js
@@ -8,6 +8,7 @@ module.exports = function (environment /*, appConfig */) {
       sessionLinkingAdminUi: true,
     },
     apiVersion: API_VERSION,
+    showHistoryBackLink: false,
   };
 
   if ('development' === environment) {

--- a/tests/acceptance/events-test.js
+++ b/tests/acceptance/events-test.js
@@ -28,7 +28,6 @@ module('Acceptance | single event', function (hooks) {
     this.owner.register('service:user-events', UserEventsServiceMock);
     await page.visit({ slug: 'Uwhatever' });
     assert.notOk(page.backLink.isVisible);
-    // @todo implement this further [ST 2023/07/24]
     assert.strictEqual(page.event.summary.title.text, 'Lorem - Ipsum');
   });
 });

--- a/tests/acceptance/events-test.js
+++ b/tests/acceptance/events-test.js
@@ -1,0 +1,34 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'dummy/tests/helpers';
+import page from 'ilios-common/page-objects/events';
+import { setupAuthentication } from 'ilios-common';
+import Service from '@ember/service';
+import { DateTime } from 'luxon';
+
+module('Acceptance | single event', function (hooks) {
+  setupApplicationTest(hooks);
+
+  hooks.beforeEach(async function () {
+    this.school = this.server.create('school');
+    this.user = await setupAuthentication({ school: this.school });
+  });
+
+  test('user event', async function (assert) {
+    this.server.create('userevent', {
+      courseTitle: 'Lorem',
+      name: 'Ipsum',
+      lastModified: DateTime.now().minus({ days: 21 }).toJSDate(),
+    });
+    const events = this.server.db.userevents;
+    class UserEventsServiceMock extends Service {
+      async getEventForSlug() {
+        return events.slice()[0];
+      }
+    }
+    this.owner.register('service:user-events', UserEventsServiceMock);
+    await page.visit({ slug: 'Uwhatever' });
+    assert.notOk(page.backLink.isVisible);
+    // @todo implement this further [ST 2023/07/24]
+    assert.strictEqual(page.event.summary.title.text, 'Lorem - Ipsum');
+  });
+});

--- a/tests/acceptance/weeklyevents-test.js
+++ b/tests/acceptance/weeklyevents-test.js
@@ -1,0 +1,20 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'dummy/tests/helpers';
+import page from 'ilios-common/page-objects/weeklyevents';
+import { setupAuthentication } from 'ilios-common';
+
+module('Acceptance | weekly events', function (hooks) {
+  setupApplicationTest(hooks);
+
+  hooks.beforeEach(async function () {
+    this.school = this.server.create('school');
+    this.user = await setupAuthentication({ school: this.school });
+  });
+
+  test('it renders', async function (assert) {
+    await page.visit();
+    assert.notOk(page.backLink.isVisible);
+    // @todo implement this further [ST 2023/07/24]
+    assert.ok(page.weeklyEvents.isVisible);
+  });
+});

--- a/tests/acceptance/weeklyevents-test.js
+++ b/tests/acceptance/weeklyevents-test.js
@@ -11,10 +11,12 @@ module('Acceptance | weekly events', function (hooks) {
     this.user = await setupAuthentication({ school: this.school });
   });
 
-  test('it renders', async function (assert) {
+  test('back-to link is not showing', async function (assert) {
     await page.visit();
     assert.notOk(page.backLink.isVisible);
-    // @todo implement this further [ST 2023/07/24]
-    assert.ok(page.weeklyEvents.isVisible);
+    assert.strictEqual(
+      page.weeklyEvents.topNavigation.title,
+      new Date().getFullYear().toString(10)
+    );
   });
 });

--- a/tests/integration/components/back-link-test.js
+++ b/tests/integration/components/back-link-test.js
@@ -3,6 +3,7 @@ import { setupRenderingTest } from 'dummy/tests/helpers';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import { component } from 'ilios-common/page-objects/components/back-link';
 
 module('Integration | Component | back link', function (hooks) {
   setupRenderingTest(hooks);
@@ -11,7 +12,6 @@ module('Integration | Component | back link', function (hooks) {
   test('it renders', async function (assert) {
     await render(hbs`<BackLink />
 `);
-
-    assert.dom(this.element).hasText('Back');
+    assert.strictEqual(component.text, 'Back');
   });
 });

--- a/tests/unit/controllers/events-test.js
+++ b/tests/unit/controllers/events-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'dummy/tests/helpers';
+
+module('Unit | Controller | events', function (hooks) {
+  setupTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it exists', function (assert) {
+    let controller = this.owner.lookup('controller:events');
+    assert.ok(controller);
+  });
+});


### PR DESCRIPTION
this came up as unnecessary and potentially confusing during a a11y audit. begone!

fixes https://github.com/ilios/ilios/issues/4774