### PR TITLE
check app env and suppress back-to link in the frontend app.

### DIFF
--- a/addon-test-support/ilios-common/page-objects/components/back-link.js
+++ b/addon-test-support/ilios-common/page-objects/components/back-link.js
@@ -1,0 +1,8 @@
+import { create } from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-back-link]',
+};
+
+export default definition;
+export const component = create(definition);

--- a/addon-test-support/ilios-common/page-objects/events.js
+++ b/addon-test-support/ilios-common/page-objects/events.js
@@ -1,0 +1,9 @@
+import { create, visitable } from 'ember-cli-page-object';
+import backLink from './components/back-link';
+import singleEvent from './components/single-event';
+
+export default create({
+  visit: visitable('/events/:slug'),
+  backLink,
+  singleEvent,
+});

--- a/addon-test-support/ilios-common/page-objects/weeklyevents.js
+++ b/addon-test-support/ilios-common/page-objects/weeklyevents.js
@@ -1,0 +1,9 @@
+import { create, visitable } from 'ember-cli-page-object';
+import backLink from './components/back-link';
+import weeklyEvents from './components/weekly-events';
+
+export default create({
+  visit: visitable('/weeklyevents'),
+  backLink,
+  weeklyEvents,
+});

--- a/addon/components/back-link.hbs
+++ b/addon/components/back-link.hbs
@@ -3,6 +3,7 @@
   class="back-link"
   href="#"
   {{on "click" (prevent-default this.back)}}
+  data-test-back-link
 >
   <FaIcon @icon="angles-left" /> {{t "general.back"}}
 </a>

--- a/addon/controllers/events.js
+++ b/addon/controllers/events.js
@@ -1,0 +1,9 @@
+import Controller from '@ember/controller';
+import { getOwner } from '@ember/application';
+
+export default class EventsController extends Controller {
+  get showBackLink() {
+    const config = getOwner(this).resolveRegistration('config:environment');
+    return config.modulePrefix !== 'ilios';
+  }
+}

--- a/addon/controllers/weeklyevents.js
+++ b/addon/controllers/weeklyevents.js
@@ -1,5 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
+import { getOwner } from '@ember/application';
 import { tracked } from '@glimmer/tracking';
 import moment from 'moment';
 
@@ -27,5 +28,10 @@ export default class WeeklyeventsController extends Controller {
     }
     arr.sort();
     this.expanded = arr.filter(Boolean).join('-');
+  }
+
+  get showBackLink() {
+    const config = getOwner(this).resolveRegistration('config:environment');
+    return config.modulePrefix !== 'ilios';
   }
 }

--- a/addon/templates/events.hbs
+++ b/addon/templates/events.hbs
@@ -1,1 +1,4 @@
-<BackLink /><SingleEvent @event={{this.model}} />
+{{#if this.showBackLink}}
+  <BackLink />
+{{/if}}
+<SingleEvent @event={{this.model}} />

--- a/addon/templates/weeklyevents.hbs
+++ b/addon/templates/weeklyevents.hbs
@@ -1,4 +1,6 @@
-<BackLink />
+{{#if this.showBackLink}}
+    <BackLink />
+{{/if}}
 <WeeklyEvents
   @year={{this.year}}
   @expandedWeeks={{this.expandedWeeks}}

--- a/app/controllers/events.js
+++ b/app/controllers/events.js
@@ -1,0 +1,1 @@
+export { default } from 'ilios-common/controllers/events';

--- a/config/environment.js
+++ b/config/environment.js
@@ -4,6 +4,7 @@ const API_VERSION = require('./api-version.js');
 
 module.exports = function (environment /*, appConfig */) {
   var ENV = {
+    modulePrefix: 'ilios',
     featureFlags: {
       sessionLinkingAdminUi: true,
     },

--- a/config/environment.js
+++ b/config/environment.js
@@ -4,7 +4,6 @@ const API_VERSION = require('./api-version.js');
 
 module.exports = function (environment /*, appConfig */) {
   var ENV = {
-    modulePrefix: 'ilios',
     featureFlags: {
       sessionLinkingAdminUi: true,
     },

--- a/tests/acceptance/events-test.js
+++ b/tests/acceptance/events-test.js
@@ -1,0 +1,35 @@
+import { module, test } from 'qunit';
+import { setupAuthentication } from 'ilios-common';
+import { setupApplicationTest } from 'dummy/tests/helpers';
+import { currentURL } from '@ember/test-helpers';
+import page from 'ilios-common/page-objects/events';
+import { DateTime } from 'luxon';
+
+module('Acceptance | Event', function (hooks) {
+  setupApplicationTest(hooks);
+
+  hooks.beforeEach(async function () {
+    this.school = this.server.create('school');
+    this.user = await setupAuthentication({ school: this.school });
+  });
+
+  test('back link is visible', async function (assert) {
+    const date = DateTime.fromISO('2023-04-23');
+    const slug = 'U' + date.toFormat('yyyyMMdd') + 'O12345';
+    this.server.get(`/api/userevents/:userid`, () => {
+      return {
+        userEvents: [
+          {
+            offering: 1,
+            startDate: '2023-04-23',
+            prerequisites: [],
+            postrequisites: [],
+          },
+        ],
+      };
+    });
+    await page.visit({ slug });
+    assert.strictEqual(currentURL(), `/events/${slug}`);
+    assert.ok(page.backLink.isPresent);
+  });
+});

--- a/tests/acceptance/weeklyevents-test.js
+++ b/tests/acceptance/weeklyevents-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupAuthentication } from 'ilios-common';
+import { setupApplicationTest } from 'dummy/tests/helpers';
+import page from 'ilios-common/page-objects/weeklyevents';
+
+module('Acceptance | Weekly events', function (hooks) {
+  setupApplicationTest(hooks);
+
+  hooks.beforeEach(async function () {
+    this.user = await setupAuthentication();
+  });
+
+  test('back link is visible', async function (assert) {
+    await page.visit();
+    assert.ok(page.backLink.isPresent);
+  });
+});

--- a/tests/integration/components/back-link-test.js
+++ b/tests/integration/components/back-link-test.js
@@ -3,15 +3,14 @@ import { setupRenderingTest } from 'dummy/tests/helpers';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import { component } from 'ilios-common/page-objects/components/back-link';
 
 module('Integration | Component | back link', function (hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
-    await render(hbs`<BackLink />
-`);
-
-    assert.dom(this.element).hasText('Back');
+    await render(hbs`<BackLink />`);
+    assert.strictEqual(component.text, 'Back');
   });
 });

--- a/tests/unit/controllers/events-test.js
+++ b/tests/unit/controllers/events-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'dummy/tests/helpers';
+
+module('Unit | Controller | events', function (hooks) {
+  setupTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it exists', function (assert) {
+    let controller = this.owner.lookup('controller:events');
+    assert.ok(controller);
+  });
+});


### PR DESCRIPTION
another attempt at fixing https://github.com/ilios/ilios/issues/4774

this time, we check the environment for the application "name" (`modulePrefix` key). 
note: we can't get to it using `getConfig` from `@ember/macros`, so i'm using the tried/true approach instead.