### PR TITLE
Fix group of percy tests

### DIFF
--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ci-${{ github.head_ref || github.ref }}
+  group: percy-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
Otherwise this cancels the CI run because they have the same identifier.