### PR TITLE
regenerates lock file.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -132,6 +132,7 @@
         "ember-source": ">= 4.0.0",
         "flatpickr": ">= 4.0.0",
         "froala-editor": ">= 4.0.0",
+        "luxon": ">= 3.0.0",
         "miragejs": ">= 0.1.45",
         "mockdate": ">= 3.0.0",
         "moment": ">= 2.29.0",


### PR DESCRIPTION
`npm install` was updating the lock file - something something Luxon peer-dependency. here it is.