### PR TITLE
Serialize false in school config

### DIFF
--- a/addon/serializers/school-config.js
+++ b/addon/serializers/school-config.js
@@ -1,0 +1,14 @@
+import IliosSerializer from 'ilios-common/serializers/ilios';
+
+export default class SchoolConfigSerializer extends IliosSerializer {
+  serialize(snapshot, options) {
+    const originalValue = snapshot.attr('value');
+    let json = super.serialize(snapshot, options);
+
+    if (originalValue === false) {
+      json.data.attributes.value = 'false';
+    }
+
+    return json;
+  }
+}

--- a/app/serializers/school-config.js
+++ b/app/serializers/school-config.js
@@ -1,0 +1,1 @@
+export { default } from 'ilios-common/serializers/school-config';


### PR DESCRIPTION
Before sending this value to the API it needs to be a string, however ember-data takes the boolean false and converts it into a null so we need to do a bit of special handling in this case.

Refs ilios/ilios#4953