### PR TITLE
Fix icon name

### DIFF
--- a/addon/components/pagedlist-controls.hbs
+++ b/addon/components/pagedlist-controls.hbs
@@ -55,7 +55,7 @@
         data-test-go-to-last
         {{on "click" this.goToLast}}
       >
-        <FaIcon @icon="fast-forward" class={{if this.lastPage "disabled"}}/>
+        <FaIcon @icon="forward-fast" class={{if this.lastPage "disabled"}}/>
       </button>
       <select aria-labelledby="per-page-{{templateId}}" {{on "change" (pick "target.value" this.setLimit)}} data-test-limits>
         {{#each this.offsetOptions as |o|}}

--- a/app/styles/ilios-common/components/pagedlist-controls.scss
+++ b/app/styles/ilios-common/components/pagedlist-controls.scss
@@ -4,7 +4,7 @@
   float: right;
 
   .fa-backward-fast,
-  .fa-fast-forward,
+  .fa-forward-fast,
   .fa-play {
     @include m.icon;
   }


### PR DESCRIPTION
This was getting auto-translated by fontawesome for us, but we need the right name now that we've dropped the FA javascript helpers. Also fixes a bug where the fast forward was always blue, even when it should have been disabled.