### PR TITLE
reduce visual surface that the expand/collapse course details button claims on screen.

### DIFF
--- a/addon-test-support/ilios-common/page-objects/components/course-details.js
+++ b/addon-test-support/ilios-common/page-objects/components/course-details.js
@@ -12,7 +12,7 @@ import header from './course-header';
 
 export default create({
   scope: '[data-test-ilios-course-details]',
-  collapseControl: clickable('.detail-collapsed-control'),
+  collapseControl: clickable('[data-test-expand-course-details]'),
   titles: count('.title'),
   header,
   overview,

--- a/addon/components/ilios-course-details.hbs
+++ b/addon/components/ilios-course-details.hbs
@@ -10,16 +10,16 @@
   <CourseHeader @course={{@course}} @editable={{and @editable this.notRolloverRoute}} />
   <CourseOverview @course={{@course}} @editable={{and @editable this.notRolloverRoute}} />
   {{#unless @showDetails}}
-    <button
-      class="detail-collapsed-control"
-      type="button"
-      {{on "click" (fn @setShowDetails true)}}
-    >
-      <span>
+    <div class="detail-collapsed-control">
+      <button
+        type="button"
+        data-test-expand-course-details
+        {{on "click" (fn @setShowDetails true)}}
+      >
         {{t "general.expandDetail"}}
         <FaIcon @icon="square-plus" class="expand-collapse-icon" />
-      </span>
-    </button>
+      </button>
+    </div>
   {{else}}
     <CourseEditing
       @course={{@course}}
@@ -35,11 +35,15 @@
       @setCourseCompetencyDetails={{@setCourseCompetencyDetails}}
       @setCourseManageLeadership={{@setCourseManageLeadership}}
     />
-    <button class="detail-collapsed-control" type="button" {{on "click" this.collapse}}>
-      <span class="is-expanded">
+    <div class="detail-collapsed-control">
+      <button
+        type="button"
+        data-test-expand-course-details
+        {{on "click" this.collapse}}
+      >
         {{t "general.collapseDetail"}}
         <FaIcon @icon="square-minus" class="expand-collapse-icon" />
-      </span>
-    </button>
+      </button>
+    </div>
   {{/unless}}
 </section>

--- a/app/styles/ilios-common/components/course-details.scss
+++ b/app/styles/ilios-common/components/course-details.scss
@@ -8,12 +8,12 @@
   $collapse-control-shadow-black: rgba(0, 0, 0, 0.34);
 
   .detail-collapsed-control {
-    @include m.ilios-button-reset;
     display: flex;
     justify-content: center;
     width: 100%;
 
-    span {
+    button {
+      @include m.ilios-button-reset;
       background-color: c.$orange;
       border-bottom-left-radius: 5px;
       border-bottom-right-radius: 5px;


### PR DESCRIPTION
fixes https://github.com/ilios/ilios/issues/4921

![image](https://github.com/ilios/common/assets/1410427/adf8d3a6-cdcf-4d42-80a1-29231a32e161)
