### PR TITLE
Drop randomUUID polyfill for ember-data

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,13 +32,6 @@ module.exports = {
         ],
       },
     },
-    '@embroider/macros': {
-      setConfig: {
-        '@ember-data/store': {
-          polyfillUUID: true,
-        },
-      },
-    },
   },
 
   included: function () {


### PR DESCRIPTION
We don't need this anymore as the randomUUID method was added to Safari starting in 15.4. We currently support 15.x, but there is almost no glbal usage of 15.4, everyone is on 15.6 at least (and probably on to 16 or 17).