### PR TITLE
Remove dotenv config

### DIFF
--- a/packages/test-app/ember-cli-build.js
+++ b/packages/test-app/ember-cli-build.js
@@ -5,9 +5,6 @@ const broccoliAssetRevDefaults = require('broccoli-asset-rev/lib/default-options
 
 module.exports = function (defaults) {
   const app = new EmberApp(defaults, {
-    dotEnv: {
-      clientAllowedKeys: ['ILIOS_FRONTEND_API_NAMESPACE', 'ILIOS_FRONTEND_API_HOST'],
-    },
     'ember-cli-babel': {
       throwUnlessParallelizable: true,
     },


### PR DESCRIPTION
We're not using dotenv anymore for managing environmental variables.