### PR TITLE
Fix spacing in lm list notes icon

### DIFF
--- a/app/styles/ilios-common/components/single-event-learningmaterial-list.scss
+++ b/app/styles/ilios-common/components/single-event-learningmaterial-list.scss
@@ -33,7 +33,7 @@
   }
   .single-event-learningmaterial-item-notes {
     @include m.font-size("small");
-    .fa-icon {
+    .fa-square-pen {
       margin-right: 5px;
     }
 


### PR DESCRIPTION
This spacing got dropped at some point in the distant past when fa-icon stopped being applied to all icons.