### PR TITLE
bring back scroll-into-view for calendars.

### DIFF
--- a/addon/components/daily-calendar.hbs
+++ b/addon/components/daily-calendar.hbs
@@ -20,6 +20,8 @@
   <div
     class="day"
     tabindex="0"
+    {{did-insert (perform this.scrollView) this.earliestHour}}
+    {{did-update (perform this.scrollView) this.earliestHour}}
   >
     <div class="hours">
       {{#each this.hours as |hour|}}

--- a/addon/components/weekly-calendar.hbs
+++ b/addon/components/weekly-calendar.hbs
@@ -21,6 +21,8 @@
   <div
     class="days"
     tabindex="0"
+    {{did-insert (perform this.scrollView) this.earliestHour}}
+    {{did-update (perform this.scrollView) this.earliestHour}}
   >
     <div class="hours">
       {{#each this.hours as |hour|}}

--- a/addon/components/weekly-calendar.js
+++ b/addon/components/weekly-calendar.js
@@ -1,13 +1,27 @@
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
+import { restartableTask, timeout } from 'ember-concurrency';
 import { action, set } from '@ember/object';
 import { DateTime } from 'luxon';
 import { sortBy } from 'ilios-common/utils/array-helpers';
 import { deprecate } from '@ember/debug';
+import scrollIntoView from 'scroll-into-view';
 
 export default class WeeklyCalendarComponent extends Component {
   @service intl;
   @service localeDays;
+
+  scrollView = restartableTask(async (calendarElement, [earliestHour]) => {
+    //waiting ensures that setHour has time to setup hour elements
+    await timeout(1);
+    // all of the hour elements are registered in the template as hour0, hour1, etc
+    let hourElement = this.hour6;
+
+    if (earliestHour < 24 && earliestHour > 2) {
+      hourElement = this[`hour${earliestHour}`];
+    }
+    scrollIntoView(hourElement, { align: { top: 0 } });
+  });
 
   get date() {
     if (typeof this.args.date === 'string') {
@@ -40,6 +54,17 @@ export default class WeeklyCalendarComponent extends Component {
         fullName: date.toFormat('dddd LL'),
       };
     });
+  }
+
+  get earliestHour() {
+    if (!this.args.events) {
+      return null;
+    }
+
+    return this.sortedEvents.reduce((earliestHour, event) => {
+      const hour = Number(DateTime.fromISO(event.startDate).toFormat('HH'));
+      return hour < earliestHour ? hour : earliestHour;
+    }, 24);
   }
 
   get sortedEvents() {


### PR DESCRIPTION
this reverts commit 8c81eba3b3aaf2eea50160ce8d461f340548cb4d

refs https://github.com/ilios/ilios/issues/4867 and https://github.com/ilios/common/pull/3460


side-note: i tried the native [`element.scrollIntoView()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView) method as suggested by @jrjohnson, in various configurations. these work just as well as the [`scroll-into-view`](https://www.npmjs.com/package/scroll-into-view) package that we're using throughout the frontend. however, it doesn't solve the general problem of the viewport shifting downwards, so this ends up being a straight-up reversal of https://github.com/ilios/common/pull/3460