### PR TITLE
Turn off asset pre-loading in tests

### DIFF
--- a/packages/ilios-common/index.js
+++ b/packages/ilios-common/index.js
@@ -105,7 +105,7 @@ module.exports = {
   },
 
   contentFor: function (type, env) {
-    if (type === 'head') {
+    if (type === 'head' && env.environment !== 'test') {
       const rootUrl = env.rootUrl ? env.rootUrl : '';
       const fonts = [
         'nunito/nunito-latin-400.woff2',


### PR DESCRIPTION
Leaving this on results in a browser warning that we didn't use the assets we pre-loaded. Let's turn it off instead.