### PR TITLE
Remove flaky test

### DIFF
--- a/tests/integration/components/ilios-calendar-event-month-test.js
+++ b/tests/integration/components/ilios-calendar-event-month-test.js
@@ -27,7 +27,6 @@ module('Integration | Component | ilios calendar event month', function (hooks) 
       'background-color': 'rgb(0, 204, 101)',
     });
     assert.dom(s).hasStyle({
-      'border-left-width': '4px',
       'border-left-style': 'solid',
       'border-left-color': 'rgb(0, 173, 86)',
     });


### PR DESCRIPTION
This test doesn't work on android chrome because the high resolution screen causes the browser there to make border adjustments unpredictably. Thanks google, aren't you sweet.