### PR TITLE
Hide back link for frontend

### DIFF
--- a/packages/ilios-common/addon/controllers/events.js
+++ b/packages/ilios-common/addon/controllers/events.js
@@ -4,6 +4,6 @@ import { getOwner } from '@ember/application';
 export default class EventsController extends Controller {
   get showBackLink() {
     const config = getOwner(this).resolveRegistration('config:environment');
-    return config.modulePrefix !== 'ilios';
+    return config.modulePrefix !== 'ilios' && config.modulePrefix !== 'frontend';
   }
 }

--- a/packages/ilios-common/addon/controllers/weeklyevents.js
+++ b/packages/ilios-common/addon/controllers/weeklyevents.js
@@ -32,6 +32,6 @@ export default class WeeklyeventsController extends Controller {
 
   get showBackLink() {
     const config = getOwner(this).resolveRegistration('config:environment');
-    return config.modulePrefix !== 'ilios';
+    return config.modulePrefix !== 'ilios' && config.modulePrefix !== 'frontend';
   }
 }


### PR DESCRIPTION
We're changing the name of the frontend app from ilios to frontend as part of migrating to a monorepo setup. For now, hide the back link from both application names.