### PR TITLE
Skip some pnpm publish checks

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,6 @@ jobs:
           cache: pnpm
       - run: pnpm install --ignore-scripts
       - name: publish
-        run: pnpm publish
+        run: pnpm publish --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
Pnpm, in the publish workflow, checks to be sure it is on master. This doesn't work with our workflow because we use a tag. This issue has been open for more than a year ([pnpm](https://github.com/pnpm/pnpm) number 5894) and the only way to get around it is to ignore the git checks here. That's not a big deal as we're in a fresh checkout.