### PR TITLE
Secure our fontawesome token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
           cache: npm
       - name: Install Dependencies
         run: npm install --no-shrinkwrap
+        env:
+          ILIOS_FONTAWESOME_NPM_AUTH_TOKEN: ${{ secrets.ILIOS_FONTAWESOME_NPM_AUTH_TOKEN }}
       - name: Run Tests
         run: npm run test:ember
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
 @fortawesome:registry=https://npm.fontawesome.com/
-//npm.fontawesome.com/:_authToken=3DCC00F4-5A45-4726-BD5E-8508D7876990
+//npm.fontawesome.com/:_authToken=${ILIOS_FONTAWESOME_NPM_AUTH_TOKEN}


### PR DESCRIPTION
This is annoying, but it appears that maybe someone was using our token to pull packages. We'll need to secure it and provide it to anyone who wants to install Ilios locally. I can find no other way to make this work at this point.