### PR TITLE
Run percy tests against a production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:ember-compatibility": "ember try:each",
     "test:ember:browserstack": "ember test --test-port=7774 --host=127.0.0.1 --config-file=testem.browserstack.js",
     "test:browserstack": "npm-run-all browserstack:connect test:ember:browserstack browserstack:disconnect browserstack:results",
-    "test:percy": "percy exec -- npm run test:ember",
+    "test:percy": "percy exec -- npm run test:ember --environment=production",
     "browserstack:connect": "ember browserstack:connect",
     "browserstack:disconnect": "ember browserstack:disconnect",
     "browserstack:results": "ember browserstack:results"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:ember-compatibility": "ember try:each",
     "test:ember:browserstack": "ember test --test-port=7774 --host=127.0.0.1 --config-file=testem.browserstack.js",
     "test:browserstack": "npm-run-all browserstack:connect test:ember:browserstack browserstack:disconnect browserstack:results",
-    "test:percy": "percy exec -- npm run test:ember --environment=production",
+    "test:percy": "percy exec -- ember test --environment=production",
     "browserstack:connect": "ember browserstack:connect",
     "browserstack:disconnect": "ember browserstack:disconnect",
     "browserstack:results": "ember browserstack:results"


### PR DESCRIPTION
Without this we miss things that are different in production, like the way our CSS is complied. Which is dumb, because that's exactly what we're trying to catch.