### PR TITLE
Remove optimization for saving learner groups

### DIFF
--- a/addon/models/learner-group.js
+++ b/addon/models/learner-group.js
@@ -433,21 +433,17 @@ export default class LearnerGroup extends Model {
 
   /**
    * Takes a user out of  a group and then traverses child groups recursively
-   * to remove the user from them as well.  Will only modify groups where the
-   * user currently exists.
+   * to remove the user from them as well and returns the entire tree for saving.
    */
   async removeUserFromGroupAndAllDescendants({ id: userId }) {
     const allDescendants = await this.getAllDescendants();
-    const groups = await map([this, ...allDescendants], async (group) => {
+    return await map([this, ...allDescendants], async (group) => {
       if (group.hasMany('users').ids().includes(userId)) {
         group.users = (await group.users).filter(({ id }) => id !== userId);
-        return group;
       }
 
-      return false;
+      return group;
     });
-
-    return uniqueValues(groups.filter(Boolean));
   }
 
   async getAllParents() {

--- a/tests/unit/models/learner-group-test.js
+++ b/tests/unit/models/learner-group-test.js
@@ -392,12 +392,12 @@ module('Unit | Model | LearnerGroup', function (hooks) {
     });
 
     const groupsToRemove = await subGroup1.removeUserFromGroupAndAllDescendants(user1);
-    assert.strictEqual(groupsToRemove.length, 3);
+    assert.strictEqual(groupsToRemove.length, 4);
     assert.notOk(groupsToRemove.includes(learnerGroup));
     assert.ok(groupsToRemove.includes(subGroup1));
     assert.ok(groupsToRemove.includes(subGroup2));
     assert.ok(groupsToRemove.includes(subGroup3));
-    assert.notOk(groupsToRemove.includes(subGroup4));
+    assert.ok(groupsToRemove.includes(subGroup4));
   });
 
   test('check addUserToGroupAndAllParents', async function (assert) {


### PR DESCRIPTION
This method was designed to only modify, and only return, groupss which were modified which is nice because it limits network requests when modifying groups trees with lots of subgroups. This turns out to be a bad idea however because users may open multiple tabs and modify the group tree in each tab. Any user errors in this process can lead to changes not being reflected back to the API because the data store in the tab they have open does not realize a change to other groups is necessary. I've removed that optimization here. It's less network efficient, however it should result in consistent data being sent to the API.

Refs ilios/ilios#4953