### PR TITLE
Deprecate and replace date formatting getters

### DIFF
--- a/addon/components/session-offerings-list.hbs
+++ b/addon/components/session-offerings-list.hbs
@@ -8,7 +8,7 @@
     <div class="offering-block">
       <div class="offering-block-date">
         <span class="offering-block-date-dayofweek">
-          {{block.dayOfWeek}}
+          {{format-date block.date weekday="long"}}
         </span>
         <span class="offering-block-date-dayofmonth">
           {{format-date block.date month="long" day="numeric"}}
@@ -22,13 +22,13 @@
                 <label class="offering-block-time-time-starts-label">
                   {{t "general.starts"}}:
                 </label>
-                {{offeringTimeBlock.longStartText}}
+                {{format-date offeringTimeBlock.startDate weekday="long" month="long" day="numeric" hour="numeric" minute="numeric"}}
               </div>
               <div class="offering-block-time-time-ends">
                 <label class="offering-block-time-time-ends-label">
                   {{t "general.ends"}}:
                 </label>
-                {{offeringTimeBlock.longEndText}}
+                {{format-date offeringTimeBlock.endDate weekday="long" month="long" day="numeric" hour="numeric" minute="numeric"}}
               </div>
             </div>
           {{else}}
@@ -37,13 +37,13 @@
                 <label class="offering-block-time-time-starttime-label">
                   {{t "general.starts"}}:
                 </label>
-                {{offeringTimeBlock.startTime}}
+                {{format-date offeringTimeBlock.startDate hour="numeric" minute="numeric"}}
               </span>
               <span class="offering-block-time-time-endtime">
                 <label class="offering-block-time-time-endtime-label">
                   {{t "general.ends"}}:
                 </label>
-                {{offeringTimeBlock.endTime}}
+                {{format-date offeringTimeBlock.endDate hour="numeric" minute="numeric"}}
               </span>
             </div>
           {{/if}}

--- a/addon/components/sessions-grid-offering-table-offerings.hbs
+++ b/addon/components/sessions-grid-offering-table-offerings.hbs
@@ -5,7 +5,7 @@
     @firstRow={{eq index 0}}
     @even={{eq (mod index 2) 1}}
     @span={{this.sortedOfferings.length}}
-    @startTime={{@offeringTimeBlock.startTime}}
+    @startTime={{format-date @offeringTimeBlock.startDate hour="numeric" minute="numeric"}}
     @durationHours={{@offeringTimeBlock.durationHours}}
     @durationMinutes={{@offeringTimeBlock.durationMinutes}}
   />

--- a/addon/components/sessions-grid-offering-table.hbs
+++ b/addon/components/sessions-grid-offering-table.hbs
@@ -32,7 +32,7 @@
           data-test-offering-block-date
         >
           <span class="offering-block-date-dayofweek" data-test-dayofweek>
-            {{block.dayOfWeek}}
+            {{format-date block.date weekday="long"}}
           </span>
           <span class="offering-block-date-dayofmonth" data-test-dayofmonth>
             {{format-date block.date month="long" day="numeric"}}

--- a/addon/utils/offering-date-block.js
+++ b/addon/utils/offering-date-block.js
@@ -1,5 +1,6 @@
 import { DateTime } from 'luxon';
 import { sortBy } from './array-helpers';
+import { deprecate } from '@ember/debug';
 
 class OfferingBlock {
   offerings = [];
@@ -26,14 +27,26 @@ class OfferingDateBlock extends OfferingBlock {
   }
 
   get dateStamp() {
-    return DateTime.fromJSDate(this.date).toFormat('X');
+    return DateTime.fromJSDate(this.date).toUnixInteger();
   }
 
   get dayOfWeek() {
+    deprecate(`Calling dayOfWeek on OfferingDateBlock. Format this from date instead`, false, {
+      id: 'common.date-block-formats',
+      for: 'ilios-common',
+      until: '85',
+      since: '84',
+    });
     return DateTime.fromJSDate(this.date).toFormat('EEEE');
   }
 
   get dayOfMonth() {
+    deprecate(`Calling dayOfMonth on OfferingDateBlock. Format this from date instead`, false, {
+      id: 'common.date-block-formats',
+      for: 'ilios-common',
+      until: '85',
+      since: '84',
+    });
     return DateTime.fromJSDate(this.date).toFormat('MMMM d');
   }
 
@@ -66,7 +79,7 @@ class OfferingTimeBlock extends OfferingBlock {
   }
 
   get isMultiDay() {
-    return this.startDate.toFormat('oooYYYY') !== this.endDate.toFormat('oooYYYY');
+    return !this.startDate.hasSame(this.endDate, 'day');
   }
 
   //pull our times out of the key
@@ -81,18 +94,46 @@ class OfferingTimeBlock extends OfferingBlock {
   }
 
   get startTime() {
+    deprecate(`Calling startTime on OfferingTimeBlock. Format this from startDate instead`, false, {
+      id: 'common.date-block-formats',
+      for: 'ilios-common',
+      until: '85',
+      since: '84',
+    });
     return this.startDate.toFormat('t');
   }
 
   get endTime() {
+    deprecate(`Calling endTime on OfferingTimeBlock. Format this from endDate instead`, false, {
+      id: 'common.date-block-formats',
+      for: 'ilios-common',
+      until: '85',
+      since: '84',
+    });
     return this.endDate.toFormat('t');
   }
 
   get longStartText() {
+    deprecate(
+      `Calling longStartText on OfferingTimeBlock. Format this from startDate instead`,
+      false,
+      {
+        id: 'common.date-block-formats',
+        for: 'ilios-common',
+        until: '85',
+        since: '84',
+      },
+    );
     return this.startDate.toFormat('EEEE MMMM d @ t');
   }
 
   get longEndText() {
+    deprecate(`Calling longEndText on OfferingTimeBlock. Format this from endDate instead`, false, {
+      id: 'common.date-block-formats',
+      for: 'ilios-common',
+      until: '85',
+      since: '84',
+    });
     return this.endDate.toFormat('EEEE MMMM d @ t');
   }
 

--- a/tests/acceptance/course/session/offerings-test.js
+++ b/tests/acceptance/course/session/offerings-test.js
@@ -351,11 +351,12 @@ module('Acceptance | Session - Offerings', function (hooks) {
 
   test('users can create a new offering multi-day', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
+    const sep112011 = DateTime.fromObject({ year: 2011, month: 9, day: 11, hour: 2, minute: 15 });
     await page.visit({ courseId: 1, sessionId: 1 });
     await page.details.offerings.header.createNew();
     const { offeringForm: form } = page.details.offerings;
     await page.details.offerings.singleOffering();
-    await form.startDate.datePicker.set(new Date(2011, 8, 11));
+    await form.startDate.datePicker.set(sep112011.toJSDate());
     await form.startTime.timePicker.hour.select('2');
     await form.startTime.timePicker.minute.select('15');
     await form.startTime.timePicker.ampm.select('am');
@@ -375,8 +376,28 @@ module('Acceptance | Session - Offerings', function (hooks) {
     assert.notOk(block.hasEndTime);
     assert.strictEqual(block.dayOfWeek, 'Sunday');
     assert.strictEqual(block.dayOfMonth, 'September 11');
-    assert.strictEqual(block.multiDayStart, 'Starts: Sunday, September 11 at 2:15 AM');
-    assert.strictEqual(block.multiDayEnd, 'Ends: Monday, September 12 at 5:30 PM');
+    assert.strictEqual(
+      block.multiDayStart,
+      'Starts: ' +
+        this.intl.formatDate(sep112011, {
+          month: 'long',
+          day: 'numeric',
+          weekday: 'long',
+          hour: 'numeric',
+          minute: 'numeric',
+        }),
+    );
+    assert.strictEqual(
+      block.multiDayEnd,
+      'Ends: ' +
+        this.intl.formatDate(sep112011.plus({ hours: 39, minutes: 15 }), {
+          month: 'long',
+          day: 'numeric',
+          weekday: 'long',
+          hour: 'numeric',
+          minute: 'numeric',
+        }),
+    );
     assert.strictEqual(block.timeBlockOfferings.offerings.length, 1);
 
     assert.strictEqual(block.timeBlockOfferings.offerings[0].learnerGroups.length, 2);

--- a/tests/acceptance/course/session/offerings-test.js
+++ b/tests/acceptance/course/session/offerings-test.js
@@ -5,9 +5,12 @@ import { setupApplicationTest } from 'dummy/tests/helpers';
 import page from 'ilios-common/page-objects/session';
 import percySnapshot from '@percy/ember';
 import { freezeDateAt, unfreezeDate } from 'ilios-common';
+import { setupIntl } from 'ember-intl/test-support';
 
 module('Acceptance | Session - Offerings', function (hooks) {
   setupApplicationTest(hooks);
+  setupIntl(hooks, 'en-us');
+
   hooks.beforeEach(async function () {
     freezeDateAt(
       DateTime.fromObject({
@@ -154,11 +157,26 @@ module('Acceptance | Session - Offerings', function (hooks) {
     assert.strictEqual(blocks[2].timeBlockOfferings.offerings.length, 1);
     assert.strictEqual(
       blocks[2].multiDayStart,
-      'Starts: ' + DateTime.fromJSDate(this.offering3.startDate).toFormat('cccc MMMM d @ h:mm a'),
+      'Starts: ' +
+        this.intl.formatDate(this.offering3.startDate, {
+          month: 'long',
+          day: 'numeric',
+          weekday: 'long',
+          hour: 'numeric',
+          minute: 'numeric',
+        }),
     );
+
     assert.strictEqual(
       blocks[2].multiDayEnd,
-      'Ends: ' + DateTime.fromJSDate(this.offering3.endDate).toFormat('cccc MMMM d @ h:mm a'),
+      'Ends: ' +
+        this.intl.formatDate(this.offering3.endDate, {
+          month: 'long',
+          day: 'numeric',
+          weekday: 'long',
+          hour: 'numeric',
+          minute: 'numeric',
+        }),
     );
   });
 
@@ -357,8 +375,8 @@ module('Acceptance | Session - Offerings', function (hooks) {
     assert.notOk(block.hasEndTime);
     assert.strictEqual(block.dayOfWeek, 'Sunday');
     assert.strictEqual(block.dayOfMonth, 'September 11');
-    assert.strictEqual(block.multiDayStart, 'Starts: Sunday September 11 @ 2:15 AM');
-    assert.strictEqual(block.multiDayEnd, 'Ends: Monday September 12 @ 5:30 PM');
+    assert.strictEqual(block.multiDayStart, 'Starts: Sunday, September 11 at 2:15 AM');
+    assert.strictEqual(block.multiDayEnd, 'Ends: Monday, September 12 at 5:30 PM');
     assert.strictEqual(block.timeBlockOfferings.offerings.length, 1);
 
     assert.strictEqual(block.timeBlockOfferings.offerings[0].learnerGroups.length, 2);

--- a/tests/unit/utils/offering-date-block-test.js
+++ b/tests/unit/utils/offering-date-block-test.js
@@ -31,21 +31,7 @@ module('Unit | Utility | offering-date-block', function (hooks) {
     const key = '2023005';
     const block = new OfferingDateBlock(key);
     const dateStamp = block.dateStamp;
-    assert.strictEqual(dateStamp, DateTime.fromJSDate(new Date(2023, 0, 5)).toFormat('X'));
-  });
-
-  test('OfferingDateBlock::dayOfWeek', function (assert) {
-    const key = '2023005';
-    const block = new OfferingDateBlock(key);
-    const dayOfWeek = block.dayOfWeek;
-    assert.strictEqual(dayOfWeek, 'Thursday');
-  });
-
-  test('OfferingDateBlock::dayOfMonth', function (assert) {
-    const key = '2023005';
-    const block = new OfferingDateBlock(key);
-    const dayOfMonth = block.dayOfMonth;
-    assert.strictEqual(dayOfMonth, 'January 5');
+    assert.strictEqual(dateStamp, DateTime.fromJSDate(new Date(2023, 0, 5)).toUnixInteger());
   });
 
   test('OfferingTimeBlocks::offeringTimeBlocks', function (assert) {
@@ -97,30 +83,6 @@ module('Unit | Utility | offering-date-block', function (hooks) {
     assert.strictEqual(endDate.ordinal, 12);
     assert.strictEqual(endDate.hour, 4);
     assert.strictEqual(endDate.minute, 30);
-  });
-
-  test('OfferingTimeBlock::startTime', function (assert) {
-    const key = '2023005134520240120430';
-    const block = new OfferingTimeBlock(key);
-    assert.strictEqual(block.startTime, '1:45 PM');
-  });
-
-  test('OfferingTimeBlock::endTime', function (assert) {
-    const key = '2023005134520240120430';
-    const block = new OfferingTimeBlock(key);
-    assert.strictEqual(block.endTime, '4:30 AM');
-  });
-
-  test('OfferingTimeBlock::longStartText', function (assert) {
-    const key = '2023005134520240120430';
-    const block = new OfferingTimeBlock(key);
-    assert.strictEqual(block.longStartText, 'Thursday January 5 @ 1:45 PM');
-  });
-
-  test('OfferingTimeBlock::longEndText', function (assert) {
-    const key = '2023005134520240120430';
-    const block = new OfferingTimeBlock(key);
-    assert.strictEqual(block.longEndText, 'Friday January 12 @ 4:30 AM');
   });
 
   test('OfferingTimeBlock::durationHours', function (assert) {


### PR DESCRIPTION
These toFormat calls were not localized and are not needed anymore, let's replace them with the helper that makes everything much nicer.