### PR TITLE
Fix tagging workflow

### DIFF
--- a/.github/workflows/tag_version.yaml
+++ b/.github/workflows/tag_version.yaml
@@ -28,7 +28,8 @@ jobs:
         git config user.name Zorgbort
         git config user.email info@iliosproject.org
     - name: Increment Version
-      run: pnpm version --filter ilios-common ${{ github.event.inputs.releaseType }}
+      working-directory: ./packages/ilios-common
+      run: npx update-version --${{ github.event.inputs.releaseType }} 1
     - run: |
         NEW_TAG=`node -p "require('./packages/ilios-common/package.json').version"`
         echo ${NEW_TAG}


### PR DESCRIPTION
The pnpm version command doesn't exist. It forwards to npm for some bizare reason. Since we're using pnpm workspaces and not the npm kind this doesn't work for us. Instead we can use this nice tiny npm package `update-version` to accomplish the same thing and modify the package.json the way we want.