### PR TITLE
sets the publication check target as scroll target.

### DIFF
--- a/addon/components/session-publicationcheck.hbs
+++ b/addon/components/session-publicationcheck.hbs
@@ -1,6 +1,5 @@
 <div
   class="session-publicationcheck"
-  {{scroll-into-view}}
   data-test-session-publicationcheck
 >
   <SessionOverview
@@ -18,7 +17,7 @@
       {{t "general.backToTitle" title=@session.title}}
     </LinkTo>
   </div>
-  <div class="results">
+  <div class="results" {{scroll-into-view}}>
     <div class="title" data-test-title>
       {{t "general.missingItems"}} ({{@session.allPublicationIssuesLength}})
     </div>


### PR DESCRIPTION
previously, the scroll-to effect was targeting the container element, which includes the read-only session details above the publication check results table. that wasn't quite cutting it - we want to scroll the results table into view.

fixes https://github.com/ilios/ilios/issues/4922