### PR TITLE
Export @ember/string

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,6 @@ updates:
   - dependency-name: "@babel/eslint-parser"
   - dependency-name: "@babel/plugin-proposal-decorators"
   - dependency-name: "@ember/optional-features"
-  - dependency-name: "@ember/string"
   - dependency-name: "@ember/test-helpers"
   - dependency-name: "@embroider/test-setup"
   - dependency-name: "@glimmer/component"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@babel/core": "^7.22.10",
     "@ember/render-modifiers": "^2.0.0",
+    "@ember/string": "^3.1.1",
     "@embroider/macros": "^1.8.3",
     "@embroider/util": "^1.0.0",
     "@fortawesome/ember-fontawesome": "^1.0.0",
@@ -118,7 +119,6 @@
     "@babel/plugin-proposal-decorators": "^7.22.10",
     "@ember/edition-utils": "^1.1.1",
     "@ember/optional-features": "^2.0.0",
-    "@ember/string": "^3.1.1",
     "@ember/test-helpers": "^3.2.0",
     "@ember/test-waiters": "^3.0.2",
     "@embroider/test-setup": "^3.0.1",


### PR DESCRIPTION
We're using methods from this package in several places in common so this is a dependency and not, as the blueprint has it a dev-dependency. Because we've moved away from the blueprint I've also allowed this package to be updated.