### PR TITLE
rm scrolling feature from calendar views.

### DIFF
--- a/addon/components/daily-calendar.hbs
+++ b/addon/components/daily-calendar.hbs
@@ -20,8 +20,6 @@
   <div
     class="day"
     tabindex="0"
-    {{did-insert (perform this.scrollView) this.earliestHour}}
-    {{did-update (perform this.scrollView) this.earliestHour}}
   >
     <div class="hours">
       {{#each this.hours as |hour|}}

--- a/addon/components/daily-calendar.js
+++ b/addon/components/daily-calendar.js
@@ -1,26 +1,12 @@
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
-import { restartableTask, timeout } from 'ember-concurrency';
 import { action, set } from '@ember/object';
 import { sortBy } from 'ilios-common/utils/array-helpers';
 import { DateTime } from 'luxon';
 import { deprecate } from '@ember/debug';
-import scrollIntoView from 'scroll-into-view';
 
 export default class DailyCalendarComponent extends Component {
   @service intl;
-
-  scrollView = restartableTask(async (calendarElement, [earliestHour]) => {
-    //waiting ensures that setHour has time to setup hour elements
-    await timeout(1);
-    // all of the hour elements are registered in the template as hour0, hour1, etc
-    let hourElement = this.hour6;
-
-    if (earliestHour < 24 && earliestHour > 2) {
-      hourElement = this[`hour${earliestHour}`];
-    }
-    scrollIntoView(hourElement, { align: { top: 0 } });
-  });
 
   get date() {
     if (typeof this.args.date === 'string') {
@@ -34,17 +20,6 @@ export default class DailyCalendarComponent extends Component {
     }
 
     return this.args.date;
-  }
-
-  get earliestHour() {
-    if (!this.args.events) {
-      return null;
-    }
-
-    return this.sortedEvents.reduce((earliestHour, event) => {
-      const { hour } = DateTime.fromISO(event.startDate);
-      return hour < earliestHour ? hour : earliestHour;
-    }, 24);
   }
 
   get sortedEvents() {

--- a/addon/components/weekly-calendar.hbs
+++ b/addon/components/weekly-calendar.hbs
@@ -21,8 +21,6 @@
   <div
     class="days"
     tabindex="0"
-    {{did-insert (perform this.scrollView) this.earliestHour}}
-    {{did-update (perform this.scrollView) this.earliestHour}}
   >
     <div class="hours">
       {{#each this.hours as |hour|}}

--- a/addon/components/weekly-calendar.js
+++ b/addon/components/weekly-calendar.js
@@ -1,27 +1,13 @@
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
-import { restartableTask, timeout } from 'ember-concurrency';
 import { action, set } from '@ember/object';
 import { DateTime } from 'luxon';
 import { sortBy } from 'ilios-common/utils/array-helpers';
 import { deprecate } from '@ember/debug';
-import scrollIntoView from 'scroll-into-view';
 
 export default class WeeklyCalendarComponent extends Component {
   @service intl;
   @service localeDays;
-
-  scrollView = restartableTask(async (calendarElement, [earliestHour]) => {
-    //waiting ensures that setHour has time to setup hour elements
-    await timeout(1);
-    // all of the hour elements are registered in the template as hour0, hour1, etc
-    let hourElement = this.hour6;
-
-    if (earliestHour < 24 && earliestHour > 2) {
-      hourElement = this[`hour${earliestHour}`];
-    }
-    scrollIntoView(hourElement, { align: { top: 0 } });
-  });
 
   get date() {
     if (typeof this.args.date === 'string') {
@@ -54,17 +40,6 @@ export default class WeeklyCalendarComponent extends Component {
         fullName: date.toFormat('dddd LL'),
       };
     });
-  }
-
-  get earliestHour() {
-    if (!this.args.events) {
-      return null;
-    }
-
-    return this.sortedEvents.reduce((earliestHour, event) => {
-      const hour = Number(DateTime.fromISO(event.startDate).toFormat('HH'));
-      return hour < earliestHour ? hour : earliestHour;
-    }, 24);
   }
 
   get sortedEvents() {


### PR DESCRIPTION
in the current implementation, the top navigation is pushed out of view when the daily or weekly calendar is loaded on the dashboard. this violates the first principle of Dave-Driven Design (TM) - "Don't confuse the user".
Since we don't have the level of control over the scrolling behaviour that would allow us to correct this issue, or at least i can't figure out how to do this, our only other option is to remove scroll-into-view functionality from the calendars altogether.

fixes https://github.com/ilios/ilios/issues/4867