### PR TITLE
Remove pnpm and cache from tag workflow

### DIFF
--- a/.github/workflows/tag_version.yaml
+++ b/.github/workflows/tag_version.yaml
@@ -14,13 +14,9 @@ jobs:
     - uses: actions/checkout@v4
       with:
           token: ${{ secrets.ZORGBORT_TOKEN }}
-    - uses: pnpm/action-setup@v2
-      with:
-        version: 8
     - uses: actions/setup-node@v4
       with:
         node-version: 18
-        cache: pnpm
     - name: Validate releaseType
       run: npx in-string-list ${{ github.event.inputs.releaseType }} major,minor,patch
     - name: Setup Git


### PR DESCRIPTION
Because we're not actually doing anything with pnpm this breaks in the cleanup step. Remove this unneeded stuff.