### PR TITLE
Reduce Percy Runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,24 +112,6 @@ jobs:
           npm run browserstack:disconnect
           npm run browserstack:results
 
-  percy:
-    name: Percy Visual Tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    needs: [test]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18.17
-          cache: npm
-      - name: install dependencies
-        run: npm ci
-      - name: test
-        run: npm run test:percy
-        env:
-          PERCY_TOKEN: web_4c771bf3f7a933514432f378ca42cfd2b04ab0dcdbdc402f4187b19176fa0f02
-
   firefox-test:
     name: Browser Tests (Firefox)
     runs-on: ubuntu-latest

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -1,0 +1,43 @@
+name: Percy Visual Tests
+
+on:
+  push:
+    tags:
+      - '*'
+  pull_request_target:
+    types: [labeled]
+  schedule:
+    - cron: "15 23 * * 2,4" # T,Th in the afternoon (UTC)
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+env:
+  SW_DISABLED: true
+  COVERAGE: false
+  PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ILIOS_DEPLOYMENT_WEBHOOK_URL }}
+
+jobs:
+  percy:
+    name: Test and Capture Screenshots
+    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'run percy tests' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.17
+          cache: npm
+      - name: install dependencies
+        run: npm ci
+      - name: Run Percy Tests
+        run: npm run percy:test
+      - uses: act10ns/slack@v2
+        if: failure()
+        with:
+          status: ${{ job.status }}
+          message: Percy Run Failed {{ env.GITHUB_SERVER_URL }}/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }}

--- a/.github/workflows/update-transitive-dependencies.yaml
+++ b/.github/workflows/update-transitive-dependencies.yaml
@@ -32,7 +32,7 @@ jobs:
 
             [1]: https://github.com/peter-evans/create-pull-request
           branch: auto-update-dependencies
-          labels: dependencies
+          labels: dependencies,run percy tests
     - name: Enable Pull Request Automerge
       if: steps.cpr.outputs.pull-request-operation == 'created'
       run: gh pr merge --merge --auto ${{ steps.cpr.outputs.pull-request-number }}


### PR DESCRIPTION
We keep running out of screen shots, this limits the number of percy runs we have by requiring a label or manual run.