### PR TITLE
scrolls taxonomy manager into view when edit-mode is activated.

### DIFF
--- a/addon/components/detail-taxonomies.hbs
+++ b/addon/components/detail-taxonomies.hbs
@@ -29,7 +29,12 @@
     {{/if}}
     <div class="actions">
       {{#if this.isManaging}}
-        <button class="bigadd" type="button" {{on "click" (perform this.save)}}>
+        <button
+          class="bigadd"
+          type="button"
+          {{on "click" (perform this.save)}}
+          {{did-insert this.scrollHere}}
+        >
           <FaIcon
             @icon={{if this.save.isRunning "spinner" "check"}}
             @spin={{this.save.isRunning}}

--- a/addon/components/detail-taxonomies.js
+++ b/addon/components/detail-taxonomies.js
@@ -5,6 +5,7 @@ import { service } from '@ember/service';
 import { dropTask } from 'ember-concurrency';
 import { TrackedAsyncData } from 'ember-async-data';
 import { cached } from '@glimmer/tracking';
+import scrollIntoView from 'scroll-into-view';
 
 export default class DetailTaxonomiesComponent extends Component {
   @service store;
@@ -59,5 +60,10 @@ export default class DetailTaxonomiesComponent extends Component {
   @action
   removeTermFromBuffer(term) {
     this.bufferedTerms = this.bufferedTerms.filter((obj) => obj.id !== term.id);
+  }
+
+  @action
+  scrollHere(element) {
+    scrollIntoView(element, { align: { top: 0 } });
   }
 }


### PR DESCRIPTION
this affects all the places where we're using the taxonomy manager - sessions, courses, and program-years.
fixes https://github.com/ilios/ilios/issues/3839

![image](https://github.com/ilios/common/assets/1410427/43a6f352-e651-446f-8508-9665c3e7c084)
