### PR TITLE
Restore required icon styling

### DIFF
--- a/packages/ilios-common/app/styles/ilios-common/components/lm-icons.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/lm-icons.scss
@@ -6,6 +6,7 @@
     grid-column-start: 1;
     grid-row-start: 1;
     height: 0.45rem;
+    width: 0.45rem;
   }
 
   .lm-type-icon {


### PR DESCRIPTION
The start for required learning material icons got slightly displaced when I updated the way we import and style icons. This puts it back into a visible spot.