### PR TITLE
Unpin embroider test versions

### DIFF
--- a/tests/dummy/config/ember-try.js
+++ b/tests/dummy/config/ember-try.js
@@ -47,15 +47,7 @@ module.exports = async function () {
         },
       },
       embroiderSafe(),
-      embroiderOptimized({
-        npm: {
-          devDependencies: {
-            '@embroider/core': '~3.0.0',
-            '@embroider/webpack': '~3.0.0',
-            '@embroider/compat': '~3.0.0',
-          },
-        },
-      }),
+      embroiderOptimized(),
     ],
     buildManagerOptions() {
       return ['--force'];


### PR DESCRIPTION
When this is fixed upstream we won't need this anymore. Not sure if that's true yet, but would like to have this dependency canary to keep track of. 🐦 

Reverts #3433 