### PR TITLE
replaces all elements that have the button role with actual buttons.

### DIFF
--- a/addon-test-support/ilios-common/page-objects/components/publish-all-sessions.js
+++ b/addon-test-support/ilios-common/page-objects/components/publish-all-sessions.js
@@ -12,6 +12,7 @@ const definition = {
   scope: '[data-test-publish-all-sessions]',
   unpublishableSessions: {
     scope: '[data-test-unpublishable]',
+    title: text('> div > [data-test-title]'),
     isExpanded: isVisible('[data-test-content]'),
     canExpandCollapse: isVisible('[data-test-expand-collapse]'),
     toggle: clickable('[data-test-expand-collapse]'),
@@ -32,7 +33,7 @@ const definition = {
   },
   publishableSessions: {
     scope: '[data-test-publishable]',
-    title: text('> [data-test-title]'),
+    title: text('> div > [data-test-title]'),
     isExpanded: isVisible('[data-test-content]'),
     canExpandCollapse: isVisible('[data-test-expand-collapse]'),
     toggle: clickable('[data-test-expand-collapse]'),

--- a/addon-test-support/ilios-common/page-objects/components/user-search-result.js
+++ b/addon-test-support/ilios-common/page-objects/components/user-search-result.js
@@ -1,8 +1,9 @@
-import { create, hasClass } from 'ember-cli-page-object';
+import { clickable, create, hasClass } from 'ember-cli-page-object';
 
 const definition = {
   scope: '[data-test-result]',
   isActive: hasClass('active'),
+  click: clickable('button'),
 };
 
 export default definition;

--- a/addon/components/choose-material-type.hbs
+++ b/addon/components/choose-material-type.hbs
@@ -16,6 +16,7 @@
     {{on "keyup" this.toggleMenu}}
   >
     {{t "general.add"}}
+    <FaIcon @icon={{if this.isOpen "caret-down" "caret-right"}} />
   </button>
   {{#if this.isOpen}}
     <div

--- a/addon/components/collapsed-competencies.hbs
+++ b/addon/components/collapsed-competencies.hbs
@@ -2,8 +2,17 @@
   class="collapsed-competencies"
   data-test-collapsed-competencies
 >
-  <div class="title" role="button" {{on "click" @expand}} data-test-title>
-    {{t "general.competencies"}} ({{@subject.competencies.length}})
+  <div>
+    <button
+      class="title link-button"
+      type="button"
+      aria-expanded="false"
+      data-test-title
+      {{on "click" @expand}}
+    >
+      {{t "general.competencies"}} ({{@subject.competencies.length}})
+      <FaIcon @icon="caret-right" />
+    </button>
   </div>
   {{#if this.isLoading}}
     <LoadingSpinner />

--- a/addon/components/collapsed-taxonomies.hbs
+++ b/addon/components/collapsed-taxonomies.hbs
@@ -2,8 +2,17 @@
   class="collapsed-taxonomies"
   data-test-collapsed-taxonomies
 >
-  <div class="title" role="button" {{on "click" @expand}} data-test-title>
-    {{t "general.terms"}} ({{@subject.terms.length}})
+  <div>
+    <button
+      class="title link-button"
+      type="button"
+      aria-expanded="false"
+      data-test-title
+      {{on "click" @expand}}
+    >
+      {{t "general.terms"}} ({{@subject.terms.length}})
+      <FaIcon @icon="caret-right" />
+    </button>
   </div>
   {{#if @subject.associatedVocabularies}}
     <div class="content">

--- a/addon/components/course-leadership-expanded.hbs
+++ b/addon/components/course-leadership-expanded.hbs
@@ -7,14 +7,22 @@
     <LoadingSpinner />
   {{else}}
     <div class="course-leadership-expanded-header">
-      <h3
-        class="title {{unless @isManaging "collapsible clickable"}}"
-        role="button"
-        {{on "click" (unless @isManaging @collapse (noop))}}
-        data-test-title
-      >
-        {{t "general.courseLeadership"}}
-      </h3>
+      {{#if @isManaging}}
+        <h3 class="title" data-test-title>
+          {{t "general.courseLeadership"}}
+        </h3>
+      {{else}}
+        <button
+          class="title link-button"
+          type="button"
+          aria-expanded="true"
+          data-test-title
+          {{on "click" @collapse}}
+        >
+          {{t "general.courseLeadership"}}
+          <FaIcon @icon="caret-down" />
+        </button>
+      {{/if}}
       <div class="actions">
         {{#if @isManaging}}
           <button class="bigadd" type="button" {{on "click" (perform this.save)}} data-test-save>

--- a/addon/components/course/collapsed-objectives.hbs
+++ b/addon/components/course/collapsed-objectives.hbs
@@ -4,8 +4,17 @@
   {{did-insert (perform this.load)}}
   {{did-update (perform this.load) @course.courseObjectives}}
 >
-  <div class="title" role="button" {{on "click" @expand}} data-test-title>
-    {{t "general.objectives"}} ({{get this.objectives "length"}})
+  <div>
+    <button
+      class="title link-button"
+      type="button"
+      aria-expanded="false"
+      data-test-title
+      {{on "click" @expand}}
+    >
+      {{t "general.objectives"}} ({{get this.objectives "length"}})
+      <FaIcon @icon="caret-right" />
+    </button>
   </div>
   {{#if this.load.lastSuccessful}}
     <div class="content">

--- a/addon/components/course/objectives.hbs
+++ b/addon/components/course/objectives.hbs
@@ -1,15 +1,28 @@
 <section
-  class="course-objectives {{if this.showCollapsible "collapsible"}}"
+  class="course-objectives"
   {{did-insert (perform this.load)}}
   {{did-update (perform this.load) @course}}
   data-test-course-objectives
 >
   <div class="header">
-    <h3 class="title {{if this.showCollapsible "clickable collapsible"}}" data-test-title>
-      <button type="button" {{on "click" this.collapse}}>
+    {{#if this.showCollapsible}}
+      <div>
+        <button
+          class="title link-button"
+          type="button"
+          aria-expanded="true"
+          data-test-title
+          {{on "click" this.collapse}}
+        >
+          {{t "general.objectives"}} ({{this.objectiveCount}})
+          <FaIcon @icon="caret-down" />
+        </button>
+      </div>
+    {{else}}
+      <h3 class="title" data-test-title>
         {{t "general.objectives"}} ({{this.objectiveCount}})
-      </button>
-    </h3>
+      </h3>
+    {{/if}}
     {{#if @editable}}
       <span data-test-actions>
         <LinkTo

--- a/addon/components/course/publication-menu.hbs
+++ b/addon/components/course/publication-menu.hbs
@@ -19,6 +19,7 @@
     <span>
       {{this.title}}
     </span>
+    <FaIcon @icon={{if this.isOpen "caret-down" "caret-right"}} />
   </button>
   {{#if this.isOpen}}
     <div

--- a/addon/components/dashboard/calendar.hbs
+++ b/addon/components/dashboard/calendar.hbs
@@ -30,14 +30,14 @@
           />
         </div>
         {{#if this.showClearFilters}}
-          <span
+          <button
             id="calendar-clear-filters"
             class="calendar-clear-filters"
-            role="button"
+            type="button"
             {{on "click" @clearFilters}}
           >
             {{t "general.clearFilters"}}
-          </span>
+          </button>
         {{/if}}
       {{/if}}
       {{#unless @mySchedule}}

--- a/addon/components/dashboard/courses-calendar-filter.hbs
+++ b/addon/components/dashboard/courses-calendar-filter.hbs
@@ -39,8 +39,13 @@
               viewportSpy=true
             }}
           >
-            <button type="button" {{on "click" (fn this.toggleYear year.year)}}>
+            <button
+              type="button"
+              aria-expanded={{if (includes year.year this.expandedYears) "true" "false"}}
+              {{on "click" (fn this.toggleYear year.year)}}
+            >
               {{year.label}}
+              <FaIcon @icon={{if (includes year.year this.expandedYears) "caret-down" "caret-right"}} />
             </button>
           </h6>
           {{#if (includes year.year this.expandedYears)}}

--- a/addon/components/detail-competencies.hbs
+++ b/addon/components/detail-competencies.hbs
@@ -1,16 +1,19 @@
 <section
- class="detail-competencies {{if this.hasCompetencies "collapsible"}}"
+ class="detail-competencies"
   {{did-insert (perform this.load)}}
   {{did-update (perform this.load) @course.competencies}}
 >
-  <div
-    class="title {{if this.hasCompetencies "clickable collapsible"}}"
-    role="button"
-    {{on "click" (if this.hasCompetencies this.collapse (noop))}}
-  >
-    {{t "general.competencies"}} ({{this.competencyCount}})
-  </div>
   {{#if this.hasCompetencies}}
+    <button
+      class="title link-button"
+      type="button"
+      aria-expanded="false"
+      data-test-title
+      {{on "click" this.collapse}}
+    >
+      {{t "general.competencies"}} ({{this.competencyCount}})
+      <FaIcon @icon="caret-down" />
+    </button>
     <div class="detail-competencies-content">
       <ul class="static-list">
         {{#each @course.domainsWithSubcompetencies as |domain|}}
@@ -26,6 +29,10 @@
           </li>
         {{/each}}
       </ul>
+    </div>
+  {{else}}
+    <div class="title" data-test-title>
+      {{t "general.competencies"}} ({{this.competencyCount}})
     </div>
   {{/if}}
 </section>

--- a/addon/components/detail-taxonomies.hbs
+++ b/addon/components/detail-taxonomies.hbs
@@ -1,22 +1,31 @@
 <section
-  class="detail-taxonomies taxonomy-manager {{if this.showCollapsible "collapsible"}}"
+  class="detail-taxonomies taxonomy-manager"
   data-test-detail-taxonomies
 >
   <div class="detail-taxonomies-header">
     {{#if this.isManaging}}
-      <div class="title">
+      <h3 class="title" data-test-title>
         <span class="detail-specific-title">
           {{t "general.termsManageTitle"}}
         </span>
-      </div>
+      </h3>
     {{else}}
-      <div
-        class="title {{if this.showCollapsible "clickable collapsible"}}"
-        role="button"
-        {{on "click" this.collapse}}
-      >
-        {{t "general.terms"}} ({{@subject.terms.length}})
-      </div>
+      {{#if this.showCollapsible}}
+        <button
+          class="title link-button"
+          type="button"
+          aria-expanded="true"
+          {{on "click" this.collapse}}
+          data-test-title
+        >
+          {{t "general.terms"}} ({{@subject.terms.length}})
+            <FaIcon @icon="caret-down" />
+        </button>
+      {{else}}
+        <h3 class="title" data-test-title>
+          {{t "general.terms"}} ({{@subject.terms.length}})
+        </h3>
+      {{/if}}
     {{/if}}
     <div class="actions">
       {{#if this.isManaging}}

--- a/addon/components/leadership-collapsed.hbs
+++ b/addon/components/leadership-collapsed.hbs
@@ -1,6 +1,15 @@
 <section class="leadership-collapsed" data-test-leadership-collapsed>
-  <div class="title clickable" role="button" {{on "click" @expand}}>
-    {{@title}}
+  <div>
+    <button
+      class="title link-button"
+      type="button"
+      aria-expanded="false"
+      data-test-title
+      {{on "click" @expand}}
+    >
+      {{@title}}
+      <FaIcon @icon="caret-right" />
+    </button>
   </div>
   <div class="content">
     <table class="condensed">

--- a/addon/components/learnergroup-tree.hbs
+++ b/addon/components/learnergroup-tree.hbs
@@ -1,7 +1,7 @@
 {{#let (unique-id) as |templateId|}}
   <li
     hidden={{this.isHidden}}
-    class={{if this.hasChildren "strong" "em"}}
+    class="learnergroup-tree {{if this.hasChildren "strong" "em"}}"
     data-test-learnergroup-tree
     data-test-learnergroup-tree-root={{if this.isRoot "true" "false"}}
   >
@@ -12,14 +12,15 @@
         {{on "click" (if (includes @learnerGroup @selectedGroups) (fn this.remove @learnerGroup) (fn this.add @learnerGroup))}}
         data-test-checkbox
       >
-      <span
+      <button
         id="learnergroup-label-{{templateId}}"
-        role="button"
+        class="learnergroup-label"
+        type="button"
         {{on "click" (if (includes @learnerGroup @selectedGroups) (fn this.remove @learnerGroup) (fn this.add @learnerGroup))}}
         data-test-checkbox-title
       >
         {{@learnerGroup.title}}
-      </span>
+      </button>
     {{#if @learnerGroup.needsAccommodation}}
       <FaIcon @icon="universal-access" @title={{t "general.membersOfThisGroupRequireAccommodation"}}></FaIcon>
     {{/if}}

--- a/addon/components/publish-all-sessions.hbs
+++ b/addon/components/publish-all-sessions.hbs
@@ -3,13 +3,18 @@
   data-test-publish-all-sessions
 >
   <section class="publish-all-sessions-unpublishable" data-test-unpublishable>
-    <div
-      class="title {{if this.unPublishableCollapsed "collapsed" "collapsible"}}"
-      role="button"
-      data-test-expand-collapse
-      {{on "click" (set this.unPublishableCollapsed (not this.unPublishableCollapsed))}}
-    >
-      {{t "general.incompleteSessions"}} ({{this.unPublishableSessions.length}})
+    <div>
+      <button
+        class="title link-button"
+        type="button"
+        aria-expanded={{if this.unPublishableCollapsed "true" "false"}}
+        data-test-expand-collapse
+        data-test-title
+        {{on "click" (set this.unPublishableCollapsed (not this.unPublishableCollapsed))}}
+      >
+        {{t "general.incompleteSessions"}} ({{this.unPublishableSessions.length}})
+        <FaIcon @icon={{if this.unPublishableCollapsed "caret-right" "caret-down"}} />
+      </button>
     </div>
     {{#unless this.unPublishableCollapsed}}
       <div class="content" data-test-content>
@@ -97,14 +102,18 @@
     {{/unless}}
   </section>
   <section class="publish-all-sessions-publishable" data-test-publishable>
-    <div
-      class="title {{if this.publishableCollapsed "collapsed" "collapsible"}}"
-      role="button"
-      {{on "click" (set this.publishableCollapsed (not this.publishableCollapsed))}}
-      data-test-expand-collapse
-      data-test-title
-    >
-      {{t "general.completeSessions"}} ({{this.publishableSessions.length}})
+    <div>
+      <button
+        class="title link-button"
+        type="button"
+        aria-expanded={{if this.publishableCollapsed "true" "false"}}
+        data-test-expand-collapse
+        data-test-title
+        {{on "click" (set this.publishableCollapsed (not this.publishableCollapsed))}}
+      >
+        {{t "general.completeSessions"}} ({{this.publishableSessions.length}})
+        <FaIcon @icon={{if this.publishableCollapsed "caret-right" "caret-down"}} />
+      </button>
     </div>
     {{#unless this.publishableCollapsed}}
       <div class="content" data-test-content>

--- a/addon/components/session-leadership-expanded.hbs
+++ b/addon/components/session-leadership-expanded.hbs
@@ -7,14 +7,22 @@
       <LoadingSpinner />
   {{else}}
     <div class="session-leadership-expanded-header">
-      <h3
-        class="title {{unless @isManaging "collapsible clickable"}}"
-        role="button"
-        {{on "click" (unless @isManaging @collapse (noop))}}
-        data-test-title
-      >
-        {{t "general.sessionLeadership"}}
-      </h3>
+      {{#if @isManaging}}
+        <h3 class="title" data-test-title>
+          {{t "general.sessionLeadership"}}
+        </h3>
+      {{else}}
+        <button
+          class="title link-button"
+          type="button"
+          aria-expanded="true"
+          data-test-title
+          {{on "click" @collapse}}
+        >
+          {{t "general.sessionLeadership"}}
+          <FaIcon @icon="caret-down" />
+        </button>
+      {{/if}}
       <div class="actions">
         {{#if @isManaging}}
           <button class="bigadd" type="button" {{on "click" (perform this.save)}} data-test-save>

--- a/addon/components/session/collapsed-objectives.hbs
+++ b/addon/components/session/collapsed-objectives.hbs
@@ -4,8 +4,17 @@
   {{did-insert (perform this.load)}}
   {{did-update (perform this.load) @session.sessionObjectives}}
 >
-  <div class="title" role="button" {{on "click" @expand}} data-test-title>
-    {{t "general.objectives"}} ({{get this.objectives "length"}})
+  <div>
+    <button
+      class="title link-button"
+      type="button"
+      aria-expanded="false"
+      data-test-title
+      {{on "click" @expand}}
+    >
+      {{t "general.objectives"}} ({{get this.objectives "length"}})
+      <FaIcon @icon="caret-right" />
+    </button>
   </div>
   {{#if this.load.lastSuccessful}}
     <div class="content">

--- a/addon/components/session/objectives.hbs
+++ b/addon/components/session/objectives.hbs
@@ -1,15 +1,28 @@
 <section
-  class="session-objectives {{if this.showCollapsible "collapsible"}}"
+  class="session-objectives"
   {{did-insert (perform this.load) }}
   {{did-update (perform this.load) @session}}
   data-test-session-objectives
 >
   <div class="header">
-    <h3 class="title {{if this.showCollapsible "clickable collapsible"}}" data-test-title>
-      <button type="button" {{on "click" this.collapse}}>
+    {{#if this.showCollapsible}}
+      <div>
+        <button
+          class="title link-button"
+          type="button"
+          aria-expanded="true"
+          data-test-title
+          {{on "click" this.collapse}}
+        >
+          {{t "general.objectives"}} ({{this.objectiveCount}})
+          <FaIcon @icon="caret-down" />
+        </button>
+      </div>
+    {{else}}
+      <h3 class="title" data-test-title>
         {{t "general.objectives"}} ({{this.objectiveCount}})
-      </button>
-    </h3>
+      </h3>
+    {{/if}}
     {{#if @editable}}
       <span data-test-actions>
         <ExpandCollapseButton

--- a/addon/components/session/publication-menu.hbs
+++ b/addon/components/session/publication-menu.hbs
@@ -19,6 +19,7 @@
     <span>
       {{this.title}}
     </span>
+    <FaIcon @icon={{if this.isOpen "caret-down" "caret-right"}} />
   </button>
   {{#if this.isOpen}}
     <div

--- a/addon/components/user-search-result-instructor-group.hbs
+++ b/addon/components/user-search-result-instructor-group.hbs
@@ -1,11 +1,12 @@
 {{#if (not (includes @group @currentlyActiveInstructorGroups))}}
-  <li
-    class="active"
-    role="button"
-    data-test-result
-    {{on "click" (fn @addInstructorGroup @group)}}
-  >
-    {{@group.title}}
+  <li class="active" data-test-result>
+    <button
+      class="link-button"
+      type="button"
+      {{on "click" (fn @addInstructorGroup @group)}}
+    >
+      {{@group.title}}
+    </button>
   </li>
 {{else}}
   <li class="inactive" data-test-result>

--- a/addon/components/user-search-result-user.hbs
+++ b/addon/components/user-search-result-user.hbs
@@ -1,16 +1,17 @@
 {{#if (and @user.enabled (not (includes @user @currentlyActiveUsers)))}}
-  <li
-    class="active"
-    role="button"
-    data-test-result
-    {{on "click" (fn @addUser @user)}}
-  >
-    <div class="name">
-      {{@user.fullName}}
-    </div>
-    <div class="email">
-      {{@user.email}}
-    </div>
+  <li class="active" data-test-result>
+    <button
+      class="link-button"
+      type="button"
+      {{on "click" (fn @addUser @user)}}
+    >
+      <div class="name">
+        {{@user.fullName}}
+      </div>
+      <div class="email">
+        {{@user.email}}
+      </div>
+    </button>
   </li>
 {{else}}
   <li class="inactive" data-test-result>

--- a/addon/components/week-glance.hbs
+++ b/addon/components/week-glance.hbs
@@ -6,7 +6,8 @@
   {{#if @collapsible}}
     <button
       type="button"
-      class="title collapsible {{if @collapsed "collapsed" "expanded"}}"
+      class="title collapsible"
+      aria-expanded={{if @collapsed "false" "true"}}
       data-test-week-title
       {{on "click" (fn (optional @toggleCollapsed) @collapsed)}}
     >
@@ -14,6 +15,7 @@
       {{#if @showFullTitle}}
         {{t "general.weekAtAGlance"}}
       {{/if}}
+      <FaIcon @icon={{if @collapsed "caret-right" "caret-down"}} />
     </button>
   {{else}}
     <h2 class="title"

--- a/app/styles/ilios-common/components.scss
+++ b/app/styles/ilios-common/components.scss
@@ -59,6 +59,7 @@
 @import "components/leadership-manager";
 @import "components/leadership-search";
 @import "components/learnergroup-selection-cohort-manager";
+@import "components/learnergroup-tree";
 @import "components/learning-materials-sort-manager";
 @import "components/learningmaterial-manager";
 @import "components/learning-material-uploader";

--- a/app/styles/ilios-common/components/choose-material-type.scss
+++ b/app/styles/ilios-common/components/choose-material-type.scss
@@ -51,9 +51,6 @@
   .toggle {
     background-color: c.$tealBlue;
     color: c.$white;
-    &::after {
-      content: "\25BE";
-    }
 
     &[aria-expanded="true"] {
       border-bottom-right-radius: 0;

--- a/app/styles/ilios-common/components/dashboard/courses-calendar-filter.scss
+++ b/app/styles/ilios-common/components/dashboard/courses-calendar-filter.scss
@@ -13,21 +13,5 @@
         margin-left: 0.25em;
       }
     }
-
-    &.collapsed {
-      .year-title button {
-        &::after {
-          content: "\25BA";
-        }
-      }
-    }
-
-    &.expanded {
-      .year-title button {
-        &::after {
-          content: "\25BC";
-        }
-      }
-    }
   }
 }

--- a/app/styles/ilios-common/components/learnergroup-tree.scss
+++ b/app/styles/ilios-common/components/learnergroup-tree.scss
@@ -1,0 +1,7 @@
+@use "../mixins" as m;
+
+.learnergroup-tree {
+  .learnergroup-label {
+    @include m.ilios-button-reset;
+  }
+}

--- a/app/styles/ilios-common/components/publication-menu.scss
+++ b/app/styles/ilios-common/components/publication-menu.scss
@@ -61,9 +61,6 @@
     border-width: 1px;
     color: c.$white;
     position: relative;
-    &::after {
-      content: "\25BE";
-    }
 
     &[aria-expanded="true"] {
       border-width: 1px 1px 0 1px;

--- a/app/styles/ilios-common/components/week-glance.scss
+++ b/app/styles/ilios-common/components/week-glance.scss
@@ -10,19 +10,6 @@
     &.collapsible {
       @include m.ilios-button-reset;
       @include m.font-size("xl");
-      &.collapsed {
-        &::after {
-          content: "\25BA";
-          @include m.font-size("medium");
-        }
-      }
-
-      &.expanded {
-        &::after {
-          content: "\25BC";
-          @include m.font-size("medium");
-        }
-      }
     }
   }
 

--- a/app/styles/ilios-common/mixins/collapsed-container.scss
+++ b/app/styles/ilios-common/mixins/collapsed-container.scss
@@ -17,11 +17,6 @@
 
 @mixin collapsed-container-title() {
   @include ilios-heading.ilios-heading-h5;
-  cursor: pointer;
-
-  &::after {
-    content: "\25BA";
-  }
 }
 
 @mixin collapsed-container-content() {

--- a/app/styles/ilios-common/mixins/detail-container.scss
+++ b/app/styles/ilios-common/mixins/detail-container.scss
@@ -12,18 +12,6 @@
 
 @mixin detail-container-title-style() {
   @include ilios-heading.ilios-heading-h5;
-
-  &.collapsible {
-    &::after {
-      content: "\25BC";
-    }
-  }
-
-  &.collapsed {
-    &::after {
-      content: "\25BA";
-    }
-  }
 }
 
 @mixin detail-container-header() {

--- a/app/styles/ilios-common/mixins/objectives.scss
+++ b/app/styles/ilios-common/mixins/objectives.scss
@@ -29,15 +29,6 @@
 
     .title {
       @include ilios-heading.ilios-heading-h5;
-      button {
-        @include ilios-button.ilios-button-reset;
-      }
-
-      &.collapsible {
-        button::after {
-          content: "\25BC";
-        }
-      }
     }
   }
 

--- a/tests/acceptance/course/session/publish-all-test.js
+++ b/tests/acceptance/course/session/publish-all-test.js
@@ -51,7 +51,6 @@ module('Acceptance | Session - Publish All', function (hooks) {
 
     await page.visit({ courseId: this.course.id });
     const { publishableSessions } = page.publishAllSessions;
-
     assert.strictEqual(publishableSessions.title, 'Sessions Complete: ready to publish (2)');
     await publishableSessions.toggle();
     assert.strictEqual(publishableSessions.sessions.length, 2);


### PR DESCRIPTION
then, it reworks markup and styles of expandable/collapsable components, and adds aria-expanded attributes, since the components affected are mostly the same, and these addresses related a11y concepts.


this is all prep work to adding focus state to the app.


refs https://github.com/ilios/ilios/issues/4782