### PR TITLE
Adjust Percy Tests

### DIFF
--- a/tests/acceptance/course/cohorts-test.js
+++ b/tests/acceptance/course/cohorts-test.js
@@ -47,7 +47,6 @@ module('Acceptance | Course - Cohorts', function (hooks) {
   test('list cohorts', async function (assert) {
     assert.expect(4);
     await page.visit({ courseId: this.course.id, details: true });
-    await percySnapshot(assert);
     assert.strictEqual(page.details.cohorts.current.length, 1);
     assert.strictEqual(page.details.cohorts.current[0].school, 'school 0');
     assert.strictEqual(page.details.cohorts.current[0].program, 'program 0');

--- a/tests/acceptance/course/learningmaterials-test.js
+++ b/tests/acceptance/course/learningmaterials-test.js
@@ -108,7 +108,6 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
       assert.expect(39);
       this.user.update({ administeredSchools: [this.school] });
       await page.visit({ courseId: this.course.id, details: true });
-      await percySnapshot(assert);
       assert.strictEqual(currentRouteName(), 'course.index');
 
       assert.strictEqual(page.details.learningMaterials.current.length, 4);

--- a/tests/acceptance/course/mesh-test.js
+++ b/tests/acceptance/course/mesh-test.js
@@ -3,7 +3,6 @@ import { setupAuthentication } from 'ilios-common';
 
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/course';
-import percySnapshot from '@percy/ember';
 
 module('Acceptance | Course - Mesh Terms', function (hooks) {
   setupApplicationTest(hooks);
@@ -37,7 +36,6 @@ module('Acceptance | Course - Mesh Terms', function (hooks) {
   test('list mesh', async function (assert) {
     assert.expect(4);
     await page.visit({ courseId: this.course.id, details: true });
-    await percySnapshot(assert);
     assert.strictEqual(page.details.meshTerms.current.length, 3);
     assert.strictEqual(page.details.meshTerms.current[0].title, 'descriptor 0');
     assert.strictEqual(page.details.meshTerms.current[1].title, 'descriptor 1');
@@ -48,7 +46,6 @@ module('Acceptance | Course - Mesh Terms', function (hooks) {
     assert.expect(24);
     this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, details: true });
-    await percySnapshot(assert);
     assert.strictEqual(page.details.meshTerms.current.length, 3);
     await page.details.meshTerms.manage();
     assert.strictEqual(page.details.meshTerms.meshManager.selectedTerms.length, 3);

--- a/tests/acceptance/course/objectivecreate-test.js
+++ b/tests/acceptance/course/objectivecreate-test.js
@@ -2,7 +2,6 @@ import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/course';
-import percySnapshot from '@percy/ember';
 
 module('Acceptance | Course - Objective Create', function (hooks) {
   setupApplicationTest(hooks);
@@ -30,7 +29,6 @@ module('Acceptance | Course - Objective Create', function (hooks) {
       details: true,
       courseObjectiveDetails: true,
     });
-    await percySnapshot(assert);
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 1);
     assert.strictEqual(
       page.details.objectives.objectiveList.objectives[0].description.text,

--- a/tests/acceptance/course/objectiveparents-test.js
+++ b/tests/acceptance/course/objectiveparents-test.js
@@ -3,7 +3,6 @@ import { setupAuthentication } from 'ilios-common';
 
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/course';
-import percySnapshot from '@percy/ember';
 
 module('Acceptance | Course - Objective Parents', function (hooks) {
   setupApplicationTest(hooks);
@@ -54,7 +53,6 @@ module('Acceptance | Course - Objective Parents', function (hooks) {
       details: true,
       courseObjectiveDetails: true,
     });
-    await percySnapshot(assert);
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 2);
 
     assert.strictEqual(

--- a/tests/acceptance/course/objectiveterms-test.js
+++ b/tests/acceptance/course/objectiveterms-test.js
@@ -2,7 +2,6 @@ import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/course';
-import percySnapshot from '@percy/ember';
 
 module('Acceptance | Course - Objective Vocabulary Terms', function (hooks) {
   setupApplicationTest(hooks);
@@ -33,7 +32,6 @@ module('Acceptance | Course - Objective Vocabulary Terms', function (hooks) {
       details: true,
       courseObjectiveDetails: true,
     });
-    await percySnapshot(assert);
     assert.strictEqual(
       page.details.objectives.objectiveList.objectives[0].selectedTerms.list.length,
       1

--- a/tests/acceptance/course/overview-test.js
+++ b/tests/acceptance/course/overview-test.js
@@ -93,7 +93,6 @@ module('Acceptance | Course - Overview', function (hooks) {
         .lookup('service:store')
         .findRecord('course', this.course.id);
       await page.visit({ courseId: courseModel.id });
-      await percySnapshot(assert);
       assert.strictEqual(page.details.titles, 2);
       assert.strictEqual(currentURL(), '/courses/1');
       await page.details.collapseControl();

--- a/tests/acceptance/course/publicationcheck-test.js
+++ b/tests/acceptance/course/publicationcheck-test.js
@@ -3,7 +3,6 @@ import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/course-publication-check';
-import percySnapshot from '@percy/ember';
 
 module('Acceptance | Course - Publication Check', function (hooks) {
   setupApplicationTest(hooks);
@@ -43,7 +42,6 @@ module('Acceptance | Course - Publication Check', function (hooks) {
   test('full course count', async function (assert) {
     assert.expect(7);
     await page.visit({ courseId: this.fullCourse.id });
-    await percySnapshot(assert);
     assert.strictEqual(page.publicationcheck.backToCourse.url, '/courses/1');
     assert.strictEqual(currentRouteName(), 'course.publication_check');
     assert.strictEqual(page.publicationcheck.courseTitle, 'course 0');

--- a/tests/acceptance/course/session/ilm-test.js
+++ b/tests/acceptance/course/session/ilm-test.js
@@ -3,7 +3,6 @@ import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/session';
-import percySnapshot from '@percy/ember';
 
 module('Acceptance | Session - Independent Learning', function (hooks) {
   setupApplicationTest(hooks);
@@ -34,7 +33,6 @@ module('Acceptance | Session - Independent Learning', function (hooks) {
       sessionId: 1,
       sessionLearnergroupDetails: true,
     });
-    await percySnapshot(assert);
 
     assert.strictEqual(currentRouteName(), 'session.index');
     assert.strictEqual(page.details.instructors.title, 'Instructors and Instructor Groups (3/3)');

--- a/tests/acceptance/course/session/learner-groups-test.js
+++ b/tests/acceptance/course/session/learner-groups-test.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/session';
-import percySnapshot from '@percy/ember';
+import { DateTime } from 'luxon';
 
 module('Acceptance | Session - Learner Groups', function (hooks) {
   setupApplicationTest(hooks);
@@ -41,6 +41,7 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
       });
       this.server.create('session', {
         courseId: 1,
+        updatedAt: DateTime.fromObject({ year: 2019, month: 7, day: 9, hour: 17 }).toJSDate(),
       });
       this.server.createList('user', 2);
       this.server.create('user', {
@@ -59,7 +60,6 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
       });
 
       await page.visit({ courseId: 1, sessionId: 1 });
-      await percySnapshot(assert);
 
       assert.strictEqual(currentRouteName(), 'session.index');
       const { selectedLearners, selectedLearnerGroups } =

--- a/tests/acceptance/course/session/learningmaterials-test.js
+++ b/tests/acceptance/course/session/learningmaterials-test.js
@@ -853,7 +853,6 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
     test('list learning materials', async function (assert) {
       assert.expect(10);
       await page.visit({ courseId: 1, sessionId: 1 });
-      await percySnapshot(assert);
       assert.strictEqual(currentRouteName(), 'session.index');
 
       assert.strictEqual(page.details.learningMaterials.current.length, 1);

--- a/tests/acceptance/course/session/mesh-test.js
+++ b/tests/acceptance/course/session/mesh-test.js
@@ -3,7 +3,6 @@ import { setupAuthentication } from 'ilios-common';
 
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/session';
-import percySnapshot from '@percy/ember';
 
 module('Acceptance | Session - Mesh Terms', function (hooks) {
   setupApplicationTest(hooks);
@@ -40,7 +39,6 @@ module('Acceptance | Session - Mesh Terms', function (hooks) {
   test('list mesh', async function (assert) {
     assert.expect(4);
     await page.visit({ courseId: 1, sessionId: 1 });
-    await percySnapshot(assert);
     assert.strictEqual(page.details.meshTerms.current.length, 3);
     assert.strictEqual(page.details.meshTerms.current[0].title, 'descriptor 0');
     assert.strictEqual(page.details.meshTerms.current[1].title, 'descriptor 1');

--- a/tests/acceptance/course/session/objectiveparents-test.js
+++ b/tests/acceptance/course/session/objectiveparents-test.js
@@ -3,7 +3,6 @@ import { setupAuthentication } from 'ilios-common';
 
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/session';
-import percySnapshot from '@percy/ember';
 
 module('Acceptance | Session - Objective Parents', function (hooks) {
   setupApplicationTest(hooks);
@@ -34,7 +33,6 @@ module('Acceptance | Session - Objective Parents', function (hooks) {
       sessionId: 1,
       sessionObjectiveDetails: true,
     });
-    await percySnapshot(assert);
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 2);
 
     assert.strictEqual(

--- a/tests/acceptance/course/session/objectiveterms-test.js
+++ b/tests/acceptance/course/session/objectiveterms-test.js
@@ -2,7 +2,6 @@ import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/session';
-import percySnapshot from '@percy/ember';
 
 module('Acceptance | Session - Objective Vocabulary Terms', function (hooks) {
   setupApplicationTest(hooks);
@@ -34,7 +33,6 @@ module('Acceptance | Session - Objective Vocabulary Terms', function (hooks) {
       sessionId: 1,
       sessionObjectiveDetails: true,
     });
-    await percySnapshot(assert);
     assert.strictEqual(
       page.details.objectives.objectiveList.objectives[0].selectedTerms.list.length,
       1

--- a/tests/acceptance/course/session/overview-test.js
+++ b/tests/acceptance/course/session/overview-test.js
@@ -5,7 +5,6 @@ import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import { enableFeature } from 'ember-feature-flags/test-support';
 import page from 'ilios-common/page-objects/session';
-import percySnapshot from '@percy/ember';
 
 module('Acceptance | Session - Overview', function (hooks) {
   setupApplicationTest(hooks);
@@ -32,7 +31,6 @@ module('Acceptance | Session - Overview', function (hooks) {
       instructionalNotes: 'session notes',
     });
     await page.visit({ courseId: 1, sessionId: 1 });
-    await percySnapshot(assert);
     assert.strictEqual(page.details.overview.sessionType.value, 'session type 0');
     assert.strictEqual(page.details.overview.sessionDescription.value, session.description);
     assert.strictEqual(page.details.overview.instructionalNotes.value, 'session notes');

--- a/tests/acceptance/course/session/publish-test.js
+++ b/tests/acceptance/course/session/publish-test.js
@@ -4,7 +4,6 @@ import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/session';
-import percySnapshot from '@percy/ember';
 import { freezeDateAt, unfreezeDate } from 'ilios-common';
 
 module('Acceptance | Session - Publish', function (hooks) {
@@ -64,7 +63,6 @@ module('Acceptance | Session - Publish', function (hooks) {
   test('check published session', async function (assert) {
     assert.expect(6);
     await page.visit({ courseId: this.course.id, sessionId: this.publishedSession.id });
-    await percySnapshot(assert);
     assert.strictEqual(currentRouteName(), 'session.index');
     assert.strictEqual(page.details.overview.publicationMenu.toggle.text, 'Published');
     await page.details.overview.publicationMenu.toggle.click();

--- a/tests/acceptance/course/session/terms-test.js
+++ b/tests/acceptance/course/session/terms-test.js
@@ -3,7 +3,6 @@ import { setupAuthentication } from 'ilios-common';
 
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/session';
-import percySnapshot from '@percy/ember';
 
 module('Acceptance | Session - Terms', function (hooks) {
   setupApplicationTest(hooks);
@@ -38,7 +37,6 @@ module('Acceptance | Session - Terms', function (hooks) {
   test('taxonomy summary', async function (assert) {
     assert.expect(9);
     await page.visit({ courseId: 1, sessionId: 1 });
-    await percySnapshot(assert);
     assert.strictEqual(page.details.collapsedTaxonomies.title, 'Terms (1)');
     assert.strictEqual(page.details.collapsedTaxonomies.headers.length, 3);
     assert.strictEqual(page.details.collapsedTaxonomies.headers[0].title, 'Vocabulary');

--- a/tests/acceptance/course/sessionlist-test.js
+++ b/tests/acceptance/course/sessionlist-test.js
@@ -145,7 +145,6 @@ module('Acceptance | Course - Session List', function (hooks) {
   test('expanded offering', async function (assert) {
     assert.expect(24);
     await page.visit({ courseId: this.course.id, details: true });
-    await percySnapshot(assert);
     const { sessions } = page.courseSessions.sessionsGrid;
 
     assert.strictEqual(sessions.length, 4);
@@ -188,7 +187,6 @@ module('Acceptance | Course - Session List', function (hooks) {
   test('no offerings', async function (assert) {
     assert.expect(8);
     await page.visit({ courseId: this.course.id, details: true });
-    await percySnapshot(assert);
     const { sessions } = page.courseSessions.sessionsGrid;
 
     assert.strictEqual(sessions.length, 4);

--- a/tests/acceptance/course/terms-test.js
+++ b/tests/acceptance/course/terms-test.js
@@ -3,7 +3,6 @@ import { setupAuthentication } from 'ilios-common';
 
 import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/course';
-import percySnapshot from '@percy/ember';
 
 module('Acceptance | Course - Terms', function (hooks) {
   setupApplicationTest(hooks);
@@ -35,7 +34,6 @@ module('Acceptance | Course - Terms', function (hooks) {
   test('taxonomy summary', async function (assert) {
     assert.expect(9);
     await page.visit({ courseId: this.course.id, details: true });
-    await percySnapshot(assert);
     assert.strictEqual(
       page.details.collapsedTaxonomies.title,
       'Terms (' + this.course.terms.length + ')'
@@ -74,7 +72,6 @@ module('Acceptance | Course - Terms', function (hooks) {
       details: true,
       courseTaxonomyDetails: true,
     });
-    await percySnapshot(assert);
     assert.strictEqual(page.details.taxonomies.vocabularies.length, 1);
     await page.details.taxonomies.manage();
 

--- a/tests/acceptance/dashboard/calendar-test.js
+++ b/tests/acceptance/dashboard/calendar-test.js
@@ -93,6 +93,13 @@ module('Acceptance | Dashboard Calendar', function (hooks) {
 
   test('load month calendar', async function (assert) {
     assert.expect(4);
+    const day = DateTime.fromObject({
+      month: 9,
+      day: 9,
+      year: 2029,
+    });
+    freezeDateAt(day.toJSDate());
+
     const today = DateTime.fromObject({ hour: 8, minute: 8, second: 8 });
     const startOfMonth = today.startOf('month');
     const endOfMonth = today.endOf('month').set({ hour: 22, minute: 59 });
@@ -141,6 +148,13 @@ module('Acceptance | Dashboard Calendar', function (hooks) {
 
   test('load week calendar', async function (assert) {
     assert.expect(9);
+    const march11th2009 = DateTime.fromObject({
+      year: 2009,
+      month: 3,
+      day: 11,
+      hour: 8,
+    });
+    freezeDateAt(march11th2009.toJSDate());
     const startOfWeek = DateTime.fromJSDate(
       this.owner.lookup('service:locale-days').firstDayOfThisWeek
     );
@@ -226,7 +240,6 @@ module('Acceptance | Dashboard Calendar', function (hooks) {
       lastModified: DateTime.now().minus({ year: 1 }),
     });
     await page.visit({ show: 'calendar' });
-    await percySnapshot(assert);
     assert.strictEqual(currentRouteName(), 'dashboard.calendar');
 
     assert.strictEqual(page.calendar.weeklyCalendar.dayHeadings.length, 7);
@@ -426,17 +439,25 @@ module('Acceptance | Dashboard Calendar', function (hooks) {
 
   test('show user events', async function (assert) {
     assert.expect(1);
-    const today = DateTime.fromObject({ hour: 8, minute: 8, second: 8 });
+    const day = DateTime.fromObject({
+      month: 4,
+      day: 4,
+      year: 2004,
+      hour: 4,
+      minute: 0,
+      second: 7,
+    });
+    freezeDateAt(day.toJSDate());
     this.server.create('userevent', {
       user: this.user.id,
-      startDate: today.toJSDate(),
-      endDate: today.plus({ hour: 1 }).toJSDate(),
+      startDate: day.toJSDate(),
+      endDate: day.plus({ hour: 1 }).toJSDate(),
       offering: 1,
     });
     this.server.create('userevent', {
       user: this.user.id,
-      startDate: today.toJSDate(),
-      endDate: today.plus({ hour: 1 }).toJSDate(),
+      startDate: day.toJSDate(),
+      endDate: day.plus({ hour: 1 }).toJSDate(),
       offering: 2,
     });
     await page.visit({ show: 'calendar' });
@@ -449,17 +470,25 @@ module('Acceptance | Dashboard Calendar', function (hooks) {
   };
   test('show school events', async function (assert) {
     assert.expect(1);
-    const today = DateTime.fromObject({ hour: 8, minute: 8, second: 8 });
+    const day = DateTime.fromObject({
+      month: 7,
+      day: 7,
+      year: 2007,
+      hour: 8,
+      minute: 8,
+      second: 8,
+    });
+    freezeDateAt(day.toJSDate());
     this.server.create('schoolevent', {
       school: 1,
-      startDate: today.toJSDate(),
-      endDate: today.plus({ hour: 1 }).toJSDate(),
+      startDate: day.toJSDate(),
+      endDate: day.plus({ hour: 1 }).toJSDate(),
       offering: 1,
     });
     this.server.create('schoolevent', {
       school: 1,
-      startDate: today.toJSDate(),
-      endDate: today.plus({ hour: 1 }).toJSDate(),
+      startDate: day.toJSDate(),
+      endDate: day.plus({ hour: 1 }).toJSDate(),
       offering: 2,
     });
     await page.visit();
@@ -674,10 +703,8 @@ module('Acceptance | Dashboard Calendar', function (hooks) {
     assert.dom(sessiontype).isChecked('filter is checked');
     assert.dom(course).isChecked('filter is checked');
     assert.dom(term).isChecked('filter is checked');
-    await percySnapshot(assert);
 
     await click(clearFilter);
-    await percySnapshot(assert);
     assert.ok(isEmpty(find(clearFilter)), 'clear filter button is inactive');
     assert.dom(sessiontype).isNotChecked('filter is unchecked');
     assert.dom(course).isNotChecked('filter is unchecked');
@@ -787,7 +814,6 @@ module('Acceptance | Dashboard Calendar', function (hooks) {
     const events = `${dashboard} .event`;
 
     await visit('/dashboard/week');
-    await percySnapshot(assert);
 
     const eventBLocks = findAll(events);
     assert.strictEqual(eventBLocks.length, 2);

--- a/tests/acceptance/dashboard/week-test.js
+++ b/tests/acceptance/dashboard/week-test.js
@@ -6,6 +6,7 @@ import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/dashboard-week';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import percySnapshot from '@percy/ember';
+import { freezeDateAt, unfreezeDate } from 'ilios-common';
 
 module('Acceptance | Dashboard Week at a Glance', function (hooks) {
   setupApplicationTest(hooks);
@@ -16,8 +17,19 @@ module('Acceptance | Dashboard Week at a Glance', function (hooks) {
     this.user = await setupAuthentication({ school: this.school });
   });
 
+  hooks.afterEach(() => {
+    unfreezeDate();
+  });
+
   test('shows events', async function (assert) {
     assert.expect(4);
+    const aug16th2023 = DateTime.fromObject({
+      year: 2023,
+      month: 8,
+      day: 16,
+      hour: 10,
+    });
+    freezeDateAt(aug16th2023.toJSDate());
     const { firstDayOfThisWeek, lastDayOfThisWeek } = this.owner.lookup('service:locale-days');
     const startOfWeek = DateTime.fromJSDate(firstDayOfThisWeek);
     const endOfWeek = DateTime.fromJSDate(lastDayOfThisWeek);
@@ -83,12 +95,19 @@ module('Acceptance | Dashboard Week at a Glance', function (hooks) {
       title: 'pre mat 3',
       sessionLearningMaterial: 24,
     });
+    const oct31st2018 = DateTime.fromObject({
+      year: 2018,
+      month: 10,
+      day: 31,
+      hour: 8,
+    });
+    freezeDateAt(oct31st2018.toJSDate());
 
     this.server.create('userevent', {
       user: Number(this.user.id),
-      startDate: today.toJSDate(),
-      endDate: today.plus({ hour: 1 }).toJSDate(),
-      lastModified: today.minus({ year: 1 }).toJSDate(),
+      startDate: oct31st2018.toJSDate(),
+      endDate: oct31st2018.plus({ hour: 1 }).toJSDate(),
+      lastModified: oct31st2018.minus({ year: 1 }).toJSDate(),
       isPublished: true,
       offering: 1,
       prerequisites,


### PR DESCRIPTION
I locked a few dates to lower the number of false positive failure rates we have as well as removing some tests that were very close to or identical with other tests.