### PR TITLE
Remove unused browserstack npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "test:ember": "ember test",
     "test:ember-compatibility": "ember try:each",
     "test:ember:browserstack": "ember test --test-port=7774 --host=127.0.0.1 --config-file=testem.browserstack.js",
-    "test:browserstack": "npm-run-all browserstack:connect test:ember:browserstack browserstack:disconnect browserstack:results",
     "test:percy": "percy exec -- npm run test:ember",
     "browserstack:connect": "ember browserstack:connect",
     "browserstack:disconnect": "ember browserstack:disconnect",


### PR DESCRIPTION
We no longer even bundle npm-run-all so this hasn't worked in a while. Our CI job for browserstack just does these steps inline.